### PR TITLE
Enhance Unset checks and update Union type hints in SDK

### DIFF
--- a/fix_unset_checks.py
+++ b/fix_unset_checks.py
@@ -32,6 +32,14 @@ def fix_unset_checks_in_file(filepath):
 
         content = re.sub(pattern, replacement, content)
 
+        # Also update type hints: Union[Unset, T] -> Union[None, Unset, T]
+        # Avoid adding None twice if it's already present as the first member
+        content = re.sub(
+            r"Union\s*\[(?!\s*None\s*,\s*Unset)\s*Unset",
+            "Union[None, Unset",
+            content,
+        )
+
         # Only write if there were changes
         if content != original_content:
             with open(filepath, "w", encoding="utf-8") as f:
@@ -60,22 +68,22 @@ def fix_unset_checks_in_directory(directory):
 
 
 def fix_unset_checks():
-    """Fix Unset checks in the generated SDK to include truthiness validation."""
-    print("🔧 Fixing Unset checks to include truthiness validation...")
+    """Fix Unset checks and Union types in the generated SDK."""
+    print("🔧 Fixing Unset checks and Union[Unset,...] type hints (adding None)...")
 
     # Target directory for generated SDK
     sdk_dir = os.path.join("src", "qualer_sdk")
 
     if not os.path.exists(sdk_dir):
-        print(f"⚠️  SDK directory {sdk_dir} not found, skipping Unset check fixes")
+        print(f"⚠️  SDK directory {sdk_dir} not found, skipping fixes")
         return
 
     fixed_files = fix_unset_checks_in_directory(sdk_dir)
 
     if fixed_files:
-        print(f"✅ Fixed Unset checks in {len(fixed_files)} files")
+        print(f"✅ Applied fixes in {len(fixed_files)} files")
     else:
-        print("ℹ️  No Unset checks needed fixing")
+        print("ℹ️  No fixes needed")
 
 
 if __name__ == "__main__":

--- a/src/qualer_sdk/api/account/get_employee_messages.py
+++ b/src/qualer_sdk/api/account/get_employee_messages.py
@@ -13,8 +13,8 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_period: Union[Unset, int] = UNSET,
-    model_site_id: Union[Unset, int] = UNSET,
+    model_period: Union[None, Unset, int] = UNSET,
+    model_site_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -69,13 +69,13 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_period: Union[Unset, int] = UNSET,
-    model_site_id: Union[Unset, int] = UNSET,
+    model_period: Union[None, Unset, int] = UNSET,
+    model_site_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAccountToEmployeeEventResponseModel"]]:
     """
     Args:
-        model_period (Union[Unset, int]):
-        model_site_id (Union[Unset, int]):
+        model_period (Union[None, Unset, int]):
+        model_site_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -100,13 +100,13 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_period: Union[Unset, int] = UNSET,
-    model_site_id: Union[Unset, int] = UNSET,
+    model_period: Union[None, Unset, int] = UNSET,
+    model_site_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAccountToEmployeeEventResponseModel"]]:
     """
     Args:
-        model_period (Union[Unset, int]):
-        model_site_id (Union[Unset, int]):
+        model_period (Union[None, Unset, int]):
+        model_site_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -126,13 +126,13 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_period: Union[Unset, int] = UNSET,
-    model_site_id: Union[Unset, int] = UNSET,
+    model_period: Union[None, Unset, int] = UNSET,
+    model_site_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAccountToEmployeeEventResponseModel"]]:
     """
     Args:
-        model_period (Union[Unset, int]):
-        model_site_id (Union[Unset, int]):
+        model_period (Union[None, Unset, int]):
+        model_site_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -155,13 +155,13 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_period: Union[Unset, int] = UNSET,
-    model_site_id: Union[Unset, int] = UNSET,
+    model_period: Union[None, Unset, int] = UNSET,
+    model_site_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAccountToEmployeeEventResponseModel"]]:
     """
     Args:
-        model_period (Union[Unset, int]):
-        model_site_id (Union[Unset, int]):
+        model_period (Union[None, Unset, int]):
+        model_site_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_measurements/get_measurements_by_asset.py
+++ b/src/qualer_sdk/api/asset_measurements/get_measurements_by_asset.py
@@ -15,17 +15,17 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     asset_id: int,
     *,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
-    json_from_: Union[Unset, str] = UNSET
+    json_from_: Union[None, Unset, str] = UNSET
     if from_ and not isinstance(from_, Unset):
         json_from_ = from_.isoformat()
     params["from"] = json_from_
 
-    json_to: Union[Unset, str] = UNSET
+    json_to: Union[None, Unset, str] = UNSET
     if to and not isinstance(to, Unset):
         json_to = to.isoformat()
     params["to"] = json_to
@@ -78,14 +78,14 @@ def sync_detailed(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -112,14 +112,14 @@ def sync(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,14 +141,14 @@ async def asyncio_detailed(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,14 +173,14 @@ async def asyncio(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_reservation/close.py
+++ b/src/qualer_sdk/api/asset_reservation/close.py
@@ -11,12 +11,12 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -70,21 +70,21 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Response[CloseResponse200]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -113,21 +113,21 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[CloseResponse200]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -151,21 +151,21 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Response[CloseResponse200]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -192,21 +192,21 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[CloseResponse200]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_reservation/get_get_2.py
+++ b/src/qualer_sdk/api/asset_reservation/get_get_2.py
@@ -14,23 +14,23 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
-    json_model_from: Union[Unset, str] = UNSET
+    json_model_from: Union[None, Unset, str] = UNSET
     if model_from and not isinstance(model_from, Unset):
         json_model_from = model_from.isoformat()
     params["model.from"] = json_model_from
 
-    json_model_to: Union[Unset, str] = UNSET
+    json_model_to: Union[None, Unset, str] = UNSET
     if model_to and not isinstance(model_to, Unset):
         json_model_to = model_to.isoformat()
     params["model.to"] = json_model_to
@@ -94,25 +94,25 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetReservationToAssetReservationResponse"]]:
     """
     Args:
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -143,25 +143,25 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetReservationToAssetReservationResponse"]]:
     """
     Args:
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -187,25 +187,25 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetReservationToAssetReservationResponse"]]:
     """
     Args:
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -234,25 +234,25 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_area_id: Union[Unset, int] = UNSET,
-    model_product_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_asset_tag: Union[Unset, str] = UNSET,
-    model_reservation_id: Union[Unset, int] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_area_id: Union[None, Unset, int] = UNSET,
+    model_product_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_asset_tag: Union[None, Unset, str] = UNSET,
+    model_reservation_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetReservationToAssetReservationResponse"]]:
     """
     Args:
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
-        model_asset_id (Union[Unset, int]):
-        model_area_id (Union[Unset, int]):
-        model_product_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_asset_tag (Union[Unset, str]):
-        model_reservation_id (Union[Unset, int]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_area_id (Union[None, Unset, int]):
+        model_product_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_asset_tag (Union[None, Unset, str]):
+        model_reservation_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_service_records/document_list.py
+++ b/src/qualer_sdk/api/asset_service_records/document_list.py
@@ -11,8 +11,8 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     asset_service_record_id_path: str,
     *,
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -59,14 +59,14 @@ def sync_detailed(
     asset_service_record_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list[str]]:
     """
     Args:
         asset_service_record_id_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -93,14 +93,14 @@ def sync(
     asset_service_record_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list[str]]:
     """
     Args:
         asset_service_record_id_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,14 +122,14 @@ async def asyncio_detailed(
     asset_service_record_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list[str]]:
     """
     Args:
         asset_service_record_id_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -154,14 +154,14 @@ async def asyncio(
     asset_service_record_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list[str]]:
     """
     Args:
         asset_service_record_id_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_service_records/download_document.py
+++ b/src/qualer_sdk/api/asset_service_records/download_document.py
@@ -13,10 +13,10 @@ def _get_kwargs(
     asset_service_record_id_path: str,
     file_name_path: str,
     *,
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    file_name_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
-    model_file_name: Union[Unset, str] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    file_name_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -68,19 +68,19 @@ def sync_detailed(
     file_name_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    file_name_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
-    model_file_name: Union[Unset, str] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    file_name_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[File]:
     """
     Args:
         asset_service_record_id_path (str):
         file_name_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        file_name_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
-        model_file_name (Union[Unset, str]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        file_name_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -111,19 +111,19 @@ def sync(
     file_name_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    file_name_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
-    model_file_name: Union[Unset, str] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    file_name_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[File]:
     """
     Args:
         asset_service_record_id_path (str):
         file_name_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        file_name_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
-        model_file_name (Union[Unset, str]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        file_name_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -149,19 +149,19 @@ async def asyncio_detailed(
     file_name_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    file_name_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
-    model_file_name: Union[Unset, str] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    file_name_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[File]:
     """
     Args:
         asset_service_record_id_path (str):
         file_name_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        file_name_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
-        model_file_name (Union[Unset, str]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        file_name_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -190,19 +190,19 @@ async def asyncio(
     file_name_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_service_record_id_query: Union[Unset, str] = UNSET,
-    file_name_query: Union[Unset, str] = UNSET,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
-    model_file_name: Union[Unset, str] = UNSET,
+    asset_service_record_id_query: Union[None, Unset, str] = UNSET,
+    file_name_query: Union[None, Unset, str] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[File]:
     """
     Args:
         asset_service_record_id_path (str):
         file_name_path (str):
-        asset_service_record_id_query (Union[Unset, str]):
-        file_name_query (Union[Unset, str]):
-        model_asset_service_record_id (Union[Unset, int]):
-        model_file_name (Union[Unset, str]):
+        asset_service_record_id_query (Union[None, Unset, str]):
+        file_name_query (Union[None, Unset, str]):
+        model_asset_service_record_id (Union[None, Unset, int]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_service_records/get_asset_service_record.py
+++ b/src/qualer_sdk/api/asset_service_records/get_asset_service_record.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     asset_service_record_id: str,
     *,
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -61,12 +61,12 @@ def sync_detailed(
     asset_service_record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
         asset_service_record_id (str):
-        model_asset_service_record_id (Union[Unset, int]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -92,12 +92,12 @@ def sync(
     asset_service_record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
         asset_service_record_id (str):
-        model_asset_service_record_id (Union[Unset, int]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -118,12 +118,12 @@ async def asyncio_detailed(
     asset_service_record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
         asset_service_record_id (str):
-        model_asset_service_record_id (Union[Unset, int]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -147,12 +147,12 @@ async def asyncio(
     asset_service_record_id: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_service_record_id: Union[Unset, int] = UNSET,
+    model_asset_service_record_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
         asset_service_record_id (str):
-        model_asset_service_record_id (Union[Unset, int]):
+        model_asset_service_record_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/asset_service_records/get_asset_service_records.py
+++ b/src/qualer_sdk/api/asset_service_records/get_asset_service_records.py
@@ -14,10 +14,10 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -25,12 +25,12 @@ def _get_kwargs(
 
     params["model.serialNumber"] = model_serial_number
 
-    json_model_from: Union[Unset, str] = UNSET
+    json_model_from: Union[None, Unset, str] = UNSET
     if model_from and not isinstance(model_from, Unset):
         json_model_from = model_from.isoformat()
     params["model.from"] = json_model_from
 
-    json_model_to: Union[Unset, str] = UNSET
+    json_model_to: Union[None, Unset, str] = UNSET
     if model_to and not isinstance(model_to, Unset):
         json_model_to = model_to.isoformat()
     params["model.to"] = json_model_to
@@ -75,17 +75,17 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -112,17 +112,17 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -144,17 +144,17 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -179,17 +179,17 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_asset_id: Union[Unset, int] = UNSET,
-    model_serial_number: Union[Unset, str] = UNSET,
-    model_from: Union[Unset, datetime.datetime] = UNSET,
-    model_to: Union[Unset, datetime.datetime] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
+    model_serial_number: Union[None, Unset, str] = UNSET,
+    model_from: Union[None, Unset, datetime.datetime] = UNSET,
+    model_to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel]:
     """
     Args:
-        model_asset_id (Union[Unset, int]):
-        model_serial_number (Union[Unset, str]):
-        model_from (Union[Unset, datetime.datetime]):
-        model_to (Union[Unset, datetime.datetime]):
+        model_asset_id (Union[None, Unset, int]):
+        model_serial_number (Union[None, Unset, str]):
+        model_from (Union[None, Unset, datetime.datetime]):
+        model_to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/assets/get_asset_by_attribute.py
+++ b/src/qualer_sdk/api/assets/get_asset_by_attribute.py
@@ -13,8 +13,8 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_name: Union[Unset, str] = UNSET,
-    model_value: Union[Unset, str] = UNSET,
+    model_name: Union[None, Unset, str] = UNSET,
+    model_value: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -67,13 +67,13 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_name: Union[Unset, str] = UNSET,
-    model_value: Union[Unset, str] = UNSET,
+    model_name: Union[None, Unset, str] = UNSET,
+    model_value: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        model_name (Union[Unset, str]):
-        model_value (Union[Unset, str]):
+        model_name (Union[None, Unset, str]):
+        model_value (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -98,13 +98,13 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_name: Union[Unset, str] = UNSET,
-    model_value: Union[Unset, str] = UNSET,
+    model_name: Union[None, Unset, str] = UNSET,
+    model_value: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        model_name (Union[Unset, str]):
-        model_value (Union[Unset, str]):
+        model_name (Union[None, Unset, str]):
+        model_value (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -124,13 +124,13 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_name: Union[Unset, str] = UNSET,
-    model_value: Union[Unset, str] = UNSET,
+    model_name: Union[None, Unset, str] = UNSET,
+    model_value: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        model_name (Union[Unset, str]):
-        model_value (Union[Unset, str]):
+        model_name (Union[None, Unset, str]):
+        model_value (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -153,13 +153,13 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_name: Union[Unset, str] = UNSET,
-    model_value: Union[Unset, str] = UNSET,
+    model_name: Union[None, Unset, str] = UNSET,
+    model_value: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        model_name (Union[Unset, str]):
-        model_value (Union[Unset, str]):
+        model_name (Union[None, Unset, str]):
+        model_value (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/assets/get_asset_manager_counters.py
+++ b/src/qualer_sdk/api/assets/get_asset_manager_counters.py
@@ -13,7 +13,7 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -59,12 +59,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Response[QualerApiModelsAssetToAssetsCountResponseModel]:
     """GetAssetManagerCounters
 
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -88,12 +88,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Optional[QualerApiModelsAssetToAssetsCountResponseModel]:
     """GetAssetManagerCounters
 
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -112,12 +112,12 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Response[QualerApiModelsAssetToAssetsCountResponseModel]:
     """GetAssetManagerCounters
 
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -139,12 +139,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Optional[QualerApiModelsAssetToAssetsCountResponseModel]:
     """GetAssetManagerCounters
 
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/assets/get_asset_manager_list.py
+++ b/src/qualer_sdk/api/assets/get_asset_manager_list.py
@@ -13,10 +13,10 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_filter_type: Union[Unset, str] = UNSET,
-    model_search_string: Union[Unset, str] = UNSET,
-    model_page: Union[Unset, int] = UNSET,
-    model_page_size: Union[Unset, int] = UNSET,
+    model_filter_type: Union[None, Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
+    model_page: Union[None, Unset, int] = UNSET,
+    model_page_size: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -75,10 +75,10 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_filter_type: Union[Unset, str] = UNSET,
-    model_search_string: Union[Unset, str] = UNSET,
-    model_page: Union[Unset, int] = UNSET,
-    model_page_size: Union[Unset, int] = UNSET,
+    model_filter_type: Union[None, Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
+    model_page: Union[None, Unset, int] = UNSET,
+    model_page_size: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetManageResponseModel"]]:
     """GetAssetManagerList
 
@@ -89,10 +89,10 @@ def sync_detailed(
         NoAgreement, ExpiredAgreement, AgreementUpForRenewal
 
     Args:
-        model_filter_type (Union[Unset, str]):
-        model_search_string (Union[Unset, str]):
-        model_page (Union[Unset, int]):
-        model_page_size (Union[Unset, int]):
+        model_filter_type (Union[None, Unset, str]):
+        model_search_string (Union[None, Unset, str]):
+        model_page (Union[None, Unset, int]):
+        model_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -119,10 +119,10 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_filter_type: Union[Unset, str] = UNSET,
-    model_search_string: Union[Unset, str] = UNSET,
-    model_page: Union[Unset, int] = UNSET,
-    model_page_size: Union[Unset, int] = UNSET,
+    model_filter_type: Union[None, Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
+    model_page: Union[None, Unset, int] = UNSET,
+    model_page_size: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetManageResponseModel"]]:
     """GetAssetManagerList
 
@@ -133,10 +133,10 @@ def sync(
         NoAgreement, ExpiredAgreement, AgreementUpForRenewal
 
     Args:
-        model_filter_type (Union[Unset, str]):
-        model_search_string (Union[Unset, str]):
-        model_page (Union[Unset, int]):
-        model_page_size (Union[Unset, int]):
+        model_filter_type (Union[None, Unset, str]):
+        model_search_string (Union[None, Unset, str]):
+        model_page (Union[None, Unset, int]):
+        model_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -158,10 +158,10 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_filter_type: Union[Unset, str] = UNSET,
-    model_search_string: Union[Unset, str] = UNSET,
-    model_page: Union[Unset, int] = UNSET,
-    model_page_size: Union[Unset, int] = UNSET,
+    model_filter_type: Union[None, Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
+    model_page: Union[None, Unset, int] = UNSET,
+    model_page_size: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetManageResponseModel"]]:
     """GetAssetManagerList
 
@@ -172,10 +172,10 @@ async def asyncio_detailed(
         NoAgreement, ExpiredAgreement, AgreementUpForRenewal
 
     Args:
-        model_filter_type (Union[Unset, str]):
-        model_search_string (Union[Unset, str]):
-        model_page (Union[Unset, int]):
-        model_page_size (Union[Unset, int]):
+        model_filter_type (Union[None, Unset, str]):
+        model_search_string (Union[None, Unset, str]):
+        model_page (Union[None, Unset, int]):
+        model_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -200,10 +200,10 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_filter_type: Union[Unset, str] = UNSET,
-    model_search_string: Union[Unset, str] = UNSET,
-    model_page: Union[Unset, int] = UNSET,
-    model_page_size: Union[Unset, int] = UNSET,
+    model_filter_type: Union[None, Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
+    model_page: Union[None, Unset, int] = UNSET,
+    model_page_size: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetManageResponseModel"]]:
     """GetAssetManagerList
 
@@ -214,10 +214,10 @@ async def asyncio(
         NoAgreement, ExpiredAgreement, AgreementUpForRenewal
 
     Args:
-        model_filter_type (Union[Unset, str]):
-        model_search_string (Union[Unset, str]):
-        model_page (Union[Unset, int]):
-        model_page_size (Union[Unset, int]):
+        model_filter_type (Union[None, Unset, str]):
+        model_search_string (Union[None, Unset, str]):
+        model_page (Union[None, Unset, int]):
+        model_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/client_assets/get_all_assets_get_2.py
+++ b/src/qualer_sdk/api/client_assets/get_all_assets_get_2.py
@@ -13,11 +13,11 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -76,19 +76,19 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -116,19 +116,19 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -151,19 +151,19 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -189,19 +189,19 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/client_assets/get_asset_get_2.py
+++ b/src/qualer_sdk/api/client_assets/get_asset_get_2.py
@@ -14,8 +14,8 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     asset_id_path: str,
     *,
-    asset_id_query: Union[Unset, str] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
+    asset_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -64,14 +64,14 @@ def sync_detailed(
     asset_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_id_query: Union[Unset, str] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
+    asset_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsAssetToAssetResponseModel]:
     """
     Args:
         asset_id_path (str):
-        asset_id_query (Union[Unset, str]):
-        model_asset_id (Union[Unset, int]):
+        asset_id_query (Union[None, Unset, str]):
+        model_asset_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -98,14 +98,14 @@ def sync(
     asset_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_id_query: Union[Unset, str] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
+    asset_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsAssetToAssetResponseModel]:
     """
     Args:
         asset_id_path (str):
-        asset_id_query (Union[Unset, str]):
-        model_asset_id (Union[Unset, int]):
+        asset_id_query (Union[None, Unset, str]):
+        model_asset_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,14 +127,14 @@ async def asyncio_detailed(
     asset_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_id_query: Union[Unset, str] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
+    asset_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsAssetToAssetResponseModel]:
     """
     Args:
         asset_id_path (str):
-        asset_id_query (Union[Unset, str]):
-        model_asset_id (Union[Unset, int]):
+        asset_id_query (Union[None, Unset, str]):
+        model_asset_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,14 +159,14 @@ async def asyncio(
     asset_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    asset_id_query: Union[Unset, str] = UNSET,
-    model_asset_id: Union[Unset, int] = UNSET,
+    asset_id_query: Union[None, Unset, str] = UNSET,
+    model_asset_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsAssetToAssetResponseModel]:
     """
     Args:
         asset_id_path (str):
-        asset_id_query (Union[Unset, str]):
-        model_asset_id (Union[Unset, int]):
+        asset_id_query (Union[None, Unset, str]):
+        model_asset_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/client_assets/get_asset_manager_list_get_2.py
+++ b/src/qualer_sdk/api/client_assets/get_asset_manager_list_get_2.py
@@ -14,10 +14,10 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     client_company_id: int,
     *,
-    query_filter_type: Union[Unset, str] = UNSET,
-    query_search_string: Union[Unset, str] = UNSET,
-    query_page: Union[Unset, int] = UNSET,
-    query_page_size: Union[Unset, int] = UNSET,
+    query_filter_type: Union[None, Unset, str] = UNSET,
+    query_search_string: Union[None, Unset, str] = UNSET,
+    query_page: Union[None, Unset, int] = UNSET,
+    query_page_size: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -77,10 +77,10 @@ def sync_detailed(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_filter_type: Union[Unset, str] = UNSET,
-    query_search_string: Union[Unset, str] = UNSET,
-    query_page: Union[Unset, int] = UNSET,
-    query_page_size: Union[Unset, int] = UNSET,
+    query_filter_type: Union[None, Unset, str] = UNSET,
+    query_search_string: Union[None, Unset, str] = UNSET,
+    query_page: Union[None, Unset, int] = UNSET,
+    query_page_size: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToClientAssetManagerResponseModel"]]:
     """GetAssetManagerList
 
@@ -92,10 +92,10 @@ def sync_detailed(
 
     Args:
         client_company_id (int):
-        query_filter_type (Union[Unset, str]):
-        query_search_string (Union[Unset, str]):
-        query_page (Union[Unset, int]):
-        query_page_size (Union[Unset, int]):
+        query_filter_type (Union[None, Unset, str]):
+        query_search_string (Union[None, Unset, str]):
+        query_page (Union[None, Unset, int]):
+        query_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -124,10 +124,10 @@ def sync(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_filter_type: Union[Unset, str] = UNSET,
-    query_search_string: Union[Unset, str] = UNSET,
-    query_page: Union[Unset, int] = UNSET,
-    query_page_size: Union[Unset, int] = UNSET,
+    query_filter_type: Union[None, Unset, str] = UNSET,
+    query_search_string: Union[None, Unset, str] = UNSET,
+    query_page: Union[None, Unset, int] = UNSET,
+    query_page_size: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToClientAssetManagerResponseModel"]]:
     """GetAssetManagerList
 
@@ -139,10 +139,10 @@ def sync(
 
     Args:
         client_company_id (int):
-        query_filter_type (Union[Unset, str]):
-        query_search_string (Union[Unset, str]):
-        query_page (Union[Unset, int]):
-        query_page_size (Union[Unset, int]):
+        query_filter_type (Union[None, Unset, str]):
+        query_search_string (Union[None, Unset, str]):
+        query_page (Union[None, Unset, int]):
+        query_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -166,10 +166,10 @@ async def asyncio_detailed(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_filter_type: Union[Unset, str] = UNSET,
-    query_search_string: Union[Unset, str] = UNSET,
-    query_page: Union[Unset, int] = UNSET,
-    query_page_size: Union[Unset, int] = UNSET,
+    query_filter_type: Union[None, Unset, str] = UNSET,
+    query_search_string: Union[None, Unset, str] = UNSET,
+    query_page: Union[None, Unset, int] = UNSET,
+    query_page_size: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToClientAssetManagerResponseModel"]]:
     """GetAssetManagerList
 
@@ -181,10 +181,10 @@ async def asyncio_detailed(
 
     Args:
         client_company_id (int):
-        query_filter_type (Union[Unset, str]):
-        query_search_string (Union[Unset, str]):
-        query_page (Union[Unset, int]):
-        query_page_size (Union[Unset, int]):
+        query_filter_type (Union[None, Unset, str]):
+        query_search_string (Union[None, Unset, str]):
+        query_page (Union[None, Unset, int]):
+        query_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -211,10 +211,10 @@ async def asyncio(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_filter_type: Union[Unset, str] = UNSET,
-    query_search_string: Union[Unset, str] = UNSET,
-    query_page: Union[Unset, int] = UNSET,
-    query_page_size: Union[Unset, int] = UNSET,
+    query_filter_type: Union[None, Unset, str] = UNSET,
+    query_search_string: Union[None, Unset, str] = UNSET,
+    query_page: Union[None, Unset, int] = UNSET,
+    query_page_size: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToClientAssetManagerResponseModel"]]:
     """GetAssetManagerList
 
@@ -226,10 +226,10 @@ async def asyncio(
 
     Args:
         client_company_id (int):
-        query_filter_type (Union[Unset, str]):
-        query_search_string (Union[Unset, str]):
-        query_page (Union[Unset, int]):
-        query_page_size (Union[Unset, int]):
+        query_filter_type (Union[None, Unset, str]):
+        query_search_string (Union[None, Unset, str]):
+        query_page (Union[None, Unset, int]):
+        query_page_size (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/client_assets/get_assets.py
+++ b/src/qualer_sdk/api/client_assets/get_assets.py
@@ -14,11 +14,11 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     client_company_id: int,
     *,
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -78,20 +78,20 @@ def sync_detailed(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
         client_company_id (int):
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -121,20 +121,20 @@ def sync(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
         client_company_id (int):
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,20 +159,20 @@ async def asyncio_detailed(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
         client_company_id (int):
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -200,20 +200,20 @@ async def asyncio(
     client_company_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    query_equipment_id: Union[Unset, str] = UNSET,
-    query_serial_number: Union[Unset, str] = UNSET,
-    query_asset_tag: Union[Unset, str] = UNSET,
-    query_barcode: Union[Unset, str] = UNSET,
-    query_legacy_id: Union[Unset, str] = UNSET,
+    query_equipment_id: Union[None, Unset, str] = UNSET,
+    query_serial_number: Union[None, Unset, str] = UNSET,
+    query_asset_tag: Union[None, Unset, str] = UNSET,
+    query_barcode: Union[None, Unset, str] = UNSET,
+    query_legacy_id: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsAssetToAssetResponseModel"]]:
     """
     Args:
         client_company_id (int):
-        query_equipment_id (Union[Unset, str]):
-        query_serial_number (Union[Unset, str]):
-        query_asset_tag (Union[Unset, str]):
-        query_barcode (Union[Unset, str]):
-        query_legacy_id (Union[Unset, str]):
+        query_equipment_id (Union[None, Unset, str]):
+        query_serial_number (Union[None, Unset, str]):
+        query_asset_tag (Union[None, Unset, str]):
+        query_barcode (Union[None, Unset, str]):
+        query_legacy_id (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/client_employees/get_employee.py
+++ b/src/qualer_sdk/api/client_employees/get_employee.py
@@ -14,8 +14,8 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     employee_id_path: str,
     *,
-    employee_id_query: Union[Unset, str] = UNSET,
-    model_employee_id: Union[Unset, int] = UNSET,
+    employee_id_query: Union[None, Unset, str] = UNSET,
+    model_employee_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -64,14 +64,14 @@ def sync_detailed(
     employee_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    employee_id_query: Union[Unset, str] = UNSET,
-    model_employee_id: Union[Unset, int] = UNSET,
+    employee_id_query: Union[None, Unset, str] = UNSET,
+    model_employee_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsClientsToEmployeeResponseModel]:
     """
     Args:
         employee_id_path (str):
-        employee_id_query (Union[Unset, str]):
-        model_employee_id (Union[Unset, int]):
+        employee_id_query (Union[None, Unset, str]):
+        model_employee_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -98,14 +98,14 @@ def sync(
     employee_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    employee_id_query: Union[Unset, str] = UNSET,
-    model_employee_id: Union[Unset, int] = UNSET,
+    employee_id_query: Union[None, Unset, str] = UNSET,
+    model_employee_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsClientsToEmployeeResponseModel]:
     """
     Args:
         employee_id_path (str):
-        employee_id_query (Union[Unset, str]):
-        model_employee_id (Union[Unset, int]):
+        employee_id_query (Union[None, Unset, str]):
+        model_employee_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,14 +127,14 @@ async def asyncio_detailed(
     employee_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    employee_id_query: Union[Unset, str] = UNSET,
-    model_employee_id: Union[Unset, int] = UNSET,
+    employee_id_query: Union[None, Unset, str] = UNSET,
+    model_employee_id: Union[None, Unset, int] = UNSET,
 ) -> Response[QualerApiModelsClientsToEmployeeResponseModel]:
     """
     Args:
         employee_id_path (str):
-        employee_id_query (Union[Unset, str]):
-        model_employee_id (Union[Unset, int]):
+        employee_id_query (Union[None, Unset, str]):
+        model_employee_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -159,14 +159,14 @@ async def asyncio(
     employee_id_path: str,
     *,
     client: Union[AuthenticatedClient, Client],
-    employee_id_query: Union[Unset, str] = UNSET,
-    model_employee_id: Union[Unset, int] = UNSET,
+    employee_id_query: Union[None, Unset, str] = UNSET,
+    model_employee_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[QualerApiModelsClientsToEmployeeResponseModel]:
     """
     Args:
         employee_id_path (str):
-        employee_id_query (Union[Unset, str]):
-        model_employee_id (Union[Unset, int]):
+        employee_id_query (Union[None, Unset, str]):
+        model_employee_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/clients/get_all_get_2.py
+++ b/src/qualer_sdk/api/clients/get_all_get_2.py
@@ -14,11 +14,11 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_legacy_id: Union[Unset, str] = UNSET,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_legacy_id: Union[None, Unset, str] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -30,7 +30,7 @@ def _get_kwargs(
 
     params["model.take"] = model_take
 
-    json_model_modified_after: Union[Unset, str] = UNSET
+    json_model_modified_after: Union[None, Unset, str] = UNSET
     if model_modified_after and not isinstance(model_modified_after, Unset):
         json_model_modified_after = model_modified_after.isoformat()
     params["model.modifiedAfter"] = json_model_modified_after
@@ -82,19 +82,19 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_legacy_id: Union[Unset, str] = UNSET,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_legacy_id: Union[None, Unset, str] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsClientsToClientCompanyResponseModel"]]:
     """
     Args:
-        model_legacy_id (Union[Unset, str]):
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_legacy_id (Union[None, Unset, str]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -122,19 +122,19 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_legacy_id: Union[Unset, str] = UNSET,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_legacy_id: Union[None, Unset, str] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsClientsToClientCompanyResponseModel"]]:
     """
     Args:
-        model_legacy_id (Union[Unset, str]):
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_legacy_id (Union[None, Unset, str]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -157,19 +157,19 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_legacy_id: Union[Unset, str] = UNSET,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_legacy_id: Union[None, Unset, str] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsClientsToClientCompanyResponseModel"]]:
     """
     Args:
-        model_legacy_id (Union[Unset, str]):
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_legacy_id (Union[None, Unset, str]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -195,19 +195,19 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_legacy_id: Union[Unset, str] = UNSET,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_legacy_id: Union[None, Unset, str] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsClientsToClientCompanyResponseModel"]]:
     """
     Args:
-        model_legacy_id (Union[Unset, str]):
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_legacy_id (Union[None, Unset, str]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/employees/get_employees_get_2.py
+++ b/src/qualer_sdk/api/employees/get_employees_get_2.py
@@ -13,7 +13,7 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -64,11 +64,11 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsClientsToEmployeeResponseModel"]]:
     """
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -92,11 +92,11 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsClientsToEmployeeResponseModel"]]:
     """
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -115,11 +115,11 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Response[list["QualerApiModelsClientsToEmployeeResponseModel"]]:
     """
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,11 +141,11 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_search_string: Union[Unset, str] = UNSET,
+    model_search_string: Union[None, Unset, str] = UNSET,
 ) -> Optional[list["QualerApiModelsClientsToEmployeeResponseModel"]]:
     """
     Args:
-        model_search_string (Union[Unset, str]):
+        model_search_string (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_documents/get_document_list.py
+++ b/src/qualer_sdk/api/service_order_documents/get_document_list.py
@@ -16,8 +16,8 @@ def _get_kwargs(
     *,
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -95,8 +95,8 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_id: Union[None, Unset, int] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -132,8 +132,8 @@ def sync_detailed(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -162,8 +162,8 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -199,8 +199,8 @@ def sync(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -224,8 +224,8 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_id: Union[None, Unset, int] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -261,8 +261,8 @@ async def asyncio_detailed(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -289,8 +289,8 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -326,8 +326,8 @@ async def asyncio(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_documents/get_documents.py
+++ b/src/qualer_sdk/api/service_order_documents/get_documents.py
@@ -12,7 +12,7 @@ from ...types import UNSET, File, Response, Unset
 def _get_kwargs(
     service_order_id: int,
     *,
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -105,7 +105,7 @@ def sync_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -115,7 +115,7 @@ def sync_detailed(
 
     Args:
         service_order_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,7 +141,7 @@ def sync(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -151,7 +151,7 @@ def sync(
 
     Args:
         service_order_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,7 +172,7 @@ async def asyncio_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -182,7 +182,7 @@ async def asyncio_detailed(
 
     Args:
         service_order_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -206,7 +206,7 @@ async def asyncio(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -216,7 +216,7 @@ async def asyncio(
 
     Args:
         service_order_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_documents/get_documents_list.py
+++ b/src/qualer_sdk/api/service_order_documents/get_documents_list.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     service_order_id: int,
     *,
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -86,7 +86,7 @@ def sync_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -98,7 +98,7 @@ def sync_detailed(
     """
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -124,7 +124,7 @@ def sync(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -136,7 +136,7 @@ def sync(
     """
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -157,7 +157,7 @@ async def asyncio_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -169,7 +169,7 @@ async def asyncio_detailed(
     """
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -193,7 +193,7 @@ async def asyncio(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -205,7 +205,7 @@ async def asyncio(
     """
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_documents/upload_documents_post_2.py
+++ b/src/qualer_sdk/api/service_order_documents/upload_documents_post_2.py
@@ -14,8 +14,8 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     service_order_id: int,
     *,
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -62,8 +62,8 @@ def sync_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Response[UploadDocumentsPost2Response200]:
     """reportType:<br />
     assetsummary, assetlabel, assetdetail, assetcertificate,<br />
@@ -76,8 +76,8 @@ def sync_detailed(
 
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -104,8 +104,8 @@ def sync(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Optional[UploadDocumentsPost2Response200]:
     """reportType:<br />
     assetsummary, assetlabel, assetdetail, assetcertificate,<br />
@@ -118,8 +118,8 @@ def sync(
 
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,8 +141,8 @@ async def asyncio_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Response[UploadDocumentsPost2Response200]:
     """reportType:<br />
     assetsummary, assetlabel, assetdetail, assetcertificate,<br />
@@ -155,8 +155,8 @@ async def asyncio_detailed(
 
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -181,8 +181,8 @@ async def asyncio(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Optional[UploadDocumentsPost2Response200]:
     """reportType:<br />
     assetsummary, assetlabel, assetdetail, assetcertificate,<br />
@@ -195,8 +195,8 @@ async def asyncio(
 
     Args:
         service_order_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_item_documents/get_document_list_get_2.py
+++ b/src/qualer_sdk/api/service_order_item_documents/get_document_list_get_2.py
@@ -16,8 +16,8 @@ def _get_kwargs(
     *,
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_item_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_item_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -95,8 +95,8 @@ def sync_detailed(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_item_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_item_id: Union[None, Unset, int] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -132,8 +132,8 @@ def sync_detailed(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -162,8 +162,8 @@ def sync(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_item_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_item_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -199,8 +199,8 @@ def sync(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -224,8 +224,8 @@ async def asyncio_detailed(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_item_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_item_id: Union[None, Unset, int] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -261,8 +261,8 @@ async def asyncio_detailed(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -289,8 +289,8 @@ async def asyncio(
     client: Union[AuthenticatedClient, Client],
     from_: datetime.datetime,
     to: datetime.datetime,
-    report_type: Union[Unset, str] = UNSET,
-    service_order_item_id: Union[Unset, int] = UNSET,
+    report_type: Union[None, Unset, str] = UNSET,
+    service_order_item_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -326,8 +326,8 @@ async def asyncio(
     Args:
         from_ (datetime.datetime):
         to (datetime.datetime):
-        report_type (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
+        report_type (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_item_documents/get_documents_get_2.py
+++ b/src/qualer_sdk/api/service_order_item_documents/get_documents_get_2.py
@@ -12,7 +12,7 @@ from ...types import UNSET, File, Response, Unset
 def _get_kwargs(
     service_order_item_id: int,
     *,
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -105,7 +105,7 @@ def sync_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -115,7 +115,7 @@ def sync_detailed(
 
     Args:
         service_order_item_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,7 +141,7 @@ def sync(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -151,7 +151,7 @@ def sync(
 
     Args:
         service_order_item_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -172,7 +172,7 @@ async def asyncio_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Response[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -182,7 +182,7 @@ async def asyncio_detailed(
 
     Args:
         service_order_item_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -206,7 +206,7 @@ async def asyncio(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_file_name: Union[Unset, str] = UNSET,
+    model_file_name: Union[None, Unset, str] = UNSET,
 ) -> Optional[Union[Any, File]]:
     """Retrieve work order documents
 
@@ -216,7 +216,7 @@ async def asyncio(
 
     Args:
         service_order_item_id (int):
-        model_file_name (Union[Unset, str]):
+        model_file_name (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_item_documents/get_documents_list_get_2.py
+++ b/src/qualer_sdk/api/service_order_item_documents/get_documents_list_get_2.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     service_order_item_id: int,
     *,
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -86,7 +86,7 @@ def sync_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -98,7 +98,7 @@ def sync_detailed(
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -124,7 +124,7 @@ def sync(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -136,7 +136,7 @@ def sync(
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -157,7 +157,7 @@ async def asyncio_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[
         Any,
@@ -169,7 +169,7 @@ async def asyncio_detailed(
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -193,7 +193,7 @@ async def asyncio(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[
         Any,
@@ -205,7 +205,7 @@ async def asyncio(
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
+        model_report_type (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_item_documents/upload_documents_post_3.py
+++ b/src/qualer_sdk/api/service_order_item_documents/upload_documents_post_3.py
@@ -14,8 +14,8 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     service_order_item_id: int,
     *,
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -62,14 +62,14 @@ def sync_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Response[UploadDocumentsPost3Response200]:
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -96,14 +96,14 @@ def sync(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Optional[UploadDocumentsPost3Response200]:
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -125,14 +125,14 @@ async def asyncio_detailed(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Response[UploadDocumentsPost3Response200]:
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -157,14 +157,14 @@ async def asyncio(
     service_order_item_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    model_report_type: Union[Unset, str] = UNSET,
-    model_is_private: Union[Unset, bool] = UNSET,
+    model_report_type: Union[None, Unset, str] = UNSET,
+    model_is_private: Union[None, Unset, bool] = UNSET,
 ) -> Optional[UploadDocumentsPost3Response200]:
     """
     Args:
         service_order_item_id (int):
-        model_report_type (Union[Unset, str]):
-        model_is_private (Union[Unset, bool]):
+        model_report_type (Union[None, Unset, str]):
+        model_is_private (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_item_measurements/get_measurements_by_asset_get_2.py
+++ b/src/qualer_sdk/api/service_order_item_measurements/get_measurements_by_asset_get_2.py
@@ -15,17 +15,17 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     asset_id: int,
     *,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
-    json_from_: Union[Unset, str] = UNSET
+    json_from_: Union[None, Unset, str] = UNSET
     if from_ and not isinstance(from_, Unset):
         json_from_ = from_.isoformat()
     params["from"] = json_from_
 
-    json_to: Union[Unset, str] = UNSET
+    json_to: Union[None, Unset, str] = UNSET
     if to and not isinstance(to, Unset):
         json_to = to.isoformat()
     params["to"] = json_to
@@ -78,14 +78,14 @@ def sync_detailed(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -112,14 +112,14 @@ def sync(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -141,14 +141,14 @@ async def asyncio_detailed(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -173,14 +173,14 @@ async def asyncio(
     asset_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsMeasurementsToMeasurementRecordResponseModel"]]:
     """
     Args:
         asset_id (int):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_order_items/get_work_items_workitems.py
+++ b/src/qualer_sdk/api/service_order_items/get_work_items_workitems.py
@@ -14,12 +14,12 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    work_item_number: Union[Unset, str] = UNSET,
-    asset_search: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    work_item_number: Union[None, Unset, str] = UNSET,
+    asset_search: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -27,12 +27,12 @@ def _get_kwargs(
 
     params["companyId"] = company_id
 
-    json_from_: Union[Unset, str] = UNSET
+    json_from_: Union[None, Unset, str] = UNSET
     if from_ and not isinstance(from_, Unset):
         json_from_ = from_.isoformat()
     params["from"] = json_from_
 
-    json_to: Union[Unset, str] = UNSET
+    json_to: Union[None, Unset, str] = UNSET
     if to and not isinstance(to, Unset):
         json_to = to.isoformat()
     params["to"] = json_to
@@ -95,12 +95,12 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    work_item_number: Union[Unset, str] = UNSET,
-    asset_search: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    work_item_number: Union[None, Unset, str] = UNSET,
+    asset_search: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderItemResponseModel"]]
 ]:
@@ -116,12 +116,12 @@ def sync_detailed(
     15T10:11:12&amp;to=2011-11-15T10:11:12&amp;workItemNumber=0629-000032-02
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        work_item_number (Union[Unset, str]):
-        asset_search (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        work_item_number (Union[None, Unset, str]):
+        asset_search (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -150,12 +150,12 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    work_item_number: Union[Unset, str] = UNSET,
-    asset_search: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    work_item_number: Union[None, Unset, str] = UNSET,
+    asset_search: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderItemResponseModel"]]
 ]:
@@ -171,12 +171,12 @@ def sync(
     15T10:11:12&amp;to=2011-11-15T10:11:12&amp;workItemNumber=0629-000032-02
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        work_item_number (Union[Unset, str]):
-        asset_search (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        work_item_number (Union[None, Unset, str]):
+        asset_search (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -200,12 +200,12 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    work_item_number: Union[Unset, str] = UNSET,
-    asset_search: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    work_item_number: Union[None, Unset, str] = UNSET,
+    asset_search: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderItemResponseModel"]]
 ]:
@@ -221,12 +221,12 @@ async def asyncio_detailed(
     15T10:11:12&amp;to=2011-11-15T10:11:12&amp;workItemNumber=0629-000032-02
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        work_item_number (Union[Unset, str]):
-        asset_search (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        work_item_number (Union[None, Unset, str]):
+        asset_search (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -253,12 +253,12 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    work_item_number: Union[Unset, str] = UNSET,
-    asset_search: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    work_item_number: Union[None, Unset, str] = UNSET,
+    asset_search: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderItemResponseModel"]]
 ]:
@@ -274,12 +274,12 @@ async def asyncio(
     15T10:11:12&amp;to=2011-11-15T10:11:12&amp;workItemNumber=0629-000032-02
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        work_item_number (Union[Unset, str]):
-        asset_search (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        work_item_number (Union[None, Unset, str]):
+        asset_search (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_orders/get_work_orders.py
+++ b/src/qualer_sdk/api/service_orders/get_work_orders.py
@@ -14,13 +14,13 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    modified_after: Union[Unset, datetime.datetime] = UNSET,
-    work_order_number: Union[Unset, str] = UNSET,
-    assigned_employees: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET,
+    work_order_number: Union[None, Unset, str] = UNSET,
+    assigned_employees: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -28,17 +28,17 @@ def _get_kwargs(
 
     params["companyId"] = company_id
 
-    json_from_: Union[Unset, str] = UNSET
+    json_from_: Union[None, Unset, str] = UNSET
     if from_ and not isinstance(from_, Unset):
         json_from_ = from_.isoformat()
     params["from"] = json_from_
 
-    json_to: Union[Unset, str] = UNSET
+    json_to: Union[None, Unset, str] = UNSET
     if to and not isinstance(to, Unset):
         json_to = to.isoformat()
     params["to"] = json_to
 
-    json_modified_after: Union[Unset, str] = UNSET
+    json_modified_after: Union[None, Unset, str] = UNSET
     if modified_after and not isinstance(modified_after, Unset):
         json_modified_after = modified_after.isoformat()
     params["modifiedAfter"] = json_modified_after
@@ -101,13 +101,13 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    modified_after: Union[Unset, datetime.datetime] = UNSET,
-    work_order_number: Union[Unset, str] = UNSET,
-    assigned_employees: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET,
+    work_order_number: Union[None, Unset, str] = UNSET,
+    assigned_employees: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderResponseModel"]]
 ]:
@@ -124,13 +124,13 @@ def sync_detailed(
     15T10:11:12&amp;workOrderNumber=00567
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        modified_after (Union[Unset, datetime.datetime]):
-        work_order_number (Union[Unset, str]):
-        assigned_employees (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        modified_after (Union[None, Unset, datetime.datetime]):
+        work_order_number (Union[None, Unset, str]):
+        assigned_employees (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -160,13 +160,13 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    modified_after: Union[Unset, datetime.datetime] = UNSET,
-    work_order_number: Union[Unset, str] = UNSET,
-    assigned_employees: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET,
+    work_order_number: Union[None, Unset, str] = UNSET,
+    assigned_employees: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderResponseModel"]]
 ]:
@@ -183,13 +183,13 @@ def sync(
     15T10:11:12&amp;workOrderNumber=00567
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        modified_after (Union[Unset, datetime.datetime]):
-        work_order_number (Union[Unset, str]):
-        assigned_employees (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        modified_after (Union[None, Unset, datetime.datetime]):
+        work_order_number (Union[None, Unset, str]):
+        assigned_employees (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -214,13 +214,13 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    modified_after: Union[Unset, datetime.datetime] = UNSET,
-    work_order_number: Union[Unset, str] = UNSET,
-    assigned_employees: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET,
+    work_order_number: Union[None, Unset, str] = UNSET,
+    assigned_employees: Union[None, Unset, str] = UNSET,
 ) -> Response[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderResponseModel"]]
 ]:
@@ -237,13 +237,13 @@ async def asyncio_detailed(
     15T10:11:12&amp;workOrderNumber=00567
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        modified_after (Union[Unset, datetime.datetime]):
-        work_order_number (Union[Unset, str]):
-        assigned_employees (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        modified_after (Union[None, Unset, datetime.datetime]):
+        work_order_number (Union[None, Unset, str]):
+        assigned_employees (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -271,13 +271,13 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    status: Union[Unset, str] = UNSET,
-    company_id: Union[Unset, int] = UNSET,
-    from_: Union[Unset, datetime.datetime] = UNSET,
-    to: Union[Unset, datetime.datetime] = UNSET,
-    modified_after: Union[Unset, datetime.datetime] = UNSET,
-    work_order_number: Union[Unset, str] = UNSET,
-    assigned_employees: Union[Unset, str] = UNSET,
+    status: Union[None, Unset, str] = UNSET,
+    company_id: Union[None, Unset, int] = UNSET,
+    from_: Union[None, Unset, datetime.datetime] = UNSET,
+    to: Union[None, Unset, datetime.datetime] = UNSET,
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET,
+    work_order_number: Union[None, Unset, str] = UNSET,
+    assigned_employees: Union[None, Unset, str] = UNSET,
 ) -> Optional[
     Union[Any, list["QualerApiModelsServiceOrdersToClientOrderResponseModel"]]
 ]:
@@ -294,13 +294,13 @@ async def asyncio(
     15T10:11:12&amp;workOrderNumber=00567
 
     Args:
-        status (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        modified_after (Union[Unset, datetime.datetime]):
-        work_order_number (Union[Unset, str]):
-        assigned_employees (Union[Unset, str]):
+        status (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        modified_after (Union[None, Unset, datetime.datetime]):
+        work_order_number (Union[None, Unset, str]):
+        assigned_employees (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_orders/get_work_orders_employee.py
+++ b/src/qualer_sdk/api/service_orders/get_work_orders_employee.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     employee_id: int,
     *,
-    is_internal: Union[Unset, bool] = UNSET,
+    is_internal: Union[None, Unset, bool] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -66,12 +66,12 @@ def sync_detailed(
     employee_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    is_internal: Union[Unset, bool] = UNSET,
+    is_internal: Union[None, Unset, bool] = UNSET,
 ) -> Response[list["QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel"]]:
     """
     Args:
         employee_id (int):
-        is_internal (Union[Unset, bool]):
+        is_internal (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -97,12 +97,12 @@ def sync(
     employee_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    is_internal: Union[Unset, bool] = UNSET,
+    is_internal: Union[None, Unset, bool] = UNSET,
 ) -> Optional[list["QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel"]]:
     """
     Args:
         employee_id (int):
-        is_internal (Union[Unset, bool]):
+        is_internal (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -123,12 +123,12 @@ async def asyncio_detailed(
     employee_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    is_internal: Union[Unset, bool] = UNSET,
+    is_internal: Union[None, Unset, bool] = UNSET,
 ) -> Response[list["QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel"]]:
     """
     Args:
         employee_id (int):
-        is_internal (Union[Unset, bool]):
+        is_internal (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -152,12 +152,12 @@ async def asyncio(
     employee_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    is_internal: Union[Unset, bool] = UNSET,
+    is_internal: Union[None, Unset, bool] = UNSET,
 ) -> Optional[list["QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel"]]:
     """
     Args:
         employee_id (int):
-        is_internal (Union[Unset, bool]):
+        is_internal (Union[None, Unset, bool]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_orders/order_cancel.py
+++ b/src/qualer_sdk/api/service_orders/order_cancel.py
@@ -12,7 +12,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     service_order_id: int,
     *,
-    reason_text: Union[Unset, str] = UNSET,
+    reason_text: Union[None, Unset, str] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -57,13 +57,13 @@ def sync_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    reason_text: Union[Unset, str] = UNSET,
+    reason_text: Union[None, Unset, str] = UNSET,
 ) -> Response[OrderCancelResponse200]:
     """Cancel work order
 
     Args:
         service_order_id (int):
-        reason_text (Union[Unset, str]):
+        reason_text (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -89,13 +89,13 @@ def sync(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    reason_text: Union[Unset, str] = UNSET,
+    reason_text: Union[None, Unset, str] = UNSET,
 ) -> Optional[OrderCancelResponse200]:
     """Cancel work order
 
     Args:
         service_order_id (int):
-        reason_text (Union[Unset, str]):
+        reason_text (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -116,13 +116,13 @@ async def asyncio_detailed(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    reason_text: Union[Unset, str] = UNSET,
+    reason_text: Union[None, Unset, str] = UNSET,
 ) -> Response[OrderCancelResponse200]:
     """Cancel work order
 
     Args:
         service_order_id (int):
-        reason_text (Union[Unset, str]):
+        reason_text (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -146,13 +146,13 @@ async def asyncio(
     service_order_id: int,
     *,
     client: Union[AuthenticatedClient, Client],
-    reason_text: Union[Unset, str] = UNSET,
+    reason_text: Union[None, Unset, str] = UNSET,
 ) -> Optional[OrderCancelResponse200]:
     """Cancel work order
 
     Args:
         service_order_id (int):
-        reason_text (Union[Unset, str]):
+        reason_text (Union[None, Unset, str]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/service_pricing/get_get_7.py
+++ b/src/qualer_sdk/api/service_pricing/get_get_7.py
@@ -14,7 +14,7 @@ from ...types import UNSET, Response, Unset
 def _get_kwargs(
     *,
     service_pricing_id: int,
-    service_group_id: Union[Unset, int] = UNSET,
+    service_group_id: Union[None, Unset, int] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -70,12 +70,12 @@ def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     service_pricing_id: int,
-    service_group_id: Union[Unset, int] = UNSET,
+    service_group_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsServiceOrdersToServiceOrderTaskResponse"]]:
     """
     Args:
         service_pricing_id (int):
-        service_group_id (Union[Unset, int]):
+        service_group_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -101,12 +101,12 @@ def sync(
     *,
     client: Union[AuthenticatedClient, Client],
     service_pricing_id: int,
-    service_group_id: Union[Unset, int] = UNSET,
+    service_group_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsServiceOrdersToServiceOrderTaskResponse"]]:
     """
     Args:
         service_pricing_id (int):
-        service_group_id (Union[Unset, int]):
+        service_group_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -127,12 +127,12 @@ async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
     service_pricing_id: int,
-    service_group_id: Union[Unset, int] = UNSET,
+    service_group_id: Union[None, Unset, int] = UNSET,
 ) -> Response[list["QualerApiModelsServiceOrdersToServiceOrderTaskResponse"]]:
     """
     Args:
         service_pricing_id (int):
-        service_group_id (Union[Unset, int]):
+        service_group_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -156,12 +156,12 @@ async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
     service_pricing_id: int,
-    service_group_id: Union[Unset, int] = UNSET,
+    service_group_id: Union[None, Unset, int] = UNSET,
 ) -> Optional[list["QualerApiModelsServiceOrdersToServiceOrderTaskResponse"]]:
     """
     Args:
         service_pricing_id (int):
-        service_group_id (Union[Unset, int]):
+        service_group_id (Union[None, Unset, int]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/api/vendors/get_all_get_3.py
+++ b/src/qualer_sdk/api/vendors/get_all_get_3.py
@@ -14,10 +14,10 @@ from ...types import UNSET, Response, Unset
 
 def _get_kwargs(
     *,
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {}
 
@@ -27,7 +27,7 @@ def _get_kwargs(
 
     params["model.take"] = model_take
 
-    json_model_modified_after: Union[Unset, str] = UNSET
+    json_model_modified_after: Union[None, Unset, str] = UNSET
     if model_modified_after and not isinstance(model_modified_after, Unset):
         json_model_modified_after = model_modified_after.isoformat()
     params["model.modifiedAfter"] = json_model_modified_after
@@ -79,17 +79,17 @@ def _build_response(
 def sync_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsVendorsToVendorCompanyResponseModel"]]:
     """
     Args:
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -116,17 +116,17 @@ def sync_detailed(
 def sync(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsVendorsToVendorCompanyResponseModel"]]:
     """
     Args:
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -148,17 +148,17 @@ def sync(
 async def asyncio_detailed(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Response[list["QualerApiModelsVendorsToVendorCompanyResponseModel"]]:
     """
     Args:
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -183,17 +183,17 @@ async def asyncio_detailed(
 async def asyncio(
     *,
     client: Union[AuthenticatedClient, Client],
-    model_account_number_text: Union[Unset, str] = UNSET,
-    model_company_name: Union[Unset, str] = UNSET,
-    model_take: Union[Unset, int] = UNSET,
-    model_modified_after: Union[Unset, datetime.datetime] = UNSET,
+    model_account_number_text: Union[None, Unset, str] = UNSET,
+    model_company_name: Union[None, Unset, str] = UNSET,
+    model_take: Union[None, Unset, int] = UNSET,
+    model_modified_after: Union[None, Unset, datetime.datetime] = UNSET,
 ) -> Optional[list["QualerApiModelsVendorsToVendorCompanyResponseModel"]]:
     """
     Args:
-        model_account_number_text (Union[Unset, str]):
-        model_company_name (Union[Unset, str]):
-        model_take (Union[Unset, int]):
-        model_modified_after (Union[Unset, datetime.datetime]):
+        model_account_number_text (Union[None, Unset, str]):
+        model_company_name (Union[None, Unset, str]):
+        model_take (Union[None, Unset, int]):
+        model_modified_after (Union[None, Unset, datetime.datetime]):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/src/qualer_sdk/models/qualer_api_models_account_from_employee_messages_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_from_employee_messages_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAccountFromEmployeeMessagesModel")
 class QualerApiModelsAccountFromEmployeeMessagesModel:
     """
     Attributes:
-        period (Union[Unset, int]):
-        site_id (Union[Unset, int]):
+        period (Union[None, Unset, int]):
+        site_id (Union[None, Unset, int]):
     """
 
-    period: Union[Unset, int] = UNSET
-    site_id: Union[Unset, int] = UNSET
+    period: Union[None, Unset, int] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_account_from_login_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_from_login_response_model.py
@@ -14,14 +14,14 @@ T = TypeVar("T", bound="QualerApiModelsAccountFromLoginResponseModel")
 class QualerApiModelsAccountFromLoginResponseModel:
     """
     Attributes:
-        token (Union[Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
+        token (Union[None, Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
     """
 
-    token: Union[Unset, UUID] = UNSET
+    token: Union[None, Unset, UUID] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        token: Union[Unset, str] = UNSET
+        token: Union[None, Unset, str] = UNSET
         if self.token and not isinstance(self.token, Unset):
             token = str(self.token)
 
@@ -37,7 +37,7 @@ class QualerApiModelsAccountFromLoginResponseModel:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _token = d.pop("Token", UNSET)
-        token: Union[Unset, UUID]
+        token: Union[None, Unset, UUID]
         if isinstance(_token, Unset):
             token = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_message_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_message_response_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAccountToEmployeeEventMessageResponseMode
 class QualerApiModelsAccountToEmployeeEventMessageResponseModel:
     """
     Attributes:
-        message (Union[Unset, str]):
+        message (Union[None, Unset, str]):
     """
 
-    message: Union[Unset, str] = UNSET
+    message: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_response_model.py
@@ -15,18 +15,18 @@ T = TypeVar("T", bound="QualerApiModelsAccountToEmployeeEventResponseModel")
 class QualerApiModelsAccountToEmployeeEventResponseModel:
     """
     Attributes:
-        id (Union[Unset, int]):
-        subject (Union[Unset, str]):
-        created_on_utc (Union[Unset, datetime.datetime]):
-        event_type_id (Union[Unset, int]):
-        event_type_group (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        subject (Union[None, Unset, str]):
+        created_on_utc (Union[None, Unset, datetime.datetime]):
+        event_type_id (Union[None, Unset, int]):
+        event_type_group (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    subject: Union[Unset, str] = UNSET
-    created_on_utc: Union[Unset, datetime.datetime] = UNSET
-    event_type_id: Union[Unset, int] = UNSET
-    event_type_group: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    subject: Union[None, Unset, str] = UNSET
+    created_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    event_type_id: Union[None, Unset, int] = UNSET
+    event_type_group: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,7 +34,7 @@ class QualerApiModelsAccountToEmployeeEventResponseModel:
 
         subject = self.subject
 
-        created_on_utc: Union[Unset, str] = UNSET
+        created_on_utc: Union[None, Unset, str] = UNSET
         if self.created_on_utc and not isinstance(self.created_on_utc, Unset):
             created_on_utc = self.created_on_utc.isoformat()
 
@@ -66,7 +66,7 @@ class QualerApiModelsAccountToEmployeeEventResponseModel:
         subject = d.pop("Subject", UNSET)
 
         _created_on_utc = d.pop("CreatedOnUtc", UNSET)
-        created_on_utc: Union[Unset, datetime.datetime]
+        created_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_created_on_utc, Unset):
             created_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_account_to_logout_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_logout_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAccountToLogoutModel")
 class QualerApiModelsAccountToLogoutModel:
     """
     Attributes:
-        logout_action (Union[Unset, str]):
+        logout_action (Union[None, Unset, str]):
     """
 
-    logout_action: Union[Unset, str] = UNSET
+    logout_action: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_address_address_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_address_address_model.py
@@ -13,38 +13,38 @@ T = TypeVar("T", bound="QualerApiModelsAddressAddressModel")
 class QualerApiModelsAddressAddressModel:
     """
     Attributes:
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        email (Union[Unset, str]):
-        company (Union[Unset, str]):
-        city (Union[Unset, str]):
-        address_1 (Union[Unset, str]):
-        address_2 (Union[Unset, str]):
-        zip_postal_code (Union[Unset, str]):
-        phone_number (Union[Unset, str]):
-        fax_number (Union[Unset, str]):
-        attention_1 (Union[Unset, str]):
-        attention_2 (Union[Unset, str]):
-        country (Union[Unset, str]):
-        state_province (Union[Unset, str]):
-        state_province_abbreviation (Union[Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        email (Union[None, Unset, str]):
+        company (Union[None, Unset, str]):
+        city (Union[None, Unset, str]):
+        address_1 (Union[None, Unset, str]):
+        address_2 (Union[None, Unset, str]):
+        zip_postal_code (Union[None, Unset, str]):
+        phone_number (Union[None, Unset, str]):
+        fax_number (Union[None, Unset, str]):
+        attention_1 (Union[None, Unset, str]):
+        attention_2 (Union[None, Unset, str]):
+        country (Union[None, Unset, str]):
+        state_province (Union[None, Unset, str]):
+        state_province_abbreviation (Union[None, Unset, str]):
     """
 
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    email: Union[Unset, str] = UNSET
-    company: Union[Unset, str] = UNSET
-    city: Union[Unset, str] = UNSET
-    address_1: Union[Unset, str] = UNSET
-    address_2: Union[Unset, str] = UNSET
-    zip_postal_code: Union[Unset, str] = UNSET
-    phone_number: Union[Unset, str] = UNSET
-    fax_number: Union[Unset, str] = UNSET
-    attention_1: Union[Unset, str] = UNSET
-    attention_2: Union[Unset, str] = UNSET
-    country: Union[Unset, str] = UNSET
-    state_province: Union[Unset, str] = UNSET
-    state_province_abbreviation: Union[Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    email: Union[None, Unset, str] = UNSET
+    company: Union[None, Unset, str] = UNSET
+    city: Union[None, Unset, str] = UNSET
+    address_1: Union[None, Unset, str] = UNSET
+    address_2: Union[None, Unset, str] = UNSET
+    zip_postal_code: Union[None, Unset, str] = UNSET
+    phone_number: Union[None, Unset, str] = UNSET
+    fax_number: Union[None, Unset, str] = UNSET
+    attention_1: Union[None, Unset, str] = UNSET
+    attention_2: Union[None, Unset, str] = UNSET
+    country: Union[None, Unset, str] = UNSET
+    state_province: Union[None, Unset, str] = UNSET
+    state_province_abbreviation: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_address_to_address_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_address_to_address_response_model.py
@@ -13,38 +13,38 @@ T = TypeVar("T", bound="QualerApiModelsAddressToAddressResponseModel")
 class QualerApiModelsAddressToAddressResponseModel:
     """
     Attributes:
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        email (Union[Unset, str]):
-        company (Union[Unset, str]):
-        city (Union[Unset, str]):
-        address_1 (Union[Unset, str]):
-        address_2 (Union[Unset, str]):
-        zip_postal_code (Union[Unset, str]):
-        phone_number (Union[Unset, str]):
-        fax_number (Union[Unset, str]):
-        attention_1 (Union[Unset, str]):
-        attention_2 (Union[Unset, str]):
-        country (Union[Unset, str]):
-        state_province (Union[Unset, str]):
-        state_province_abbreviation (Union[Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        email (Union[None, Unset, str]):
+        company (Union[None, Unset, str]):
+        city (Union[None, Unset, str]):
+        address_1 (Union[None, Unset, str]):
+        address_2 (Union[None, Unset, str]):
+        zip_postal_code (Union[None, Unset, str]):
+        phone_number (Union[None, Unset, str]):
+        fax_number (Union[None, Unset, str]):
+        attention_1 (Union[None, Unset, str]):
+        attention_2 (Union[None, Unset, str]):
+        country (Union[None, Unset, str]):
+        state_province (Union[None, Unset, str]):
+        state_province_abbreviation (Union[None, Unset, str]):
     """
 
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    email: Union[Unset, str] = UNSET
-    company: Union[Unset, str] = UNSET
-    city: Union[Unset, str] = UNSET
-    address_1: Union[Unset, str] = UNSET
-    address_2: Union[Unset, str] = UNSET
-    zip_postal_code: Union[Unset, str] = UNSET
-    phone_number: Union[Unset, str] = UNSET
-    fax_number: Union[Unset, str] = UNSET
-    attention_1: Union[Unset, str] = UNSET
-    attention_2: Union[Unset, str] = UNSET
-    country: Union[Unset, str] = UNSET
-    state_province: Union[Unset, str] = UNSET
-    state_province_abbreviation: Union[Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    email: Union[None, Unset, str] = UNSET
+    company: Union[None, Unset, str] = UNSET
+    city: Union[None, Unset, str] = UNSET
+    address_1: Union[None, Unset, str] = UNSET
+    address_2: Union[None, Unset, str] = UNSET
+    zip_postal_code: Union[None, Unset, str] = UNSET
+    phone_number: Union[None, Unset, str] = UNSET
+    fax_number: Union[None, Unset, str] = UNSET
+    attention_1: Union[None, Unset, str] = UNSET
+    attention_2: Union[None, Unset, str] = UNSET
+    country: Union[None, Unset, str] = UNSET
+    state_province: Union[None, Unset, str] = UNSET
+    state_province_abbreviation: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_attributes_to_asset_attributes_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_attributes_to_asset_attributes_response.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAssetAttributesToAssetAttributesResponse"
 class QualerApiModelsAssetAttributesToAssetAttributesResponse:
     """
     Attributes:
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_client_asset_manager_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_client_asset_manager_list_model.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromClientAssetManagerListModel")
 class QualerApiModelsAssetFromClientAssetManagerListModel:
     """
     Attributes:
-        filter_type (Union[Unset, str]):
-        search_string (Union[Unset, str]):
-        page (Union[Unset, int]):
-        page_size (Union[Unset, int]):
+        filter_type (Union[None, Unset, str]):
+        search_string (Union[None, Unset, str]):
+        page (Union[None, Unset, int]):
+        page_size (Union[None, Unset, int]):
     """
 
-    filter_type: Union[Unset, str] = UNSET
-    search_string: Union[Unset, str] = UNSET
-    page: Union[Unset, int] = UNSET
-    page_size: Union[Unset, int] = UNSET
+    filter_type: Union[None, Unset, str] = UNSET
+    search_string: Union[None, Unset, str] = UNSET
+    page: Union[None, Unset, int] = UNSET
+    page_size: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_counter_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_counter_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromGetAssetManagerCounterModel")
 class QualerApiModelsAssetFromGetAssetManagerCounterModel:
     """
     Attributes:
-        search_string (Union[Unset, str]):
+        search_string (Union[None, Unset, str]):
     """
 
-    search_string: Union[Unset, str] = UNSET
+    search_string: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_list_model.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromGetAssetManagerListModel")
 class QualerApiModelsAssetFromGetAssetManagerListModel:
     """
     Attributes:
-        filter_type (Union[Unset, str]):
-        search_string (Union[Unset, str]):
-        page (Union[Unset, int]):
-        page_size (Union[Unset, int]):
+        filter_type (Union[None, Unset, str]):
+        search_string (Union[None, Unset, str]):
+        page (Union[None, Unset, int]):
+        page_size (Union[None, Unset, int]):
     """
 
-    filter_type: Union[Unset, str] = UNSET
-    search_string: Union[Unset, str] = UNSET
-    page: Union[Unset, int] = UNSET
-    page_size: Union[Unset, int] = UNSET
+    filter_type: Union[None, Unset, str] = UNSET
+    search_string: Union[None, Unset, str] = UNSET
+    page: Union[None, Unset, int] = UNSET
+    page_size: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_class_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_class_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateAssetClassModel")
 class QualerApiModelsAssetFromUpdateAssetClassModel:
     """
     Attributes:
-        class_ (Union[Unset, str]):
+        class_ (Union[None, Unset, str]):
     """
 
-    class_: Union[Unset, str] = UNSET
+    class_: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_department_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_department_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateAssetDepartmentModel")
 class QualerApiModelsAssetFromUpdateAssetDepartmentModel:
     """
     Attributes:
-        department_name (Union[Unset, str]):
+        department_name (Union[None, Unset, str]):
     """
 
-    department_name: Union[Unset, str] = UNSET
+    department_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_maintenance_service_dat.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_maintenance_service_dat.py
@@ -15,16 +15,16 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateAssetMaintenanceServiceDat
 class QualerApiModelsAssetFromUpdateAssetMaintenanceServiceDat:
     """
     Attributes:
-        reset_service_date (Union[Unset, datetime.datetime]):
-        reset_service_task (Union[Unset, str]):
+        reset_service_date (Union[None, Unset, datetime.datetime]):
+        reset_service_task (Union[None, Unset, str]):
     """
 
-    reset_service_date: Union[Unset, datetime.datetime] = UNSET
-    reset_service_task: Union[Unset, str] = UNSET
+    reset_service_date: Union[None, Unset, datetime.datetime] = UNSET
+    reset_service_task: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        reset_service_date: Union[Unset, str] = UNSET
+        reset_service_date: Union[None, Unset, str] = UNSET
         if self.reset_service_date and not isinstance(self.reset_service_date, Unset):
             reset_service_date = self.reset_service_date.isoformat()
 
@@ -44,7 +44,7 @@ class QualerApiModelsAssetFromUpdateAssetMaintenanceServiceDat:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _reset_service_date = d.pop("ResetServiceDate", UNSET)
-        reset_service_date: Union[Unset, datetime.datetime]
+        reset_service_date: Union[None, Unset, datetime.datetime]
         if isinstance(_reset_service_date, Unset):
             reset_service_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_room_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_room_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateAssetRoomModel")
 class QualerApiModelsAssetFromUpdateAssetRoomModel:
     """
     Attributes:
-        room_number (Union[Unset, str]):
+        room_number (Union[None, Unset, str]):
     """
 
-    room_number: Union[Unset, str] = UNSET
+    room_number: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_filter_preference_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_filter_preference_model.py
@@ -15,16 +15,16 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateFilterPreferenceModel")
 class QualerApiModelsAssetFromUpdateFilterPreferenceModel:
     """
     Attributes:
-        filter_type (Union[Unset, str]):
-        within_days (Union[Unset, int]):
-        use_date_range (Union[Unset, bool]):
+        filter_type (Union[None, Unset, str]):
+        within_days (Union[None, Unset, int]):
+        use_date_range (Union[None, Unset, bool]):
         start_date (Union[None, Unset, datetime.datetime]):
         end_date (Union[None, Unset, datetime.datetime]):
     """
 
-    filter_type: Union[Unset, str] = UNSET
-    within_days: Union[Unset, int] = UNSET
-    use_date_range: Union[Unset, bool] = UNSET
+    filter_type: Union[None, Unset, str] = UNSET
+    within_days: Union[None, Unset, int] = UNSET
+    use_date_range: Union[None, Unset, bool] = UNSET
     start_date: Union[None, Unset, datetime.datetime] = UNSET
     end_date: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_room_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_room_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAssetFromUpdateRoomModel")
 class QualerApiModelsAssetFromUpdateRoomModel:
     """
     Attributes:
-        room (Union[Unset, str]):
-        tracking_id (Union[Unset, str]):
+        room (Union[None, Unset, str]):
+        tracking_id (Union[None, Unset, str]):
     """
 
-    room: Union[Unset, str] = UNSET
-    tracking_id: Union[Unset, str] = UNSET
+    room: Union[None, Unset, str] = UNSET
+    tracking_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_pools_to_asset_pool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_pools_to_asset_pool_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAssetPoolsToAssetPoolModel")
 class QualerApiModelsAssetPoolsToAssetPoolModel:
     """
     Attributes:
-        asset_pool_id (Union[Unset, int]):
-        asset_pool_name (Union[Unset, str]):
+        asset_pool_id (Union[None, Unset, int]):
+        asset_pool_name (Union[None, Unset, str]):
     """
 
-    asset_pool_id: Union[Unset, int] = UNSET
-    asset_pool_name: Union[Unset, str] = UNSET
+    asset_pool_id: Union[None, Unset, int] = UNSET
+    asset_pool_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
@@ -13,20 +13,20 @@ T = TypeVar("T", bound="QualerApiModelsAssetReservationFromCloseAssetReservation
 class QualerApiModelsAssetReservationFromCloseAssetReservationsModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        area_id (Union[Unset, int]):
-        product_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        reservation_id (Union[Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        area_id (Union[None, Unset, int]):
+        product_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        reservation_id (Union[None, Unset, int]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    area_id: Union[Unset, int] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    reservation_id: Union[Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    area_id: Union[None, Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    reservation_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_get_asset_reservations_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_get_asset_reservations_model.py
@@ -15,32 +15,32 @@ T = TypeVar("T", bound="QualerApiModelsAssetReservationFromGetAssetReservationsM
 class QualerApiModelsAssetReservationFromGetAssetReservationsModel:
     """
     Attributes:
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
-        asset_id (Union[Unset, int]):
-        area_id (Union[Unset, int]):
-        product_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        reservation_id (Union[Unset, int]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
+        asset_id (Union[None, Unset, int]):
+        area_id (Union[None, Unset, int]):
+        product_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        reservation_id (Union[None, Unset, int]):
     """
 
-    from_: Union[Unset, datetime.datetime] = UNSET
-    to: Union[Unset, datetime.datetime] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    area_id: Union[Unset, int] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    reservation_id: Union[Unset, int] = UNSET
+    from_: Union[None, Unset, datetime.datetime] = UNSET
+    to: Union[None, Unset, datetime.datetime] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    area_id: Union[None, Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    reservation_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        from_: Union[Unset, str] = UNSET
+        from_: Union[None, Unset, str] = UNSET
         if self.from_ and not isinstance(self.from_, Unset):
             from_ = self.from_.isoformat()
 
-        to: Union[Unset, str] = UNSET
+        to: Union[None, Unset, str] = UNSET
         if self.to and not isinstance(self.to, Unset):
             to = self.to.isoformat()
 
@@ -82,14 +82,14 @@ class QualerApiModelsAssetReservationFromGetAssetReservationsModel:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _from_ = d.pop("From", UNSET)
-        from_: Union[Unset, datetime.datetime]
+        from_: Union[None, Unset, datetime.datetime]
         if isinstance(_from_, Unset):
             from_ = UNSET
         else:
             from_ = isoparse(_from_)
 
         _to = d.pop("To", UNSET)
-        to: Union[Unset, datetime.datetime]
+        to: Union[None, Unset, datetime.datetime]
         if isinstance(_to, Unset):
             to = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
@@ -15,26 +15,26 @@ T = TypeVar("T", bound="QualerApiModelsAssetReservationFromUpsertAssetReservatio
 class QualerApiModelsAssetReservationFromUpsertAssetReservationModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        product_id (Union[Unset, int]):
-        reservation_id (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        begin_date (Union[Unset, datetime.datetime]):
-        end_date (Union[Unset, datetime.datetime]):
-        reserved_by (Union[Unset, int]):
-        reserved_by_name (Union[Unset, str]):
-        comments (Union[Unset, str]):
+        asset_id (Union[None, Unset, int]):
+        product_id (Union[None, Unset, int]):
+        reservation_id (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        begin_date (Union[None, Unset, datetime.datetime]):
+        end_date (Union[None, Unset, datetime.datetime]):
+        reserved_by (Union[None, Unset, int]):
+        reserved_by_name (Union[None, Unset, str]):
+        comments (Union[None, Unset, str]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    reservation_id: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    begin_date: Union[Unset, datetime.datetime] = UNSET
-    end_date: Union[Unset, datetime.datetime] = UNSET
-    reserved_by: Union[Unset, int] = UNSET
-    reserved_by_name: Union[Unset, str] = UNSET
-    comments: Union[Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    reservation_id: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    begin_date: Union[None, Unset, datetime.datetime] = UNSET
+    end_date: Union[None, Unset, datetime.datetime] = UNSET
+    reserved_by: Union[None, Unset, int] = UNSET
+    reserved_by_name: Union[None, Unset, str] = UNSET
+    comments: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -46,11 +46,11 @@ class QualerApiModelsAssetReservationFromUpsertAssetReservationModel:
 
         service_order_id = self.service_order_id
 
-        begin_date: Union[Unset, str] = UNSET
+        begin_date: Union[None, Unset, str] = UNSET
         if self.begin_date and not isinstance(self.begin_date, Unset):
             begin_date = self.begin_date.isoformat()
 
-        end_date: Union[Unset, str] = UNSET
+        end_date: Union[None, Unset, str] = UNSET
         if self.end_date and not isinstance(self.end_date, Unset):
             end_date = self.end_date.isoformat()
 
@@ -96,14 +96,14 @@ class QualerApiModelsAssetReservationFromUpsertAssetReservationModel:
         service_order_id = d.pop("ServiceOrderId", UNSET)
 
         _begin_date = d.pop("BeginDate", UNSET)
-        begin_date: Union[Unset, datetime.datetime]
+        begin_date: Union[None, Unset, datetime.datetime]
         if isinstance(_begin_date, Unset):
             begin_date = UNSET
         else:
             begin_date = isoparse(_begin_date)
 
         _end_date = d.pop("EndDate", UNSET)
-        end_date: Union[Unset, datetime.datetime]
+        end_date: Union[None, Unset, datetime.datetime]
         if isinstance(_end_date, Unset):
             end_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_asset_reservation_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_asset_reservation_response.py
@@ -15,56 +15,56 @@ T = TypeVar("T", bound="QualerApiModelsAssetReservationToAssetReservationRespons
 class QualerApiModelsAssetReservationToAssetReservationResponse:
     """
     Attributes:
-        original_begin_date (Union[Unset, datetime.datetime]):
-        original_end_date (Union[Unset, datetime.datetime]):
-        begin_date (Union[Unset, datetime.datetime]):
-        end_date (Union[Unset, datetime.datetime]):
-        reserved_on (Union[Unset, datetime.datetime]):
-        reserved_on_utc (Union[Unset, datetime.datetime]):
-        comments (Union[Unset, str]):
-        product_id (Union[Unset, int]):
-        asset_id (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        reserved_by_id (Union[Unset, int]):
-        reserved_by_name (Union[Unset, str]):
+        original_begin_date (Union[None, Unset, datetime.datetime]):
+        original_end_date (Union[None, Unset, datetime.datetime]):
+        begin_date (Union[None, Unset, datetime.datetime]):
+        end_date (Union[None, Unset, datetime.datetime]):
+        reserved_on (Union[None, Unset, datetime.datetime]):
+        reserved_on_utc (Union[None, Unset, datetime.datetime]):
+        comments (Union[None, Unset, str]):
+        product_id (Union[None, Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        reserved_by_id (Union[None, Unset, int]):
+        reserved_by_name (Union[None, Unset, str]):
     """
 
-    original_begin_date: Union[Unset, datetime.datetime] = UNSET
-    original_end_date: Union[Unset, datetime.datetime] = UNSET
-    begin_date: Union[Unset, datetime.datetime] = UNSET
-    end_date: Union[Unset, datetime.datetime] = UNSET
-    reserved_on: Union[Unset, datetime.datetime] = UNSET
-    reserved_on_utc: Union[Unset, datetime.datetime] = UNSET
-    comments: Union[Unset, str] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    reserved_by_id: Union[Unset, int] = UNSET
-    reserved_by_name: Union[Unset, str] = UNSET
+    original_begin_date: Union[None, Unset, datetime.datetime] = UNSET
+    original_end_date: Union[None, Unset, datetime.datetime] = UNSET
+    begin_date: Union[None, Unset, datetime.datetime] = UNSET
+    end_date: Union[None, Unset, datetime.datetime] = UNSET
+    reserved_on: Union[None, Unset, datetime.datetime] = UNSET
+    reserved_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    comments: Union[None, Unset, str] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    reserved_by_id: Union[None, Unset, int] = UNSET
+    reserved_by_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        original_begin_date: Union[Unset, str] = UNSET
+        original_begin_date: Union[None, Unset, str] = UNSET
         if self.original_begin_date and not isinstance(self.original_begin_date, Unset):
             original_begin_date = self.original_begin_date.isoformat()
 
-        original_end_date: Union[Unset, str] = UNSET
+        original_end_date: Union[None, Unset, str] = UNSET
         if self.original_end_date and not isinstance(self.original_end_date, Unset):
             original_end_date = self.original_end_date.isoformat()
 
-        begin_date: Union[Unset, str] = UNSET
+        begin_date: Union[None, Unset, str] = UNSET
         if self.begin_date and not isinstance(self.begin_date, Unset):
             begin_date = self.begin_date.isoformat()
 
-        end_date: Union[Unset, str] = UNSET
+        end_date: Union[None, Unset, str] = UNSET
         if self.end_date and not isinstance(self.end_date, Unset):
             end_date = self.end_date.isoformat()
 
-        reserved_on: Union[Unset, str] = UNSET
+        reserved_on: Union[None, Unset, str] = UNSET
         if self.reserved_on and not isinstance(self.reserved_on, Unset):
             reserved_on = self.reserved_on.isoformat()
 
-        reserved_on_utc: Union[Unset, str] = UNSET
+        reserved_on_utc: Union[None, Unset, str] = UNSET
         if self.reserved_on_utc and not isinstance(self.reserved_on_utc, Unset):
             reserved_on_utc = self.reserved_on_utc.isoformat()
 
@@ -114,42 +114,42 @@ class QualerApiModelsAssetReservationToAssetReservationResponse:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _original_begin_date = d.pop("OriginalBeginDate", UNSET)
-        original_begin_date: Union[Unset, datetime.datetime]
+        original_begin_date: Union[None, Unset, datetime.datetime]
         if isinstance(_original_begin_date, Unset):
             original_begin_date = UNSET
         else:
             original_begin_date = isoparse(_original_begin_date)
 
         _original_end_date = d.pop("OriginalEndDate", UNSET)
-        original_end_date: Union[Unset, datetime.datetime]
+        original_end_date: Union[None, Unset, datetime.datetime]
         if isinstance(_original_end_date, Unset):
             original_end_date = UNSET
         else:
             original_end_date = isoparse(_original_end_date)
 
         _begin_date = d.pop("BeginDate", UNSET)
-        begin_date: Union[Unset, datetime.datetime]
+        begin_date: Union[None, Unset, datetime.datetime]
         if isinstance(_begin_date, Unset):
             begin_date = UNSET
         else:
             begin_date = isoparse(_begin_date)
 
         _end_date = d.pop("EndDate", UNSET)
-        end_date: Union[Unset, datetime.datetime]
+        end_date: Union[None, Unset, datetime.datetime]
         if isinstance(_end_date, Unset):
             end_date = UNSET
         else:
             end_date = isoparse(_end_date)
 
         _reserved_on = d.pop("ReservedOn", UNSET)
-        reserved_on: Union[Unset, datetime.datetime]
+        reserved_on: Union[None, Unset, datetime.datetime]
         if isinstance(_reserved_on, Unset):
             reserved_on = UNSET
         else:
             reserved_on = isoparse(_reserved_on)
 
         _reserved_on_utc = d.pop("ReservedOnUtc", UNSET)
-        reserved_on_utc: Union[Unset, datetime.datetime]
+        reserved_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_reserved_on_utc, Unset):
             reserved_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_upsert_asset_reservation_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_upsert_asset_reservation_response.py
@@ -15,10 +15,10 @@ T = TypeVar(
 class QualerApiModelsAssetReservationToUpsertAssetReservationResponse:
     """
     Attributes:
-        asset_reservation_id (Union[Unset, int]):
+        asset_reservation_id (Union[None, Unset, int]):
     """
 
-    asset_reservation_id: Union[Unset, int] = UNSET
+    asset_reservation_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_add_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_add_asset_service_record_model.py
@@ -17,10 +17,10 @@ T = TypeVar(
 class QualerApiModelsAssetServiceRecordsFromAddAssetServiceRecordModel:
     """
     Attributes:
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        certificate_number (Union[Unset, str]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        certificate_number (Union[None, Unset, str]):
         result_status (Union[None, Unset, str]):
         as_found_result (Union[None, Unset, str]):
         as_left_result (Union[None, Unset, str]):
@@ -51,10 +51,10 @@ class QualerApiModelsAssetServiceRecordsFromAddAssetServiceRecordModel:
         schedule_name (Union[None, Unset, str]):
     """
 
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     result_status: Union[None, Unset, str] = UNSET
     as_found_result: Union[None, Unset, str] = UNSET
     as_left_result: Union[None, Unset, str] = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_download_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_download_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAssetServiceRecordsFromAsrDocumentDownloa
 class QualerApiModelsAssetServiceRecordsFromAsrDocumentDownloadModel:
     """
     Attributes:
-        asset_service_record_id (Union[Unset, int]):
-        file_name (Union[Unset, str]):
+        asset_service_record_id (Union[None, Unset, int]):
+        file_name (Union[None, Unset, str]):
     """
 
-    asset_service_record_id: Union[Unset, int] = UNSET
-    file_name: Union[Unset, str] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
+    file_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetServiceRecordsFromAsrDocumentModel")
 class QualerApiModelsAssetServiceRecordsFromAsrDocumentModel:
     """
     Attributes:
-        asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
     """
 
-    asset_service_record_id: Union[Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
@@ -17,16 +17,16 @@ T = TypeVar(
 class QualerApiModelsAssetServiceRecordsFromAssetServiceRecordFilterModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        from_ (Union[Unset, datetime.datetime]):
-        to (Union[Unset, datetime.datetime]):
+        asset_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        from_ (Union[None, Unset, datetime.datetime]):
+        to (Union[None, Unset, datetime.datetime]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    from_: Union[Unset, datetime.datetime] = UNSET
-    to: Union[Unset, datetime.datetime] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    from_: Union[None, Unset, datetime.datetime] = UNSET
+    to: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,11 +34,11 @@ class QualerApiModelsAssetServiceRecordsFromAssetServiceRecordFilterModel:
 
         serial_number = self.serial_number
 
-        from_: Union[Unset, str] = UNSET
+        from_: Union[None, Unset, str] = UNSET
         if self.from_ and not isinstance(self.from_, Unset):
             from_ = self.from_.isoformat()
 
-        to: Union[Unset, str] = UNSET
+        to: Union[None, Unset, str] = UNSET
         if self.to and not isinstance(self.to, Unset):
             to = self.to.isoformat()
 
@@ -64,14 +64,14 @@ class QualerApiModelsAssetServiceRecordsFromAssetServiceRecordFilterModel:
         serial_number = d.pop("SerialNumber", UNSET)
 
         _from_ = d.pop("From", UNSET)
-        from_: Union[Unset, datetime.datetime]
+        from_: Union[None, Unset, datetime.datetime]
         if isinstance(_from_, Unset):
             from_ = UNSET
         else:
             from_ = isoparse(_from_)
 
         _to = d.pop("To", UNSET)
-        to: Union[Unset, datetime.datetime]
+        to: Union[None, Unset, datetime.datetime]
         if isinstance(_to, Unset):
             to = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsAssetServiceRecordsFromAssetServiceRecord
 class QualerApiModelsAssetServiceRecordsFromAssetServiceRecordModel:
     """
     Attributes:
-        asset_service_record_id (Union[Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
     """
 
-    asset_service_record_id: Union[Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_update_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_update_asset_service_record_model.py
@@ -17,10 +17,10 @@ T = TypeVar(
 class QualerApiModelsAssetServiceRecordsFromUpdateAssetServiceRecordModel:
     """
     Attributes:
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        certificate_number (Union[Unset, str]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        certificate_number (Union[None, Unset, str]):
         result_status (Union[None, Unset, str]):
         as_found_result (Union[None, Unset, str]):
         as_left_result (Union[None, Unset, str]):
@@ -28,7 +28,7 @@ class QualerApiModelsAssetServiceRecordsFromUpdateAssetServiceRecordModel:
         as_found_tolerance (Union[None, Unset, float]):
         as_left_tolerance (Union[None, Unset, float]):
         service_date (Union[None, Unset, datetime.datetime]):
-        serial_number (Union[Unset, str]):
+        serial_number (Union[None, Unset, str]):
         asset_tag (Union[None, Unset, str]):
         asset_user (Union[None, Unset, str]):
         service_notes (Union[None, Unset, str]):
@@ -51,10 +51,10 @@ class QualerApiModelsAssetServiceRecordsFromUpdateAssetServiceRecordModel:
         schedule_name (Union[None, Unset, str]):
     """
 
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     result_status: Union[None, Unset, str] = UNSET
     as_found_result: Union[None, Unset, str] = UNSET
     as_left_result: Union[None, Unset, str] = UNSET
@@ -62,7 +62,7 @@ class QualerApiModelsAssetServiceRecordsFromUpdateAssetServiceRecordModel:
     as_found_tolerance: Union[None, Unset, float] = UNSET
     as_left_tolerance: Union[None, Unset, float] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
-    serial_number: Union[Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
     asset_tag: Union[None, Unset, str] = UNSET
     asset_user: Union[None, Unset, str] = UNSET
     service_notes: Union[None, Unset, str] = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_add_asset_service_record_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_add_asset_service_record_response.py
@@ -15,10 +15,10 @@ T = TypeVar(
 class QualerApiModelsAssetServiceRecordsToAddAssetServiceRecordResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
@@ -18,20 +18,20 @@ T = TypeVar(
 class QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        asset_service_record_id (Union[Unset, int]):
-        service_schedule_segment_id (Union[Unset, int]):
-        forward_segment_id (Union[Unset, int]):
-        forward_next_service (Union[Unset, bool]):
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        certificate_number (Union[Unset, str]):
+        asset_id (Union[None, Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
+        service_schedule_segment_id (Union[None, Unset, int]):
+        forward_segment_id (Union[None, Unset, int]):
+        forward_next_service (Union[None, Unset, bool]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        certificate_number (Union[None, Unset, str]):
         result_status (Union[None, Unset, str]):
         as_found_result (Union[None, Unset, str]):
         as_left_result (Union[None, Unset, str]):
         service_date (Union[None, Unset, datetime.datetime]):
-        serial_number (Union[Unset, str]):
+        serial_number (Union[None, Unset, str]):
         asset_tag (Union[None, Unset, str]):
         asset_user (Union[None, Unset, str]):
         asset_tag_change (Union[None, Unset, str]):
@@ -58,20 +58,20 @@ class QualerApiModelsAssetServiceRecordsToAssetServiceRecordResponseModel:
         schedule_name (Union[None, Unset, str]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    asset_service_record_id: Union[Unset, int] = UNSET
-    service_schedule_segment_id: Union[Unset, int] = UNSET
-    forward_segment_id: Union[Unset, int] = UNSET
-    forward_next_service: Union[Unset, bool] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
+    service_schedule_segment_id: Union[None, Unset, int] = UNSET
+    forward_segment_id: Union[None, Unset, int] = UNSET
+    forward_next_service: Union[None, Unset, bool] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     result_status: Union[None, Unset, str] = UNSET
     as_found_result: Union[None, Unset, str] = UNSET
     as_left_result: Union[None, Unset, str] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
-    serial_number: Union[Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
     asset_tag: Union[None, Unset, str] = UNSET
     asset_user: Union[None, Unset, str] = UNSET
     asset_tag_change: Union[None, Unset, str] = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_forecast_api_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_forecast_api_response_model.py
@@ -22,110 +22,109 @@ class QualerApiModelsAssetToAssetForecastApiResponseModel:
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
         next_service_task (Union[None, Unset, str]):
-        company_id (Union[Unset, int]):
-        asset_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        asset_status (Union[Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        location (Union[Unset, str]):
-        room_number (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        class_ (Union[Unset, str]):
-        custodian_email (Union[Unset, str]):
-        custodian_first_name (Union[Unset, str]):
-        custodian_last_name (Union[Unset, str]):
-        custodian_name (Union[Unset, str]):
-        department (Union[Unset, str]):
-        station (Union[Unset, str]):
-        notes (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        cumulative_service_cost (Union[Unset, float]):
-        product_id (Union[Unset, int]):
-        manufacturer_part_number (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        product_manufacturer (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        site_id (Union[Unset, int]):
-        condition (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        pool (Union[Unset, str]):
+        company_id (Union[None, Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        asset_status (Union[None, Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        room_number (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        class_ (Union[None, Unset, str]):
+        custodian_email (Union[None, Unset, str]):
+        custodian_first_name (Union[None, Unset, str]):
+        custodian_last_name (Union[None, Unset, str]):
+        custodian_name (Union[None, Unset, str]):
+        department (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        notes (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        cumulative_service_cost (Union[None, Unset, float]):
+        product_id (Union[None, Unset, int]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        product_manufacturer (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        site_id (Union[None, Unset, int]):
+        condition (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        pool (Union[None, Unset, str]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        purchase_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         activation_date (Union[None, Unset, datetime.datetime]):
-        depreciation_basis (Union[Unset, float]):
-        depreciation_method (Union[Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        depreciation_method (Union[None, Unset, int]):
         retirement_date (Union[None, Unset, datetime.datetime]):
-        salvage_value (Union[Unset, float]):
-        retirment_reason (Union[Unset, str]):
-        composite_parent_id (Union[Unset, int]):
-        composite_child_count (Union[Unset, int]):
+        salvage_value (Union[None, Unset, float]):
+        retirment_reason (Union[None, Unset, str]):
+        composite_parent_id (Union[None, Unset, int]):
+        composite_child_count (Union[None, Unset, int]):
     """
 
     last_due_date: Union[None, Unset, datetime.datetime] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_task: Union[None, Unset, str] = UNSET
-    company_id: Union[Unset, int] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    asset_status: Union[
-        Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus
+    company_id: Union[None, Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    asset_status: Union[None, Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus
     ] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    room_number: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    class_: Union[Unset, str] = UNSET
-    custodian_email: Union[Unset, str] = UNSET
-    custodian_first_name: Union[Unset, str] = UNSET
-    custodian_last_name: Union[Unset, str] = UNSET
-    custodian_name: Union[Unset, str] = UNSET
-    department: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    notes: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    cumulative_service_cost: Union[Unset, float] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    product_manufacturer: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    condition: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    pool: Union[Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    room_number: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    class_: Union[None, Unset, str] = UNSET
+    custodian_email: Union[None, Unset, str] = UNSET
+    custodian_first_name: Union[None, Unset, str] = UNSET
+    custodian_last_name: Union[None, Unset, str] = UNSET
+    custodian_name: Union[None, Unset, str] = UNSET
+    department: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    notes: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    cumulative_service_cost: Union[None, Unset, float] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    product_manufacturer: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    pool: Union[None, Unset, str] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
     retirement_date: Union[None, Unset, datetime.datetime] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
-    retirment_reason: Union[Unset, str] = UNSET
-    composite_parent_id: Union[Unset, int] = UNSET
-    composite_child_count: Union[Unset, int] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
+    retirment_reason: Union[None, Unset, str] = UNSET
+    composite_parent_id: Union[None, Unset, int] = UNSET
+    composite_child_count: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -171,7 +170,7 @@ class QualerApiModelsAssetToAssetForecastApiResponseModel:
 
         equipment_id = self.equipment_id
 
-        asset_status: Union[Unset, str] = UNSET
+        asset_status: Union[None, Unset, str] = UNSET
         if self.asset_status and not isinstance(self.asset_status, Unset):
             asset_status = self.asset_status.value
 
@@ -466,8 +465,7 @@ class QualerApiModelsAssetToAssetForecastApiResponseModel:
         equipment_id = d.pop("EquipmentId", UNSET)
 
         _asset_status = d.pop("AssetStatus", UNSET)
-        asset_status: Union[
-            Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus
+        asset_status: Union[None, Unset, QualerApiModelsAssetToAssetForecastApiResponseModelAssetStatus
         ]
         if isinstance(_asset_status, Unset):
             asset_status = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_model.py
@@ -24,114 +24,112 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetMaintenancePlanModel")
 class QualerApiModelsAssetToAssetMaintenancePlanModel:
     """
     Attributes:
-        maintenance_plans (Union[Unset, list['QualerApiModelsAssetToAssetMaintenancePlanResponse']]):
-        company_id (Union[Unset, int]):
-        asset_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        asset_status (Union[Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        location (Union[Unset, str]):
-        room_number (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        class_ (Union[Unset, str]):
-        custodian_email (Union[Unset, str]):
-        custodian_first_name (Union[Unset, str]):
-        custodian_last_name (Union[Unset, str]):
-        custodian_name (Union[Unset, str]):
-        department (Union[Unset, str]):
-        station (Union[Unset, str]):
-        notes (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        cumulative_service_cost (Union[Unset, float]):
-        product_id (Union[Unset, int]):
-        manufacturer_part_number (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        product_manufacturer (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        site_id (Union[Unset, int]):
-        condition (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        pool (Union[Unset, str]):
+        maintenance_plans (Union[None, Unset, list['QualerApiModelsAssetToAssetMaintenancePlanResponse']]):
+        company_id (Union[None, Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        asset_status (Union[None, Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        room_number (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        class_ (Union[None, Unset, str]):
+        custodian_email (Union[None, Unset, str]):
+        custodian_first_name (Union[None, Unset, str]):
+        custodian_last_name (Union[None, Unset, str]):
+        custodian_name (Union[None, Unset, str]):
+        department (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        notes (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        cumulative_service_cost (Union[None, Unset, float]):
+        product_id (Union[None, Unset, int]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        product_manufacturer (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        site_id (Union[None, Unset, int]):
+        condition (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        pool (Union[None, Unset, str]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        purchase_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         activation_date (Union[None, Unset, datetime.datetime]):
-        depreciation_basis (Union[Unset, float]):
-        depreciation_method (Union[Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        depreciation_method (Union[None, Unset, int]):
         retirement_date (Union[None, Unset, datetime.datetime]):
-        salvage_value (Union[Unset, float]):
-        retirment_reason (Union[Unset, str]):
-        composite_parent_id (Union[Unset, int]):
-        composite_child_count (Union[Unset, int]):
+        salvage_value (Union[None, Unset, float]):
+        retirment_reason (Union[None, Unset, str]):
+        composite_parent_id (Union[None, Unset, int]):
+        composite_child_count (Union[None, Unset, int]):
     """
 
-    maintenance_plans: Union[
-        Unset, list["QualerApiModelsAssetToAssetMaintenancePlanResponse"]
+    maintenance_plans: Union[None, Unset, list["QualerApiModelsAssetToAssetMaintenancePlanResponse"]
     ] = UNSET
-    company_id: Union[Unset, int] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    asset_status: Union[
-        Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus
+    company_id: Union[None, Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    asset_status: Union[None, Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus
     ] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    room_number: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    class_: Union[Unset, str] = UNSET
-    custodian_email: Union[Unset, str] = UNSET
-    custodian_first_name: Union[Unset, str] = UNSET
-    custodian_last_name: Union[Unset, str] = UNSET
-    custodian_name: Union[Unset, str] = UNSET
-    department: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    notes: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    cumulative_service_cost: Union[Unset, float] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    product_manufacturer: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    condition: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    pool: Union[Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    room_number: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    class_: Union[None, Unset, str] = UNSET
+    custodian_email: Union[None, Unset, str] = UNSET
+    custodian_first_name: Union[None, Unset, str] = UNSET
+    custodian_last_name: Union[None, Unset, str] = UNSET
+    custodian_name: Union[None, Unset, str] = UNSET
+    department: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    notes: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    cumulative_service_cost: Union[None, Unset, float] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    product_manufacturer: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    pool: Union[None, Unset, str] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
     retirement_date: Union[None, Unset, datetime.datetime] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
-    retirment_reason: Union[Unset, str] = UNSET
-    composite_parent_id: Union[Unset, int] = UNSET
-    composite_child_count: Union[Unset, int] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
+    retirment_reason: Union[None, Unset, str] = UNSET
+    composite_parent_id: Union[None, Unset, int] = UNSET
+    composite_child_count: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        maintenance_plans: Union[Unset, list[dict[str, Any]]] = UNSET
+        maintenance_plans: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.maintenance_plans and not isinstance(self.maintenance_plans, Unset):
             maintenance_plans = []
             for maintenance_plans_item_data in self.maintenance_plans:
@@ -150,7 +148,7 @@ class QualerApiModelsAssetToAssetMaintenancePlanModel:
 
         equipment_id = self.equipment_id
 
-        asset_status: Union[Unset, str] = UNSET
+        asset_status: Union[None, Unset, str] = UNSET
         if self.asset_status and not isinstance(self.asset_status, Unset):
             asset_status = self.asset_status.value
 
@@ -389,8 +387,7 @@ class QualerApiModelsAssetToAssetMaintenancePlanModel:
         equipment_id = d.pop("EquipmentId", UNSET)
 
         _asset_status = d.pop("AssetStatus", UNSET)
-        asset_status: Union[
-            Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus
+        asset_status: Union[None, Unset, QualerApiModelsAssetToAssetMaintenancePlanModelAssetStatus
         ]
         if isinstance(_asset_status, Unset):
             asset_status = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
@@ -21,43 +21,42 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetMaintenancePlanResponse")
 class QualerApiModelsAssetToAssetMaintenancePlanResponse:
     """
     Attributes:
-        maintenance_plan_id (Union[Unset, int]):
-        maintenance_plan_name (Union[Unset, str]):
-        task_notes (Union[Unset, str]):
-        last_service_task (Union[Unset, str]):
+        maintenance_plan_id (Union[None, Unset, int]):
+        maintenance_plan_name (Union[None, Unset, str]):
+        task_notes (Union[None, Unset, str]):
+        last_service_task (Union[None, Unset, str]):
         last_service_date (Union[None, Unset, datetime.datetime]):
-        next_service_task (Union[Unset, str]):
+        next_service_task (Union[None, Unset, str]):
         next_service_date (Union[None, Unset, datetime.datetime]):
         certificate_due_date (Union[None, Unset, datetime.datetime]):
-        owner_first_name (Union[Unset, str]):
-        owner_last_name (Union[Unset, str]):
-        owner_alias (Union[Unset, str]):
-        owner_department_name (Union[Unset, str]):
-        technician_first_name (Union[Unset, str]):
-        technician_last_name (Union[Unset, str]):
-        technician_alias (Union[Unset, str]):
-        technician_department_name (Union[Unset, str]):
-        assigned_employees (Union[Unset, list['QualerApiModelsAssetToAssetMaintenancePlanResponseAssignedEmployee']]):
+        owner_first_name (Union[None, Unset, str]):
+        owner_last_name (Union[None, Unset, str]):
+        owner_alias (Union[None, Unset, str]):
+        owner_department_name (Union[None, Unset, str]):
+        technician_first_name (Union[None, Unset, str]):
+        technician_last_name (Union[None, Unset, str]):
+        technician_alias (Union[None, Unset, str]):
+        technician_department_name (Union[None, Unset, str]):
+        assigned_employees (Union[None, Unset, list['QualerApiModelsAssetToAssetMaintenancePlanResponseAssignedEmployee']]):
     """
 
-    maintenance_plan_id: Union[Unset, int] = UNSET
-    maintenance_plan_name: Union[Unset, str] = UNSET
-    task_notes: Union[Unset, str] = UNSET
-    last_service_task: Union[Unset, str] = UNSET
+    maintenance_plan_id: Union[None, Unset, int] = UNSET
+    maintenance_plan_name: Union[None, Unset, str] = UNSET
+    task_notes: Union[None, Unset, str] = UNSET
+    last_service_task: Union[None, Unset, str] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    next_service_task: Union[Unset, str] = UNSET
+    next_service_task: Union[None, Unset, str] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
     certificate_due_date: Union[None, Unset, datetime.datetime] = UNSET
-    owner_first_name: Union[Unset, str] = UNSET
-    owner_last_name: Union[Unset, str] = UNSET
-    owner_alias: Union[Unset, str] = UNSET
-    owner_department_name: Union[Unset, str] = UNSET
-    technician_first_name: Union[Unset, str] = UNSET
-    technician_last_name: Union[Unset, str] = UNSET
-    technician_alias: Union[Unset, str] = UNSET
-    technician_department_name: Union[Unset, str] = UNSET
-    assigned_employees: Union[
-        Unset,
+    owner_first_name: Union[None, Unset, str] = UNSET
+    owner_last_name: Union[None, Unset, str] = UNSET
+    owner_alias: Union[None, Unset, str] = UNSET
+    owner_department_name: Union[None, Unset, str] = UNSET
+    technician_first_name: Union[None, Unset, str] = UNSET
+    technician_last_name: Union[None, Unset, str] = UNSET
+    technician_alias: Union[None, Unset, str] = UNSET
+    technician_department_name: Union[None, Unset, str] = UNSET
+    assigned_employees: Union[None, Unset,
         list["QualerApiModelsAssetToAssetMaintenancePlanResponseAssignedEmployee"],
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -113,7 +112,7 @@ class QualerApiModelsAssetToAssetMaintenancePlanResponse:
 
         technician_department_name = self.technician_department_name
 
-        assigned_employees: Union[Unset, list[dict[str, Any]]] = UNSET
+        assigned_employees: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.assigned_employees and not isinstance(self.assigned_employees, Unset):
             assigned_employees = []
             for assigned_employees_item_data in self.assigned_employees:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee.py
@@ -15,14 +15,14 @@ T = TypeVar(
 class QualerApiModelsAssetToAssetMaintenancePlanResponseAssignedEmployee:
     """
     Attributes:
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        alias (Union[Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
     """
 
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
@@ -29,180 +29,180 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetManageResponseModel")
 class QualerApiModelsAssetToAssetManageResponseModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        record_type (Union[Unset, QualerApiModelsAssetToAssetManageResponseModelRecordType]):
-        parent_asset_id (Union[Unset, int]):
-        children_count (Union[Unset, int]):
-        site_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        condition (Union[Unset, str]):
-        asset_class (Union[Unset, str]):
+        asset_id (Union[None, Unset, int]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        record_type (Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelRecordType]):
+        parent_asset_id (Union[None, Unset, int]):
+        children_count (Union[None, Unset, int]):
+        site_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        condition (Union[None, Unset, str]):
+        asset_class (Union[None, Unset, str]):
         activation_date (Union[None, Unset, datetime.datetime]):
         retirment_date (Union[None, Unset, datetime.datetime]):
-        client_vendor_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        asset_has_image (Union[Unset, bool]):
-        has_image (Union[Unset, bool]):
-        parent_has_image (Union[Unset, bool]):
-        pool_id (Union[Unset, int]):
-        pool (Union[Unset, str]):
-        product_id (Union[Unset, int]):
-        parent_product_id (Union[Unset, int]):
-        product_name (Union[Unset, str]):
-        parent_product_name (Union[Unset, str]):
-        category_id (Union[Unset, int]):
-        root_category_id (Union[Unset, int]):
-        category_name (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        manufacturer_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        display_name (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        asset_room (Union[Unset, str]):
-        location (Union[Unset, str]):
-        station (Union[Unset, str]):
-        tool_role (Union[Unset, QualerApiModelsAssetToAssetManageResponseModelToolRole]):
-        tool_id (Union[Unset, int]):
-        department_id (Union[Unset, int]):
-        department_name (Union[Unset, str]):
-        custodian_name (Union[Unset, str]):
-        warranty (Union[Unset, str]):
+        client_vendor_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        asset_has_image (Union[None, Unset, bool]):
+        has_image (Union[None, Unset, bool]):
+        parent_has_image (Union[None, Unset, bool]):
+        pool_id (Union[None, Unset, int]):
+        pool (Union[None, Unset, str]):
+        product_id (Union[None, Unset, int]):
+        parent_product_id (Union[None, Unset, int]):
+        product_name (Union[None, Unset, str]):
+        parent_product_name (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        root_category_id (Union[None, Unset, int]):
+        category_name (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        manufacturer_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        display_name (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        asset_room (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        tool_role (Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelToolRole]):
+        tool_id (Union[None, Unset, int]):
+        department_id (Union[None, Unset, int]):
+        department_name (Union[None, Unset, str]):
+        custodian_name (Union[None, Unset, str]):
+        warranty (Union[None, Unset, str]):
         warranty_end (Union[None, Unset, datetime.datetime]):
-        is_warranty_expired (Union[Unset, bool]):
-        depreciation_method (Union[Unset, int]):
-        depreciation_basis (Union[Unset, float]):
-        salvage_value (Union[Unset, float]):
-        total_service_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        is_warranty_expired (Union[None, Unset, bool]):
+        depreciation_method (Union[None, Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        salvage_value (Union[None, Unset, float]):
+        total_service_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         due_for_replacement_date (Union[None, Unset, datetime.datetime]):
-        depreciation_proc (Union[Unset, float]):
+        depreciation_proc (Union[None, Unset, float]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        time_in_service (Union[Unset, int]):
-        retirement_reason (Union[Unset, str]):
-        residual_cost (Union[Unset, float]):
-        employee_id (Union[Unset, int]):
-        asset_service_record_id (Union[Unset, int]):
-        result_status (Union[Unset, ServiceResultStatus]):
-        as_found_result (Union[Unset, ServiceResultStatus]):
-        as_left_result (Union[Unset, ServiceResultStatus]):
+        purchase_cost (Union[None, Unset, float]):
+        time_in_service (Union[None, Unset, int]):
+        retirement_reason (Union[None, Unset, str]):
+        residual_cost (Union[None, Unset, float]):
+        employee_id (Union[None, Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
+        result_status (Union[None, Unset, ServiceResultStatus]):
+        as_found_result (Union[None, Unset, ServiceResultStatus]):
+        as_left_result (Union[None, Unset, ServiceResultStatus]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         last_service (Union[None, Unset, str]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        next_service (Union[Unset, str]):
-        service_schedule_segment_id (Union[Unset, int]):
-        service_schedule_id (Union[Unset, int]):
-        service_schedule (Union[Unset, str]):
-        service_order_id (Union[Unset, int]):
-        service_order_status (Union[Unset, QualerApiModelsAssetToAssetManageResponseModelServiceOrderStatus]):
-        custom_order_number (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
-        vendor (Union[Unset, str]):
-        technician (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
+        next_service (Union[None, Unset, str]):
+        service_schedule_segment_id (Union[None, Unset, int]):
+        service_schedule_id (Union[None, Unset, int]):
+        service_schedule (Union[None, Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        service_order_status (Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelServiceOrderStatus]):
+        custom_order_number (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        vendor (Union[None, Unset, str]):
+        technician (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
         due_trigger_date (Union[None, Unset, datetime.datetime]):
         past_due_trigger_date (Union[None, Unset, datetime.datetime]):
-        due_status (Union[Unset, QualerApiModelsAssetToAssetManageResponseModelDueStatus]):
-        work_status (Union[Unset, WorkStatus]):
+        due_status (Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelDueStatus]):
+        work_status (Union[None, Unset, WorkStatus]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
     record_type: Union[
         None, Unset, QualerApiModelsAssetToAssetManageResponseModelRecordType
     ] = UNSET
-    parent_asset_id: Union[Unset, int] = UNSET
-    children_count: Union[Unset, int] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    condition: Union[Unset, str] = UNSET
-    asset_class: Union[Unset, str] = UNSET
+    parent_asset_id: Union[None, Unset, int] = UNSET
+    children_count: Union[None, Unset, int] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    asset_class: Union[None, Unset, str] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
     retirment_date: Union[None, Unset, datetime.datetime] = UNSET
-    client_vendor_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    asset_has_image: Union[Unset, bool] = UNSET
-    has_image: Union[Unset, bool] = UNSET
-    parent_has_image: Union[Unset, bool] = UNSET
-    pool_id: Union[Unset, int] = UNSET
-    pool: Union[Unset, str] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    parent_product_id: Union[Unset, int] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    parent_product_name: Union[Unset, str] = UNSET
-    category_id: Union[Unset, int] = UNSET
-    root_category_id: Union[Unset, int] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    manufacturer_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    display_name: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    asset_room: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
+    client_vendor_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    asset_has_image: Union[None, Unset, bool] = UNSET
+    has_image: Union[None, Unset, bool] = UNSET
+    parent_has_image: Union[None, Unset, bool] = UNSET
+    pool_id: Union[None, Unset, int] = UNSET
+    pool: Union[None, Unset, str] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    parent_product_id: Union[None, Unset, int] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    parent_product_name: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    root_category_id: Union[None, Unset, int] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    manufacturer_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    display_name: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    asset_room: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
     tool_role: Union[
         None, Unset, QualerApiModelsAssetToAssetManageResponseModelToolRole
     ] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    department_id: Union[Unset, int] = UNSET
-    department_name: Union[Unset, str] = UNSET
-    custodian_name: Union[Unset, str] = UNSET
-    warranty: Union[Unset, str] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    department_id: Union[None, Unset, int] = UNSET
+    department_name: Union[None, Unset, str] = UNSET
+    custodian_name: Union[None, Unset, str] = UNSET
+    warranty: Union[None, Unset, str] = UNSET
     warranty_end: Union[None, Unset, datetime.datetime] = UNSET
-    is_warranty_expired: Union[Unset, bool] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
-    total_service_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    is_warranty_expired: Union[None, Unset, bool] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
+    total_service_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     due_for_replacement_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_proc: Union[Unset, float] = UNSET
+    depreciation_proc: Union[None, Unset, float] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    time_in_service: Union[Unset, int] = UNSET
-    retirement_reason: Union[Unset, str] = UNSET
-    residual_cost: Union[Unset, float] = UNSET
-    employee_id: Union[Unset, int] = UNSET
-    asset_service_record_id: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    time_in_service: Union[None, Unset, int] = UNSET
+    retirement_reason: Union[None, Unset, str] = UNSET
+    residual_cost: Union[None, Unset, float] = UNSET
+    employee_id: Union[None, Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
     result_status: Union[None, Unset, ServiceResultStatus] = UNSET
     as_found_result: Union[None, Unset, ServiceResultStatus] = UNSET
     as_left_result: Union[None, Unset, ServiceResultStatus] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     last_service: Union[None, Unset, str] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    next_service: Union[Unset, str] = UNSET
-    service_schedule_segment_id: Union[Unset, int] = UNSET
-    service_schedule_id: Union[Unset, int] = UNSET
-    service_schedule: Union[Unset, str] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
+    next_service: Union[None, Unset, str] = UNSET
+    service_schedule_segment_id: Union[None, Unset, int] = UNSET
+    service_schedule_id: Union[None, Unset, int] = UNSET
+    service_schedule: Union[None, Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
     service_order_status: Union[
         None, Unset, QualerApiModelsAssetToAssetManageResponseModelServiceOrderStatus
     ] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    vendor: Union[Unset, str] = UNSET
-    technician: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    vendor: Union[None, Unset, str] = UNSET
+    technician: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     due_trigger_date: Union[None, Unset, datetime.datetime] = UNSET
     past_due_trigger_date: Union[None, Unset, datetime.datetime] = UNSET
     due_status: Union[
@@ -646,8 +646,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
         asset_maker = d.pop("AssetMaker", UNSET)
 
         _record_type = d.pop("RecordType", UNSET)
-        record_type: Union[
-            Unset, QualerApiModelsAssetToAssetManageResponseModelRecordType
+        record_type: Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelRecordType
         ]
         if isinstance(_record_type, Unset):
             record_type = UNSET
@@ -767,7 +766,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
         station = d.pop("Station", UNSET)
 
         _tool_role = d.pop("ToolRole", UNSET)
-        tool_role: Union[Unset, QualerApiModelsAssetToAssetManageResponseModelToolRole]
+        tool_role: Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelToolRole]
         if isinstance(_tool_role, Unset):
             tool_role = UNSET
         elif _tool_role is None:
@@ -869,7 +868,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
         asset_service_record_id = d.pop("AssetServiceRecordId", UNSET)
 
         _result_status = d.pop("ResultStatus", UNSET)
-        result_status: Union[Unset, ServiceResultStatus]
+        result_status: Union[None, Unset, ServiceResultStatus]
         if isinstance(_result_status, Unset):
             result_status = UNSET
         elif _result_status is None:
@@ -878,7 +877,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
             result_status = ServiceResultStatus(_result_status)
 
         _as_found_result = d.pop("AsFoundResult", UNSET)
-        as_found_result: Union[Unset, ServiceResultStatus]
+        as_found_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_found_result, Unset):
             as_found_result = UNSET
         elif _as_found_result is None:
@@ -887,7 +886,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
             as_found_result = ServiceResultStatus(_as_found_result)
 
         _as_left_result = d.pop("AsLeftResult", UNSET)
-        as_left_result: Union[Unset, ServiceResultStatus]
+        as_left_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_left_result, Unset):
             as_left_result = UNSET
         elif _as_left_result is None:
@@ -953,8 +952,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
         service_order_id = d.pop("ServiceOrderId", UNSET)
 
         _service_order_status = d.pop("ServiceOrderStatus", UNSET)
-        service_order_status: Union[
-            Unset, QualerApiModelsAssetToAssetManageResponseModelServiceOrderStatus
+        service_order_status: Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelServiceOrderStatus
         ]
         if isinstance(_service_order_status, Unset):
             service_order_status = UNSET
@@ -1018,8 +1016,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
         )
 
         _due_status = d.pop("DueStatus", UNSET)
-        due_status: Union[
-            Unset, QualerApiModelsAssetToAssetManageResponseModelDueStatus
+        due_status: Union[None, Unset, QualerApiModelsAssetToAssetManageResponseModelDueStatus
         ]
         if isinstance(_due_status, Unset):
             due_status = UNSET
@@ -1031,7 +1028,7 @@ class QualerApiModelsAssetToAssetManageResponseModel:
             )
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_response_model.py
@@ -18,106 +18,106 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetResponseModel")
 class QualerApiModelsAssetToAssetResponseModel:
     """
     Attributes:
-        company_id (Union[Unset, int]):
-        asset_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        asset_status (Union[Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        location (Union[Unset, str]):
-        room_number (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        class_ (Union[Unset, str]):
-        custodian_email (Union[Unset, str]):
-        custodian_first_name (Union[Unset, str]):
-        custodian_last_name (Union[Unset, str]):
-        custodian_name (Union[Unset, str]):
-        department (Union[Unset, str]):
-        station (Union[Unset, str]):
-        notes (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        cumulative_service_cost (Union[Unset, float]):
-        product_id (Union[Unset, int]):
-        manufacturer_part_number (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        product_manufacturer (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        site_id (Union[Unset, int]):
-        condition (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        pool (Union[Unset, str]):
+        company_id (Union[None, Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        asset_status (Union[None, Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        room_number (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        class_ (Union[None, Unset, str]):
+        custodian_email (Union[None, Unset, str]):
+        custodian_first_name (Union[None, Unset, str]):
+        custodian_last_name (Union[None, Unset, str]):
+        custodian_name (Union[None, Unset, str]):
+        department (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        notes (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        cumulative_service_cost (Union[None, Unset, float]):
+        product_id (Union[None, Unset, int]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        product_manufacturer (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        site_id (Union[None, Unset, int]):
+        condition (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        pool (Union[None, Unset, str]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        purchase_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         activation_date (Union[None, Unset, datetime.datetime]):
-        depreciation_basis (Union[Unset, float]):
-        depreciation_method (Union[Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        depreciation_method (Union[None, Unset, int]):
         retirement_date (Union[None, Unset, datetime.datetime]):
-        salvage_value (Union[Unset, float]):
-        retirment_reason (Union[Unset, str]):
-        composite_parent_id (Union[Unset, int]):
-        composite_child_count (Union[Unset, int]):
+        salvage_value (Union[None, Unset, float]):
+        retirment_reason (Union[None, Unset, str]):
+        composite_parent_id (Union[None, Unset, int]):
+        composite_child_count (Union[None, Unset, int]):
     """
 
-    company_id: Union[Unset, int] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    asset_status: Union[Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus] = (
+    company_id: Union[None, Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    asset_status: Union[None, Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus] = (
         UNSET
     )
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    room_number: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    class_: Union[Unset, str] = UNSET
-    custodian_email: Union[Unset, str] = UNSET
-    custodian_first_name: Union[Unset, str] = UNSET
-    custodian_last_name: Union[Unset, str] = UNSET
-    custodian_name: Union[Unset, str] = UNSET
-    department: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    notes: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    cumulative_service_cost: Union[Unset, float] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    product_manufacturer: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    condition: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    pool: Union[Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    room_number: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    class_: Union[None, Unset, str] = UNSET
+    custodian_email: Union[None, Unset, str] = UNSET
+    custodian_first_name: Union[None, Unset, str] = UNSET
+    custodian_last_name: Union[None, Unset, str] = UNSET
+    custodian_name: Union[None, Unset, str] = UNSET
+    department: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    notes: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    cumulative_service_cost: Union[None, Unset, float] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    product_manufacturer: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    pool: Union[None, Unset, str] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
     retirement_date: Union[None, Unset, datetime.datetime] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
-    retirment_reason: Union[Unset, str] = UNSET
-    composite_parent_id: Union[Unset, int] = UNSET
-    composite_child_count: Union[Unset, int] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
+    retirment_reason: Union[None, Unset, str] = UNSET
+    composite_parent_id: Union[None, Unset, int] = UNSET
+    composite_child_count: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -133,7 +133,7 @@ class QualerApiModelsAssetToAssetResponseModel:
 
         equipment_id = self.equipment_id
 
-        asset_status: Union[Unset, str] = UNSET
+        asset_status: Union[None, Unset, str] = UNSET
         if self.asset_status and not isinstance(self.asset_status, Unset):
             asset_status = self.asset_status.value
 
@@ -355,7 +355,7 @@ class QualerApiModelsAssetToAssetResponseModel:
         equipment_id = d.pop("EquipmentId", UNSET)
 
         _asset_status = d.pop("AssetStatus", UNSET)
-        asset_status: Union[Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus]
+        asset_status: Union[None, Unset, QualerApiModelsAssetToAssetResponseModelAssetStatus]
         if isinstance(_asset_status, Unset):
             asset_status = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_service_forecast_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_service_forecast_model.py
@@ -15,70 +15,70 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetServiceForecastModel")
 class QualerApiModelsAssetToAssetServiceForecastModel:
     """
     Attributes:
-        company_id (Union[Unset, int]):
-        asset_id (Union[Unset, int]):
-        site_id (Union[Unset, int]):
-        asset_service_record_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        manufacturer_name (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        maintenance_plan_id (Union[Unset, int]):
-        maintenance_plan_name (Union[Unset, str]):
-        maintenance_task_id (Union[Unset, int]):
-        maintenance_task_name (Union[Unset, str]):
+        company_id (Union[None, Unset, int]):
+        asset_id (Union[None, Unset, int]):
+        site_id (Union[None, Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        manufacturer_name (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        maintenance_plan_id (Union[None, Unset, int]):
+        maintenance_plan_name (Union[None, Unset, str]):
+        maintenance_task_id (Union[None, Unset, int]):
+        maintenance_task_name (Union[None, Unset, str]):
         next_service_date (Union[None, Unset, datetime.datetime]):
         advance_recall_date (Union[None, Unset, datetime.datetime]):
         grace_period_date (Union[None, Unset, datetime.datetime]):
         certificate_next_service_date (Union[None, Unset, datetime.datetime]):
-        service_interval (Union[Unset, str]):
-        interval_cycle (Union[Unset, str]):
-        interval_length (Union[Unset, int]):
-        on_day (Union[Unset, int]):
-        on_month (Union[Unset, int]):
-        on_week_days (Union[Unset, int]):
-        weekday_of_month (Union[Unset, int]):
-        advance_recall_period (Union[Unset, str]):
-        days_before_due (Union[Unset, int]):
-        past_due_grace_period (Union[Unset, str]):
-        days_after_due (Union[Unset, int]):
+        service_interval (Union[None, Unset, str]):
+        interval_cycle (Union[None, Unset, str]):
+        interval_length (Union[None, Unset, int]):
+        on_day (Union[None, Unset, int]):
+        on_month (Union[None, Unset, int]):
+        on_week_days (Union[None, Unset, int]):
+        weekday_of_month (Union[None, Unset, int]):
+        advance_recall_period (Union[None, Unset, str]):
+        days_before_due (Union[None, Unset, int]):
+        past_due_grace_period (Union[None, Unset, str]):
+        days_after_due (Union[None, Unset, int]):
     """
 
-    company_id: Union[Unset, int] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    asset_service_record_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    manufacturer_name: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    maintenance_plan_id: Union[Unset, int] = UNSET
-    maintenance_plan_name: Union[Unset, str] = UNSET
-    maintenance_task_id: Union[Unset, int] = UNSET
-    maintenance_task_name: Union[Unset, str] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    manufacturer_name: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    maintenance_plan_id: Union[None, Unset, int] = UNSET
+    maintenance_plan_name: Union[None, Unset, str] = UNSET
+    maintenance_task_id: Union[None, Unset, int] = UNSET
+    maintenance_task_name: Union[None, Unset, str] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
     advance_recall_date: Union[None, Unset, datetime.datetime] = UNSET
     grace_period_date: Union[None, Unset, datetime.datetime] = UNSET
     certificate_next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    service_interval: Union[Unset, str] = UNSET
-    interval_cycle: Union[Unset, str] = UNSET
-    interval_length: Union[Unset, int] = UNSET
-    on_day: Union[Unset, int] = UNSET
-    on_month: Union[Unset, int] = UNSET
-    on_week_days: Union[Unset, int] = UNSET
-    weekday_of_month: Union[Unset, int] = UNSET
-    advance_recall_period: Union[Unset, str] = UNSET
-    days_before_due: Union[Unset, int] = UNSET
-    past_due_grace_period: Union[Unset, str] = UNSET
-    days_after_due: Union[Unset, int] = UNSET
+    service_interval: Union[None, Unset, str] = UNSET
+    interval_cycle: Union[None, Unset, str] = UNSET
+    interval_length: Union[None, Unset, int] = UNSET
+    on_day: Union[None, Unset, int] = UNSET
+    on_month: Union[None, Unset, int] = UNSET
+    on_week_days: Union[None, Unset, int] = UNSET
+    weekday_of_month: Union[None, Unset, int] = UNSET
+    advance_recall_period: Union[None, Unset, str] = UNSET
+    days_before_due: Union[None, Unset, int] = UNSET
+    past_due_grace_period: Union[None, Unset, str] = UNSET
+    days_after_due: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_assets_count_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_assets_count_response_model.py
@@ -13,48 +13,48 @@ T = TypeVar("T", bound="QualerApiModelsAssetToAssetsCountResponseModel")
 class QualerApiModelsAssetToAssetsCountResponseModel:
     """
     Attributes:
-        assets_all (Union[Unset, int]):
-        assets_collected (Union[Unset, int]):
-        assets_recently_serviced (Union[Unset, int]):
-        assets_due (Union[Unset, int]):
-        assets_past_due (Union[Unset, int]):
-        assets_service_pending (Union[Unset, int]):
-        assets_recently_purchased (Union[Unset, int]):
-        assets_warranty_expires (Union[Unset, int]):
-        assets_due_for_replacement (Union[Unset, int]):
-        assets_out_of_service (Union[Unset, int]):
-        assets_not_serviced (Union[Unset, int]):
-        assets_without_schedule (Union[Unset, int]):
-        assets_without_vendor (Union[Unset, int]):
-        assets_without_product (Union[Unset, int]):
-        assets_added (Union[Unset, int]):
-        assets_updated (Union[Unset, int]):
-        assets_deleted (Union[Unset, int]):
-        assets_no_agreement (Union[Unset, int]):
-        assets_expired_agreement (Union[Unset, int]):
-        assets_expiring_soon_agreement (Union[Unset, int]):
+        assets_all (Union[None, Unset, int]):
+        assets_collected (Union[None, Unset, int]):
+        assets_recently_serviced (Union[None, Unset, int]):
+        assets_due (Union[None, Unset, int]):
+        assets_past_due (Union[None, Unset, int]):
+        assets_service_pending (Union[None, Unset, int]):
+        assets_recently_purchased (Union[None, Unset, int]):
+        assets_warranty_expires (Union[None, Unset, int]):
+        assets_due_for_replacement (Union[None, Unset, int]):
+        assets_out_of_service (Union[None, Unset, int]):
+        assets_not_serviced (Union[None, Unset, int]):
+        assets_without_schedule (Union[None, Unset, int]):
+        assets_without_vendor (Union[None, Unset, int]):
+        assets_without_product (Union[None, Unset, int]):
+        assets_added (Union[None, Unset, int]):
+        assets_updated (Union[None, Unset, int]):
+        assets_deleted (Union[None, Unset, int]):
+        assets_no_agreement (Union[None, Unset, int]):
+        assets_expired_agreement (Union[None, Unset, int]):
+        assets_expiring_soon_agreement (Union[None, Unset, int]):
     """
 
-    assets_all: Union[Unset, int] = UNSET
-    assets_collected: Union[Unset, int] = UNSET
-    assets_recently_serviced: Union[Unset, int] = UNSET
-    assets_due: Union[Unset, int] = UNSET
-    assets_past_due: Union[Unset, int] = UNSET
-    assets_service_pending: Union[Unset, int] = UNSET
-    assets_recently_purchased: Union[Unset, int] = UNSET
-    assets_warranty_expires: Union[Unset, int] = UNSET
-    assets_due_for_replacement: Union[Unset, int] = UNSET
-    assets_out_of_service: Union[Unset, int] = UNSET
-    assets_not_serviced: Union[Unset, int] = UNSET
-    assets_without_schedule: Union[Unset, int] = UNSET
-    assets_without_vendor: Union[Unset, int] = UNSET
-    assets_without_product: Union[Unset, int] = UNSET
-    assets_added: Union[Unset, int] = UNSET
-    assets_updated: Union[Unset, int] = UNSET
-    assets_deleted: Union[Unset, int] = UNSET
-    assets_no_agreement: Union[Unset, int] = UNSET
-    assets_expired_agreement: Union[Unset, int] = UNSET
-    assets_expiring_soon_agreement: Union[Unset, int] = UNSET
+    assets_all: Union[None, Unset, int] = UNSET
+    assets_collected: Union[None, Unset, int] = UNSET
+    assets_recently_serviced: Union[None, Unset, int] = UNSET
+    assets_due: Union[None, Unset, int] = UNSET
+    assets_past_due: Union[None, Unset, int] = UNSET
+    assets_service_pending: Union[None, Unset, int] = UNSET
+    assets_recently_purchased: Union[None, Unset, int] = UNSET
+    assets_warranty_expires: Union[None, Unset, int] = UNSET
+    assets_due_for_replacement: Union[None, Unset, int] = UNSET
+    assets_out_of_service: Union[None, Unset, int] = UNSET
+    assets_not_serviced: Union[None, Unset, int] = UNSET
+    assets_without_schedule: Union[None, Unset, int] = UNSET
+    assets_without_vendor: Union[None, Unset, int] = UNSET
+    assets_without_product: Union[None, Unset, int] = UNSET
+    assets_added: Union[None, Unset, int] = UNSET
+    assets_updated: Union[None, Unset, int] = UNSET
+    assets_deleted: Union[None, Unset, int] = UNSET
+    assets_no_agreement: Union[None, Unset, int] = UNSET
+    assets_expired_agreement: Union[None, Unset, int] = UNSET
+    assets_expiring_soon_agreement: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_counters_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_counters_response_model.py
@@ -13,20 +13,20 @@ T = TypeVar("T", bound="QualerApiModelsAssetToClientAssetCountersResponseModel")
 class QualerApiModelsAssetToClientAssetCountersResponseModel:
     """
     Attributes:
-        client_assets_collected (Union[Unset, int]):
-        client_unset (Union[Unset, int]):
-        client_due_for_service (Union[Unset, int]):
-        client_past_due (Union[Unset, int]):
-        client_out_of_service (Union[Unset, int]):
-        client_without_schedule (Union[Unset, int]):
+        client_assets_collected (Union[None, Unset, int]):
+        client_unset (Union[None, Unset, int]):
+        client_due_for_service (Union[None, Unset, int]):
+        client_past_due (Union[None, Unset, int]):
+        client_out_of_service (Union[None, Unset, int]):
+        client_without_schedule (Union[None, Unset, int]):
     """
 
-    client_assets_collected: Union[Unset, int] = UNSET
-    client_unset: Union[Unset, int] = UNSET
-    client_due_for_service: Union[Unset, int] = UNSET
-    client_past_due: Union[Unset, int] = UNSET
-    client_out_of_service: Union[Unset, int] = UNSET
-    client_without_schedule: Union[Unset, int] = UNSET
+    client_assets_collected: Union[None, Unset, int] = UNSET
+    client_unset: Union[None, Unset, int] = UNSET
+    client_due_for_service: Union[None, Unset, int] = UNSET
+    client_past_due: Union[None, Unset, int] = UNSET
+    client_out_of_service: Union[None, Unset, int] = UNSET
+    client_without_schedule: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
@@ -29,204 +29,204 @@ T = TypeVar("T", bound="QualerApiModelsAssetToClientAssetManagerResponseModel")
 class QualerApiModelsAssetToClientAssetManagerResponseModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        record_type (Union[Unset, QualerApiModelsAssetToClientAssetManagerResponseModelRecordType]):
-        parent_asset_id (Union[Unset, int]):
-        children_count (Union[Unset, int]):
-        site_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        condition (Union[Unset, str]):
-        asset_class (Union[Unset, str]):
+        asset_id (Union[None, Unset, int]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        record_type (Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelRecordType]):
+        parent_asset_id (Union[None, Unset, int]):
+        children_count (Union[None, Unset, int]):
+        site_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        condition (Union[None, Unset, str]):
+        asset_class (Union[None, Unset, str]):
         activation_date (Union[None, Unset, datetime.datetime]):
         retirment_date (Union[None, Unset, datetime.datetime]):
-        client_vendor_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        asset_has_image (Union[Unset, bool]):
-        has_image (Union[Unset, bool]):
-        parent_has_image (Union[Unset, bool]):
-        pool_id (Union[Unset, int]):
-        pool (Union[Unset, str]):
-        product_id (Union[Unset, int]):
-        parent_product_id (Union[Unset, int]):
-        product_name (Union[Unset, str]):
-        parent_product_name (Union[Unset, str]):
-        category_id (Union[Unset, int]):
-        root_category_id (Union[Unset, int]):
-        category_name (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        manufacturer_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        display_name (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        asset_room (Union[Unset, str]):
-        location (Union[Unset, str]):
-        station (Union[Unset, str]):
-        tool_role (Union[Unset, QualerApiModelsAssetToClientAssetManagerResponseModelToolRole]):
-        tool_id (Union[Unset, int]):
-        department_id (Union[Unset, int]):
-        department_name (Union[Unset, str]):
-        custodian_name (Union[Unset, str]):
-        warranty (Union[Unset, str]):
+        client_vendor_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        asset_has_image (Union[None, Unset, bool]):
+        has_image (Union[None, Unset, bool]):
+        parent_has_image (Union[None, Unset, bool]):
+        pool_id (Union[None, Unset, int]):
+        pool (Union[None, Unset, str]):
+        product_id (Union[None, Unset, int]):
+        parent_product_id (Union[None, Unset, int]):
+        product_name (Union[None, Unset, str]):
+        parent_product_name (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        root_category_id (Union[None, Unset, int]):
+        category_name (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        manufacturer_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        display_name (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        asset_room (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        tool_role (Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelToolRole]):
+        tool_id (Union[None, Unset, int]):
+        department_id (Union[None, Unset, int]):
+        department_name (Union[None, Unset, str]):
+        custodian_name (Union[None, Unset, str]):
+        warranty (Union[None, Unset, str]):
         warranty_end (Union[None, Unset, datetime.datetime]):
-        is_warranty_expired (Union[Unset, bool]):
-        depreciation_method (Union[Unset, int]):
-        depreciation_basis (Union[Unset, float]):
-        salvage_value (Union[Unset, float]):
-        total_service_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        is_warranty_expired (Union[None, Unset, bool]):
+        depreciation_method (Union[None, Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        salvage_value (Union[None, Unset, float]):
+        total_service_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         due_for_replacement_date (Union[None, Unset, datetime.datetime]):
-        depreciation_proc (Union[Unset, float]):
+        depreciation_proc (Union[None, Unset, float]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        time_in_service (Union[Unset, int]):
-        retirement_reason (Union[Unset, str]):
-        residual_cost (Union[Unset, float]):
-        employee_id (Union[Unset, int]):
-        asset_collection_id (Union[Unset, int]):
-        asset_service_record_id (Union[Unset, int]):
-        result_status (Union[Unset, ServiceResultStatus]):
-        as_found_result (Union[Unset, ServiceResultStatus]):
-        as_left_result (Union[Unset, ServiceResultStatus]):
+        purchase_cost (Union[None, Unset, float]):
+        time_in_service (Union[None, Unset, int]):
+        retirement_reason (Union[None, Unset, str]):
+        residual_cost (Union[None, Unset, float]):
+        employee_id (Union[None, Unset, int]):
+        asset_collection_id (Union[None, Unset, int]):
+        asset_service_record_id (Union[None, Unset, int]):
+        result_status (Union[None, Unset, ServiceResultStatus]):
+        as_found_result (Union[None, Unset, ServiceResultStatus]):
+        as_left_result (Union[None, Unset, ServiceResultStatus]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         last_service (Union[None, Unset, str]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        next_service (Union[Unset, str]):
-        service_schedule_segment_id (Union[Unset, int]):
-        service_schedule_id (Union[Unset, int]):
-        service_schedule (Union[Unset, str]):
-        in_service (Union[Unset, bool]):
-        in_last_service (Union[Unset, bool]):
-        service_order_id (Union[Unset, int]):
-        service_order_status (Union[Unset, QualerApiModelsAssetToClientAssetManagerResponseModelServiceOrderStatus]):
-        custom_order_number (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
-        vendor (Union[Unset, str]):
-        technician (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
+        next_service (Union[None, Unset, str]):
+        service_schedule_segment_id (Union[None, Unset, int]):
+        service_schedule_id (Union[None, Unset, int]):
+        service_schedule (Union[None, Unset, str]):
+        in_service (Union[None, Unset, bool]):
+        in_last_service (Union[None, Unset, bool]):
+        service_order_id (Union[None, Unset, int]):
+        service_order_status (Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelServiceOrderStatus]):
+        custom_order_number (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        vendor (Union[None, Unset, str]):
+        technician (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
         due_trigger_date (Union[None, Unset, datetime.datetime]):
         past_due_trigger_date (Union[None, Unset, datetime.datetime]):
-        due_status (Union[Unset, QualerApiModelsAssetToClientAssetManagerResponseModelDueStatus]):
-        work_status (Union[Unset, WorkStatus]):
-        service_tag (Union[Unset, str]):
-        service_site_name (Union[Unset, str]):
-        service_site_id (Union[Unset, int]):
-        standard_title (Union[Unset, str]):
-        schedules (Union[Unset, str]):
+        due_status (Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelDueStatus]):
+        work_status (Union[None, Unset, WorkStatus]):
+        service_tag (Union[None, Unset, str]):
+        service_site_name (Union[None, Unset, str]):
+        service_site_id (Union[None, Unset, int]):
+        standard_title (Union[None, Unset, str]):
+        schedules (Union[None, Unset, str]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
     record_type: Union[
         None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelRecordType
     ] = UNSET
-    parent_asset_id: Union[Unset, int] = UNSET
-    children_count: Union[Unset, int] = UNSET
-    site_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    condition: Union[Unset, str] = UNSET
-    asset_class: Union[Unset, str] = UNSET
+    parent_asset_id: Union[None, Unset, int] = UNSET
+    children_count: Union[None, Unset, int] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    asset_class: Union[None, Unset, str] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
     retirment_date: Union[None, Unset, datetime.datetime] = UNSET
-    client_vendor_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    asset_has_image: Union[Unset, bool] = UNSET
-    has_image: Union[Unset, bool] = UNSET
-    parent_has_image: Union[Unset, bool] = UNSET
-    pool_id: Union[Unset, int] = UNSET
-    pool: Union[Unset, str] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    parent_product_id: Union[Unset, int] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    parent_product_name: Union[Unset, str] = UNSET
-    category_id: Union[Unset, int] = UNSET
-    root_category_id: Union[Unset, int] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    manufacturer_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    display_name: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    asset_room: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
+    client_vendor_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    asset_has_image: Union[None, Unset, bool] = UNSET
+    has_image: Union[None, Unset, bool] = UNSET
+    parent_has_image: Union[None, Unset, bool] = UNSET
+    pool_id: Union[None, Unset, int] = UNSET
+    pool: Union[None, Unset, str] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    parent_product_id: Union[None, Unset, int] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    parent_product_name: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    root_category_id: Union[None, Unset, int] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    manufacturer_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    display_name: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    asset_room: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
     tool_role: Union[
         None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelToolRole
     ] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    department_id: Union[Unset, int] = UNSET
-    department_name: Union[Unset, str] = UNSET
-    custodian_name: Union[Unset, str] = UNSET
-    warranty: Union[Unset, str] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    department_id: Union[None, Unset, int] = UNSET
+    department_name: Union[None, Unset, str] = UNSET
+    custodian_name: Union[None, Unset, str] = UNSET
+    warranty: Union[None, Unset, str] = UNSET
     warranty_end: Union[None, Unset, datetime.datetime] = UNSET
-    is_warranty_expired: Union[Unset, bool] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
-    total_service_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    is_warranty_expired: Union[None, Unset, bool] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
+    total_service_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     due_for_replacement_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_proc: Union[Unset, float] = UNSET
+    depreciation_proc: Union[None, Unset, float] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    time_in_service: Union[Unset, int] = UNSET
-    retirement_reason: Union[Unset, str] = UNSET
-    residual_cost: Union[Unset, float] = UNSET
-    employee_id: Union[Unset, int] = UNSET
-    asset_collection_id: Union[Unset, int] = UNSET
-    asset_service_record_id: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    time_in_service: Union[None, Unset, int] = UNSET
+    retirement_reason: Union[None, Unset, str] = UNSET
+    residual_cost: Union[None, Unset, float] = UNSET
+    employee_id: Union[None, Unset, int] = UNSET
+    asset_collection_id: Union[None, Unset, int] = UNSET
+    asset_service_record_id: Union[None, Unset, int] = UNSET
     result_status: Union[None, Unset, ServiceResultStatus] = UNSET
     as_found_result: Union[None, Unset, ServiceResultStatus] = UNSET
     as_left_result: Union[None, Unset, ServiceResultStatus] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     last_service: Union[None, Unset, str] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    next_service: Union[Unset, str] = UNSET
-    service_schedule_segment_id: Union[Unset, int] = UNSET
-    service_schedule_id: Union[Unset, int] = UNSET
-    service_schedule: Union[Unset, str] = UNSET
-    in_service: Union[Unset, bool] = UNSET
-    in_last_service: Union[Unset, bool] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
+    next_service: Union[None, Unset, str] = UNSET
+    service_schedule_segment_id: Union[None, Unset, int] = UNSET
+    service_schedule_id: Union[None, Unset, int] = UNSET
+    service_schedule: Union[None, Unset, str] = UNSET
+    in_service: Union[None, Unset, bool] = UNSET
+    in_last_service: Union[None, Unset, bool] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
     service_order_status: Union[
         None,
         Unset,
         QualerApiModelsAssetToClientAssetManagerResponseModelServiceOrderStatus,
     ] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    vendor: Union[Unset, str] = UNSET
-    technician: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    vendor: Union[None, Unset, str] = UNSET
+    technician: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     due_trigger_date: Union[None, Unset, datetime.datetime] = UNSET
     past_due_trigger_date: Union[None, Unset, datetime.datetime] = UNSET
     due_status: Union[
         None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelDueStatus
     ] = UNSET
     work_status: Union[None, Unset, WorkStatus] = UNSET
-    service_tag: Union[Unset, str] = UNSET
-    service_site_name: Union[Unset, str] = UNSET
-    service_site_id: Union[Unset, int] = UNSET
-    standard_title: Union[Unset, str] = UNSET
-    schedules: Union[Unset, str] = UNSET
+    service_tag: Union[None, Unset, str] = UNSET
+    service_site_name: Union[None, Unset, str] = UNSET
+    service_site_id: Union[None, Unset, int] = UNSET
+    standard_title: Union[None, Unset, str] = UNSET
+    schedules: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -696,8 +696,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
         asset_maker = d.pop("AssetMaker", UNSET)
 
         _record_type = d.pop("RecordType", UNSET)
-        record_type: Union[
-            Unset, QualerApiModelsAssetToClientAssetManagerResponseModelRecordType
+        record_type: Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelRecordType
         ]
         if isinstance(_record_type, Unset):
             record_type = UNSET
@@ -819,8 +818,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
         station = d.pop("Station", UNSET)
 
         _tool_role = d.pop("ToolRole", UNSET)
-        tool_role: Union[
-            Unset, QualerApiModelsAssetToClientAssetManagerResponseModelToolRole
+        tool_role: Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelToolRole
         ]
         if isinstance(_tool_role, Unset):
             tool_role = UNSET
@@ -925,7 +923,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
         asset_service_record_id = d.pop("AssetServiceRecordId", UNSET)
 
         _result_status = d.pop("ResultStatus", UNSET)
-        result_status: Union[Unset, ServiceResultStatus]
+        result_status: Union[None, Unset, ServiceResultStatus]
         if isinstance(_result_status, Unset):
             result_status = UNSET
         elif _result_status is None:
@@ -934,7 +932,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
             result_status = ServiceResultStatus(_result_status)
 
         _as_found_result = d.pop("AsFoundResult", UNSET)
-        as_found_result: Union[Unset, ServiceResultStatus]
+        as_found_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_found_result, Unset):
             as_found_result = UNSET
         elif _as_found_result is None:
@@ -943,7 +941,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
             as_found_result = ServiceResultStatus(_as_found_result)
 
         _as_left_result = d.pop("AsLeftResult", UNSET)
-        as_left_result: Union[Unset, ServiceResultStatus]
+        as_left_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_left_result, Unset):
             as_left_result = UNSET
         elif _as_left_result is None:
@@ -1013,8 +1011,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
         service_order_id = d.pop("ServiceOrderId", UNSET)
 
         _service_order_status = d.pop("ServiceOrderStatus", UNSET)
-        service_order_status: Union[
-            Unset,
+        service_order_status: Union[None, Unset,
             QualerApiModelsAssetToClientAssetManagerResponseModelServiceOrderStatus,
         ]
         if isinstance(_service_order_status, Unset):
@@ -1079,8 +1076,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
         )
 
         _due_status = d.pop("DueStatus", UNSET)
-        due_status: Union[
-            Unset, QualerApiModelsAssetToClientAssetManagerResponseModelDueStatus
+        due_status: Union[None, Unset, QualerApiModelsAssetToClientAssetManagerResponseModelDueStatus
         ]
         if isinstance(_due_status, Unset):
             due_status = UNSET
@@ -1092,7 +1088,7 @@ class QualerApiModelsAssetToClientAssetManagerResponseModel:
             )
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_employee_filter_preference_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_employee_filter_preference_response_model.py
@@ -15,16 +15,16 @@ T = TypeVar("T", bound="QualerApiModelsAssetToEmployeeFilterPreferenceResponseMo
 class QualerApiModelsAssetToEmployeeFilterPreferenceResponseModel:
     """
     Attributes:
-        filter_type (Union[Unset, str]):
-        within_days (Union[Unset, int]):
-        use_date_range (Union[Unset, bool]):
+        filter_type (Union[None, Unset, str]):
+        within_days (Union[None, Unset, int]):
+        use_date_range (Union[None, Unset, bool]):
         start_date (Union[None, Unset, datetime.datetime]):
         end_date (Union[None, Unset, datetime.datetime]):
     """
 
-    filter_type: Union[Unset, str] = UNSET
-    within_days: Union[Unset, int] = UNSET
-    use_date_range: Union[Unset, bool] = UNSET
+    filter_type: Union[None, Unset, str] = UNSET
+    within_days: Union[None, Unset, int] = UNSET
+    use_date_range: Union[None, Unset, bool] = UNSET
     start_date: Union[None, Unset, datetime.datetime] = UNSET
     end_date: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_employee_preference_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_employee_preference_response_model.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsAssetToEmployeePreferenceResponseModel")
 class QualerApiModelsAssetToEmployeePreferenceResponseModel:
     """
     Attributes:
-        element_type (Union[Unset, str]):
-        element_page (Union[Unset, str]):
-        element_id (Union[Unset, str]):
-        preference (Union[Unset, list[str]]):
-        is_pinned (Union[Unset, bool]):
+        element_type (Union[None, Unset, str]):
+        element_page (Union[None, Unset, str]):
+        element_id (Union[None, Unset, str]):
+        preference (Union[None, Unset, list[str]]):
+        is_pinned (Union[None, Unset, bool]):
     """
 
-    element_type: Union[Unset, str] = UNSET
-    element_page: Union[Unset, str] = UNSET
-    element_id: Union[Unset, str] = UNSET
-    preference: Union[Unset, list[str]] = UNSET
-    is_pinned: Union[Unset, bool] = UNSET
+    element_type: Union[None, Unset, str] = UNSET
+    element_page: Union[None, Unset, str] = UNSET
+    element_id: Union[None, Unset, str] = UNSET
+    preference: Union[None, Unset, list[str]] = UNSET
+    is_pinned: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,7 +34,7 @@ class QualerApiModelsAssetToEmployeePreferenceResponseModel:
 
         element_id = self.element_id
 
-        preference: Union[Unset, list[str]] = UNSET
+        preference: Union[None, Unset, list[str]] = UNSET
         if self.preference and not isinstance(self.preference, Unset):
             preference = self.preference
 

--- a/src/qualer_sdk/models/qualer_api_models_attributes_to_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_attributes_to_attribute_response.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsAttributesToAttributeResponse")
 class QualerApiModelsAttributesToAttributeResponse:
     """
     Attributes:
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_client_attributes_from_client_attribute_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_client_attributes_from_client_attribute_model.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsClientAttributesFromClientAttributeModel"
 class QualerApiModelsClientAttributesFromClientAttributeModel:
     """
     Attributes:
-        client_site_id (Union[Unset, int]):
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
+        client_site_id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    client_site_id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    client_site_id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_asset_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_asset_model.py
@@ -18,60 +18,60 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromAssetModel")
 class QualerApiModelsClientsFromAssetModel:
     """
     Attributes:
-        site_id (Union[Unset, int]):
-        product_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        category_id (Union[Unset, int]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_status (Union[Unset, QualerApiModelsClientsFromAssetModelAssetStatus]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        location (Union[Unset, str]):
-        retirement_reason (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        condition (Union[Unset, str]):
-        criticality (Union[Unset, str]):
+        site_id (Union[None, Unset, int]):
+        product_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_status (Union[None, Unset, QualerApiModelsClientsFromAssetModelAssetStatus]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        retirement_reason (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        condition (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
         purchase_date (Union[None, Unset, datetime.datetime]):
-        purchase_cost (Union[Unset, float]):
-        life_span_months (Union[Unset, int]):
+        purchase_cost (Union[None, Unset, float]):
+        life_span_months (Union[None, Unset, int]):
         activation_date (Union[None, Unset, datetime.datetime]):
-        depreciation_basis (Union[Unset, float]):
-        depreciation_method (Union[Unset, int]):
+        depreciation_basis (Union[None, Unset, float]):
+        depreciation_method (Union[None, Unset, int]):
         retirement_date (Union[None, Unset, datetime.datetime]):
-        salvage_value (Union[Unset, float]):
+        salvage_value (Union[None, Unset, float]):
     """
 
-    site_id: Union[Unset, int] = UNSET
-    product_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    category_id: Union[Unset, int] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_status: Union[Unset, QualerApiModelsClientsFromAssetModelAssetStatus] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    retirement_reason: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    condition: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_status: Union[None, Unset, QualerApiModelsClientsFromAssetModelAssetStatus] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    retirement_reason: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
-    purchase_cost: Union[Unset, float] = UNSET
-    life_span_months: Union[Unset, int] = UNSET
+    purchase_cost: Union[None, Unset, float] = UNSET
+    life_span_months: Union[None, Unset, int] = UNSET
     activation_date: Union[None, Unset, datetime.datetime] = UNSET
-    depreciation_basis: Union[Unset, float] = UNSET
-    depreciation_method: Union[Unset, int] = UNSET
+    depreciation_basis: Union[None, Unset, float] = UNSET
+    depreciation_method: Union[None, Unset, int] = UNSET
     retirement_date: Union[None, Unset, datetime.datetime] = UNSET
-    salvage_value: Union[Unset, float] = UNSET
+    salvage_value: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -91,7 +91,7 @@ class QualerApiModelsClientsFromAssetModel:
 
         asset_user = self.asset_user
 
-        asset_status: Union[Unset, str] = UNSET
+        asset_status: Union[None, Unset, str] = UNSET
         if self.asset_status and not isinstance(self.asset_status, Unset):
             asset_status = self.asset_status.value
 
@@ -225,7 +225,7 @@ class QualerApiModelsClientsFromAssetModel:
         asset_user = d.pop("AssetUser", UNSET)
 
         _asset_status = d.pop("AssetStatus", UNSET)
-        asset_status: Union[Unset, QualerApiModelsClientsFromAssetModelAssetStatus]
+        asset_status: Union[None, Unset, QualerApiModelsClientsFromAssetModelAssetStatus]
         if isinstance(_asset_status, Unset):
             asset_status = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromClientAssetModel")
 class QualerApiModelsClientsFromClientAssetModel:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
+        asset_id (Union[None, Unset, int]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_query.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_query.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromClientAssetQuery")
 class QualerApiModelsClientsFromClientAssetQuery:
     """
     Attributes:
-        equipment_id (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
     """
 
-    equipment_id: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_company_search_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_company_search_model.py
@@ -15,18 +15,18 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromClientCompanySearchModel")
 class QualerApiModelsClientsFromClientCompanySearchModel:
     """
     Attributes:
-        legacy_id (Union[Unset, str]):
-        account_number_text (Union[Unset, str]):
-        company_name (Union[Unset, str]):
-        take (Union[Unset, int]):
-        modified_after (Union[Unset, datetime.datetime]):
+        legacy_id (Union[None, Unset, str]):
+        account_number_text (Union[None, Unset, str]):
+        company_name (Union[None, Unset, str]):
+        take (Union[None, Unset, int]):
+        modified_after (Union[None, Unset, datetime.datetime]):
     """
 
-    legacy_id: Union[Unset, str] = UNSET
-    account_number_text: Union[Unset, str] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    take: Union[Unset, int] = UNSET
-    modified_after: Union[Unset, datetime.datetime] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    take: Union[None, Unset, int] = UNSET
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -38,7 +38,7 @@ class QualerApiModelsClientsFromClientCompanySearchModel:
 
         take = self.take
 
-        modified_after: Union[Unset, str] = UNSET
+        modified_after: Union[None, Unset, str] = UNSET
         if self.modified_after and not isinstance(self.modified_after, Unset):
             modified_after = self.modified_after.isoformat()
 
@@ -70,7 +70,7 @@ class QualerApiModelsClientsFromClientCompanySearchModel:
         take = d.pop("Take", UNSET)
 
         _modified_after = d.pop("ModifiedAfter", UNSET)
-        modified_after: Union[Unset, datetime.datetime]
+        modified_after: Union[None, Unset, datetime.datetime]
         if isinstance(_modified_after, Unset):
             modified_after = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_employee_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromClientEmployeeModel")
 class QualerApiModelsClientsFromClientEmployeeModel:
     """
     Attributes:
-        employee_id (Union[Unset, int]):
+        employee_id (Union[None, Unset, int]):
     """
 
-    employee_id: Union[Unset, int] = UNSET
+    employee_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_send_employee_email_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_send_employee_email_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromSendEmployeeEmailModel")
 class QualerApiModelsClientsFromSendEmployeeEmailModel:
     """
     Attributes:
-        subject (Union[Unset, str]):
-        body (Union[Unset, str]):
+        subject (Union[None, Unset, str]):
+        body (Union[None, Unset, str]):
     """
 
-    subject: Union[Unset, str] = UNSET
-    body: Union[Unset, str] = UNSET
+    subject: Union[None, Unset, str] = UNSET
+    body: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_create_model.py
@@ -22,40 +22,39 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromSponsoredClientCreateModel")
 class QualerApiModelsClientsFromSponsoredClientCreateModel:
     """
     Attributes:
-        account_number_text (Union[Unset, str]):
-        client_status (Union[Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus]):
-        domain_name (Union[Unset, str]):
-        custom_client_name (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
-        currency_id (Union[Unset, int]):
-        account_representative_employee_id (Union[Unset, int]):
-        account_representative_site_id (Union[Unset, int]):
-        account_manager_employee_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        account_number_text (Union[None, Unset, str]):
+        client_status (Union[None, Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus]):
+        domain_name (Union[None, Unset, str]):
+        custom_client_name (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
+        currency_id (Union[None, Unset, int]):
+        account_representative_employee_id (Union[None, Unset, int]):
+        account_representative_site_id (Union[None, Unset, int]):
+        account_manager_employee_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    account_number_text: Union[Unset, str] = UNSET
-    client_status: Union[
-        Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus
+    account_number_text: Union[None, Unset, str] = UNSET
+    client_status: Union[None, Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus
     ] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_client_name: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    account_representative_employee_id: Union[Unset, int] = UNSET
-    account_representative_site_id: Union[Unset, int] = UNSET
-    account_manager_employee_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_client_name: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    account_representative_employee_id: Union[None, Unset, int] = UNSET
+    account_representative_site_id: Union[None, Unset, int] = UNSET
+    account_manager_employee_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         account_number_text = self.account_number_text
 
-        client_status: Union[Unset, str] = UNSET
+        client_status: Union[None, Unset, str] = UNSET
         if self.client_status and not isinstance(self.client_status, Unset):
             client_status = self.client_status.value
 
@@ -75,11 +74,11 @@ class QualerApiModelsClientsFromSponsoredClientCreateModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -125,8 +124,7 @@ class QualerApiModelsClientsFromSponsoredClientCreateModel:
         account_number_text = d.pop("AccountNumberText", UNSET)
 
         _client_status = d.pop("ClientStatus", UNSET)
-        client_status: Union[
-            Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus
+        client_status: Union[None, Unset, QualerApiModelsClientsFromSponsoredClientCreateModelClientStatus
         ]
         if isinstance(_client_status, Unset):
             client_status = UNSET
@@ -156,7 +154,7 @@ class QualerApiModelsClientsFromSponsoredClientCreateModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -165,7 +163,7 @@ class QualerApiModelsClientsFromSponsoredClientCreateModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_edit_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_edit_model.py
@@ -22,36 +22,35 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromSponsoredClientEditModel")
 class QualerApiModelsClientsFromSponsoredClientEditModel:
     """
     Attributes:
-        company_id (Union[Unset, int]):
-        account_number_text (Union[Unset, str]):
-        client_status (Union[Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus]):
-        domain_name (Union[Unset, str]):
-        custom_client_name (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
-        currency_id (Union[Unset, int]):
-        account_representative_employee_id (Union[Unset, int]):
-        account_representative_site_id (Union[Unset, int]):
-        account_manager_employee_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        company_id (Union[None, Unset, int]):
+        account_number_text (Union[None, Unset, str]):
+        client_status (Union[None, Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus]):
+        domain_name (Union[None, Unset, str]):
+        custom_client_name (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
+        currency_id (Union[None, Unset, int]):
+        account_representative_employee_id (Union[None, Unset, int]):
+        account_representative_site_id (Union[None, Unset, int]):
+        account_manager_employee_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    company_id: Union[Unset, int] = UNSET
-    account_number_text: Union[Unset, str] = UNSET
-    client_status: Union[
-        Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus
+    company_id: Union[None, Unset, int] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    client_status: Union[None, Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus
     ] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_client_name: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    account_representative_employee_id: Union[Unset, int] = UNSET
-    account_representative_site_id: Union[Unset, int] = UNSET
-    account_manager_employee_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_client_name: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    account_representative_employee_id: Union[None, Unset, int] = UNSET
+    account_representative_site_id: Union[None, Unset, int] = UNSET
+    account_manager_employee_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -59,7 +58,7 @@ class QualerApiModelsClientsFromSponsoredClientEditModel:
 
         account_number_text = self.account_number_text
 
-        client_status: Union[Unset, str] = UNSET
+        client_status: Union[None, Unset, str] = UNSET
         if self.client_status and not isinstance(self.client_status, Unset):
             client_status = self.client_status.value
 
@@ -79,11 +78,11 @@ class QualerApiModelsClientsFromSponsoredClientEditModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -133,8 +132,7 @@ class QualerApiModelsClientsFromSponsoredClientEditModel:
         account_number_text = d.pop("AccountNumberText", UNSET)
 
         _client_status = d.pop("ClientStatus", UNSET)
-        client_status: Union[
-            Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus
+        client_status: Union[None, Unset, QualerApiModelsClientsFromSponsoredClientEditModelClientStatus
         ]
         if isinstance(_client_status, Unset):
             client_status = UNSET
@@ -164,7 +162,7 @@ class QualerApiModelsClientsFromSponsoredClientEditModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -173,7 +171,7 @@ class QualerApiModelsClientsFromSponsoredClientEditModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_employee_model.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsClientsFromSponsoredEmployeeModel")
 class QualerApiModelsClientsFromSponsoredEmployeeModel:
     """
     Attributes:
-        client_company_id (Union[Unset, int]):
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        login_email (Union[Unset, str]):
-        password (Union[Unset, str]):
-        subscription_email (Union[Unset, str]):
-        mobile_phone (Union[Unset, str]):
-        office_phone (Union[Unset, str]):
+        client_company_id (Union[None, Unset, int]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        login_email (Union[None, Unset, str]):
+        password (Union[None, Unset, str]):
+        subscription_email (Union[None, Unset, str]):
+        mobile_phone (Union[None, Unset, str]):
+        office_phone (Union[None, Unset, str]):
     """
 
-    client_company_id: Union[Unset, int] = UNSET
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    login_email: Union[Unset, str] = UNSET
-    password: Union[Unset, str] = UNSET
-    subscription_email: Union[Unset, str] = UNSET
-    mobile_phone: Union[Unset, str] = UNSET
-    office_phone: Union[Unset, str] = UNSET
+    client_company_id: Union[None, Unset, int] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    login_email: Union[None, Unset, str] = UNSET
+    password: Union[None, Unset, str] = UNSET
+    subscription_email: Union[None, Unset, str] = UNSET
+    mobile_phone: Union[None, Unset, str] = UNSET
+    office_phone: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model.py
@@ -27,39 +27,39 @@ T = TypeVar("T", bound="QualerApiModelsClientsToClientCompanyResponseModel")
 class QualerApiModelsClientsToClientCompanyResponseModel:
     """
     Attributes:
-        company_id (Union[Unset, int]):
-        account_number_text (Union[Unset, str]):
-        account_number (Union[Unset, int]):
-        currency_id (Union[Unset, int]):
-        client_status (Union[Unset, str]):
-        company_name (Union[Unset, str]):
-        company_description (Union[Unset, str]):
-        domain_name (Union[Unset, str]):
-        custom_client_name (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
-        updated_on_utc (Union[Unset, datetime.datetime]):
-        account_representative_employee_id (Union[Unset, int]):
-        account_representative_site_id (Union[Unset, int]):
-        account_manager_employee_id (Union[Unset, int]):
+        company_id (Union[None, Unset, int]):
+        account_number_text (Union[None, Unset, str]):
+        account_number (Union[None, Unset, int]):
+        currency_id (Union[None, Unset, int]):
+        client_status (Union[None, Unset, str]):
+        company_name (Union[None, Unset, str]):
+        company_description (Union[None, Unset, str]):
+        domain_name (Union[None, Unset, str]):
+        custom_client_name (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
+        updated_on_utc (Union[None, Unset, datetime.datetime]):
+        account_representative_employee_id (Union[None, Unset, int]):
+        account_representative_site_id (Union[None, Unset, int]):
+        account_manager_employee_id (Union[None, Unset, int]):
         billing_address (Union['QualerApiModelsClientsToClientCompanyResponseModelBillingAddressType0', None, Unset]):
         shipping_address (Union['QualerApiModelsClientsToClientCompanyResponseModelShippingAddressType0', None, Unset]):
-        attributes (Union[Unset, list['QualerApiModelsAttributesToAttributeResponse']]):
+        attributes (Union[None, Unset, list['QualerApiModelsAttributesToAttributeResponse']]):
     """
 
-    company_id: Union[Unset, int] = UNSET
-    account_number_text: Union[Unset, str] = UNSET
-    account_number: Union[Unset, int] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    client_status: Union[Unset, str] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    company_description: Union[Unset, str] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_client_name: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
-    updated_on_utc: Union[Unset, datetime.datetime] = UNSET
-    account_representative_employee_id: Union[Unset, int] = UNSET
-    account_representative_site_id: Union[Unset, int] = UNSET
-    account_manager_employee_id: Union[Unset, int] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    account_number: Union[None, Unset, int] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    client_status: Union[None, Unset, str] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    company_description: Union[None, Unset, str] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_client_name: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    updated_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    account_representative_employee_id: Union[None, Unset, int] = UNSET
+    account_representative_site_id: Union[None, Unset, int] = UNSET
+    account_manager_employee_id: Union[None, Unset, int] = UNSET
     billing_address: Union[
         "QualerApiModelsClientsToClientCompanyResponseModelBillingAddressType0",
         None,
@@ -70,7 +70,7 @@ class QualerApiModelsClientsToClientCompanyResponseModel:
         None,
         Unset,
     ] = UNSET
-    attributes: Union[Unset, list["QualerApiModelsAttributesToAttributeResponse"]] = (
+    attributes: Union[None, Unset, list["QualerApiModelsAttributesToAttributeResponse"]] = (
         UNSET
     )
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -103,7 +103,7 @@ class QualerApiModelsClientsToClientCompanyResponseModel:
 
         legacy_id = self.legacy_id
 
-        updated_on_utc: Union[Unset, str] = UNSET
+        updated_on_utc: Union[None, Unset, str] = UNSET
         if self.updated_on_utc and not isinstance(self.updated_on_utc, Unset):
             updated_on_utc = self.updated_on_utc.isoformat()
 
@@ -135,7 +135,7 @@ class QualerApiModelsClientsToClientCompanyResponseModel:
         else:
             shipping_address = self.shipping_address
 
-        attributes: Union[Unset, list[dict[str, Any]]] = UNSET
+        attributes: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.attributes and not isinstance(self.attributes, Unset):
             attributes = []
             for attributes_item_data in self.attributes:
@@ -218,7 +218,7 @@ class QualerApiModelsClientsToClientCompanyResponseModel:
         legacy_id = d.pop("LegacyId", UNSET)
 
         _updated_on_utc = d.pop("UpdatedOnUtc", UNSET)
-        updated_on_utc: Union[Unset, datetime.datetime]
+        updated_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on_utc, Unset):
             updated_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_asset_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_asset_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsClientsToCreatedClientAssetResponse")
 class QualerApiModelsClientsToCreatedClientAssetResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_company_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_company_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsClientsToCreatedClientCompanyResponse")
 class QualerApiModelsClientsToCreatedClientCompanyResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_employee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_employee_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsClientsToCreatedClientEmployeeResponse")
 class QualerApiModelsClientsToCreatedClientEmployeeResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_employee_employee_department_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_employee_employee_department_response.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsClientsToEmployeeEmployeeDepartmentRespon
 class QualerApiModelsClientsToEmployeeEmployeeDepartmentResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
-        name (Union[Unset, str]):
-        position (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
+        position (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
-    position: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    position: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_employee_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_employee_response_model.py
@@ -21,44 +21,43 @@ T = TypeVar("T", bound="QualerApiModelsClientsToEmployeeResponseModel")
 class QualerApiModelsClientsToEmployeeResponseModel:
     """
     Attributes:
-        employee_id (Union[Unset, int]):
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        company_id (Union[Unset, int]):
-        login_email (Union[Unset, str]):
-        departments (Union[Unset, list['QualerApiModelsClientsToEmployeeEmployeeDepartmentResponse']]):
-        subscription_email (Union[Unset, str]):
-        subscription_phone (Union[Unset, str]):
-        office_phone (Union[Unset, str]):
-        is_locked (Union[Unset, bool]):
-        image_url (Union[Unset, str]):
-        alias (Union[Unset, str]):
-        title (Union[Unset, str]):
-        is_deleted (Union[Unset, bool]):
+        employee_id (Union[None, Unset, int]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        company_id (Union[None, Unset, int]):
+        login_email (Union[None, Unset, str]):
+        departments (Union[None, Unset, list['QualerApiModelsClientsToEmployeeEmployeeDepartmentResponse']]):
+        subscription_email (Union[None, Unset, str]):
+        subscription_phone (Union[None, Unset, str]):
+        office_phone (Union[None, Unset, str]):
+        is_locked (Union[None, Unset, bool]):
+        image_url (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
+        is_deleted (Union[None, Unset, bool]):
         last_seen_date_utc (Union[None, Unset, datetime.datetime]):
-        culture_name (Union[Unset, str]):
-        culture_ui_name (Union[Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        culture_ui_name (Union[None, Unset, str]):
     """
 
-    employee_id: Union[Unset, int] = UNSET
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    company_id: Union[Unset, int] = UNSET
-    login_email: Union[Unset, str] = UNSET
-    departments: Union[
-        Unset, list["QualerApiModelsClientsToEmployeeEmployeeDepartmentResponse"]
+    employee_id: Union[None, Unset, int] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    login_email: Union[None, Unset, str] = UNSET
+    departments: Union[None, Unset, list["QualerApiModelsClientsToEmployeeEmployeeDepartmentResponse"]
     ] = UNSET
-    subscription_email: Union[Unset, str] = UNSET
-    subscription_phone: Union[Unset, str] = UNSET
-    office_phone: Union[Unset, str] = UNSET
-    is_locked: Union[Unset, bool] = UNSET
-    image_url: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    is_deleted: Union[Unset, bool] = UNSET
+    subscription_email: Union[None, Unset, str] = UNSET
+    subscription_phone: Union[None, Unset, str] = UNSET
+    office_phone: Union[None, Unset, str] = UNSET
+    is_locked: Union[None, Unset, bool] = UNSET
+    image_url: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    is_deleted: Union[None, Unset, bool] = UNSET
     last_seen_date_utc: Union[None, Unset, datetime.datetime] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    culture_ui_name: Union[Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    culture_ui_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -72,7 +71,7 @@ class QualerApiModelsClientsToEmployeeResponseModel:
 
         login_email = self.login_email
 
-        departments: Union[Unset, list[dict[str, Any]]] = UNSET
+        departments: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.departments and not isinstance(self.departments, Unset):
             departments = []
             for departments_item_data in self.departments:

--- a/src/qualer_sdk/models/qualer_api_models_common_from_attribute_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_from_attribute_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsCommonFromAttributeModel")
 class QualerApiModelsCommonFromAttributeModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_common_to_culture_list_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_to_culture_list_response_model.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsCommonToCultureListResponseModel")
 class QualerApiModelsCommonToCultureListResponseModel:
     """
     Attributes:
-        culture_list (Union[Unset, list[str]]):
+        culture_list (Union[None, Unset, list[str]]):
     """
 
-    culture_list: Union[Unset, list[str]] = UNSET
+    culture_list: Union[None, Unset, list[str]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        culture_list: Union[Unset, list[str]] = UNSET
+        culture_list: Union[None, Unset, list[str]] = UNSET
         if self.culture_list and not isinstance(self.culture_list, Unset):
             culture_list = self.culture_list
 

--- a/src/qualer_sdk/models/qualer_api_models_common_to_setting_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_to_setting_response_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsCommonToSettingResponseModel")
 class QualerApiModelsCommonToSettingResponseModel:
     """
     Attributes:
-        value (Union[Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    value: Union[Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_company_to_departments_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_departments_response_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsCompanyToDepartmentsResponseModel")
 class QualerApiModelsCompanyToDepartmentsResponseModel:
     """
     Attributes:
-        id (Union[Unset, int]):
-        name (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_company_to_environment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_environment_response_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsCompanyToEnvironmentResponseModel")
 class QualerApiModelsCompanyToEnvironmentResponseModel:
     """
     Attributes:
-        id (Union[Unset, int]):
-        name (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_company_to_sites_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_sites_response_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsCompanyToSitesResponseModel")
 class QualerApiModelsCompanyToSitesResponseModel:
     """
     Attributes:
-        id (Union[Unset, int]):
-        name (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_create_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_create_employee_model.py
@@ -13,32 +13,32 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesFromCreateEmployeeModel")
 class QualerApiModelsEmployeesFromCreateEmployeeModel:
     """
     Attributes:
-        login_email (Union[Unset, str]):
-        password (Union[Unset, str]):
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        subscription_email (Union[Unset, str]):
-        mobile_phone (Union[Unset, str]):
-        office_phone (Union[Unset, str]):
-        alias (Union[Unset, str]):
-        title (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        culture_ui_name (Union[Unset, str]):
-        image_url (Union[Unset, str]):
+        login_email (Union[None, Unset, str]):
+        password (Union[None, Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        subscription_email (Union[None, Unset, str]):
+        mobile_phone (Union[None, Unset, str]):
+        office_phone (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        culture_ui_name (Union[None, Unset, str]):
+        image_url (Union[None, Unset, str]):
     """
 
-    login_email: Union[Unset, str] = UNSET
-    password: Union[Unset, str] = UNSET
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    subscription_email: Union[Unset, str] = UNSET
-    mobile_phone: Union[Unset, str] = UNSET
-    office_phone: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    culture_ui_name: Union[Unset, str] = UNSET
-    image_url: Union[Unset, str] = UNSET
+    login_email: Union[None, Unset, str] = UNSET
+    password: Union[None, Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    subscription_email: Union[None, Unset, str] = UNSET
+    mobile_phone: Union[None, Unset, str] = UNSET
+    office_phone: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    culture_ui_name: Union[None, Unset, str] = UNSET
+    image_url: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_employee_department_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_employee_department_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesFromEmployeeDepartmentModel")
 class QualerApiModelsEmployeesFromEmployeeDepartmentModel:
     """
     Attributes:
-        department_id (Union[Unset, int]):
-        position (Union[Unset, str]):
+        department_id (Union[None, Unset, int]):
+        position (Union[None, Unset, str]):
     """
 
-    department_id: Union[Unset, int] = UNSET
-    position: Union[Unset, str] = UNSET
+    department_id: Union[None, Unset, int] = UNSET
+    position: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_employee_location_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_employee_location_model.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesFromEmployeeLocationModel")
 class QualerApiModelsEmployeesFromEmployeeLocationModel:
     """
     Attributes:
-        latitude (Union[Unset, float]):
-        longitude (Union[Unset, float]):
-        accuracy (Union[Unset, float]):
-        altitude (Union[Unset, float]):
-        altitude_accuracy (Union[Unset, float]):
-        heading (Union[Unset, float]):
-        speed (Union[Unset, float]):
-        timestamp (Union[Unset, int]):
+        latitude (Union[None, Unset, float]):
+        longitude (Union[None, Unset, float]):
+        accuracy (Union[None, Unset, float]):
+        altitude (Union[None, Unset, float]):
+        altitude_accuracy (Union[None, Unset, float]):
+        heading (Union[None, Unset, float]):
+        speed (Union[None, Unset, float]):
+        timestamp (Union[None, Unset, int]):
     """
 
-    latitude: Union[Unset, float] = UNSET
-    longitude: Union[Unset, float] = UNSET
-    accuracy: Union[Unset, float] = UNSET
-    altitude: Union[Unset, float] = UNSET
-    altitude_accuracy: Union[Unset, float] = UNSET
-    heading: Union[Unset, float] = UNSET
-    speed: Union[Unset, float] = UNSET
-    timestamp: Union[Unset, int] = UNSET
+    latitude: Union[None, Unset, float] = UNSET
+    longitude: Union[None, Unset, float] = UNSET
+    accuracy: Union[None, Unset, float] = UNSET
+    altitude: Union[None, Unset, float] = UNSET
+    altitude_accuracy: Union[None, Unset, float] = UNSET
+    heading: Union[None, Unset, float] = UNSET
+    speed: Union[None, Unset, float] = UNSET
+    timestamp: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_search_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_search_employee_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesFromSearchEmployeeModel")
 class QualerApiModelsEmployeesFromSearchEmployeeModel:
     """
     Attributes:
-        search_string (Union[Unset, str]):
+        search_string (Union[None, Unset, str]):
     """
 
-    search_string: Union[Unset, str] = UNSET
+    search_string: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_update_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_update_employee_model.py
@@ -13,28 +13,28 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesFromUpdateEmployeeModel")
 class QualerApiModelsEmployeesFromUpdateEmployeeModel:
     """
     Attributes:
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        subscription_email (Union[Unset, str]):
-        mobile_phone (Union[Unset, str]):
-        office_phone (Union[Unset, str]):
-        alias (Union[Unset, str]):
-        title (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        culture_ui_name (Union[Unset, str]):
-        image_url (Union[Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        subscription_email (Union[None, Unset, str]):
+        mobile_phone (Union[None, Unset, str]):
+        office_phone (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        culture_ui_name (Union[None, Unset, str]):
+        image_url (Union[None, Unset, str]):
     """
 
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    subscription_email: Union[Unset, str] = UNSET
-    mobile_phone: Union[Unset, str] = UNSET
-    office_phone: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    culture_ui_name: Union[Unset, str] = UNSET
-    image_url: Union[Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    subscription_email: Union[None, Unset, str] = UNSET
+    mobile_phone: Union[None, Unset, str] = UNSET
+    office_phone: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    culture_ui_name: Union[None, Unset, str] = UNSET
+    image_url: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_employees_to_created_employee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_to_created_employee_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsEmployeesToCreatedEmployeeResponse")
 class QualerApiModelsEmployeesToCreatedEmployeeResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_environment_from_environment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_environment_from_environment_model.py
@@ -16,26 +16,26 @@ T = TypeVar("T", bound="QualerApiModelsEnvironmentFromEnvironmentModel")
 class QualerApiModelsEnvironmentFromEnvironmentModel:
     """
     Attributes:
-        station_id (Union[Unset, int]):
-        factor_id (Union[Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        unit_of_measure (Union[Unset, str]):
+        station_id (Union[None, Unset, int]):
+        factor_id (Union[None, Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        unit_of_measure (Union[None, Unset, str]):
     """
 
-    station_id: Union[Unset, int] = UNSET
-    factor_id: Union[Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId] = (
+    station_id: Union[None, Unset, int] = UNSET
+    factor_id: Union[None, Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId] = (
         UNSET
     )
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         station_id = self.station_id
 
-        factor_id: Union[Unset, str] = UNSET
+        factor_id: Union[None, Unset, str] = UNSET
         if self.factor_id and not isinstance(self.factor_id, Unset):
             factor_id = self.factor_id.value
 
@@ -67,7 +67,7 @@ class QualerApiModelsEnvironmentFromEnvironmentModel:
         station_id = d.pop("StationId", UNSET)
 
         _factor_id = d.pop("FactorId", UNSET)
-        factor_id: Union[Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId]
+        factor_id: Union[None, Unset, QualerApiModelsEnvironmentFromEnvironmentModelFactorId]
         if isinstance(_factor_id, Unset):
             factor_id = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_environment_to_environment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_environment_to_environment_model.py
@@ -16,32 +16,32 @@ T = TypeVar("T", bound="QualerApiModelsEnvironmentToEnvironmentModel")
 class QualerApiModelsEnvironmentToEnvironmentModel:
     """
     Attributes:
-        room_name (Union[Unset, str]):
-        factor_id (Union[Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId]):
-        station_id (Union[Unset, int]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        valid_range_min (Union[Unset, float]):
-        valid_range_max (Union[Unset, float]):
-        unit_of_measure (Union[Unset, str]):
+        room_name (Union[None, Unset, str]):
+        factor_id (Union[None, Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId]):
+        station_id (Union[None, Unset, int]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        valid_range_min (Union[None, Unset, float]):
+        valid_range_max (Union[None, Unset, float]):
+        unit_of_measure (Union[None, Unset, str]):
     """
 
-    room_name: Union[Unset, str] = UNSET
-    factor_id: Union[Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId] = (
+    room_name: Union[None, Unset, str] = UNSET
+    factor_id: Union[None, Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId] = (
         UNSET
     )
-    station_id: Union[Unset, int] = UNSET
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    valid_range_min: Union[Unset, float] = UNSET
-    valid_range_max: Union[Unset, float] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
+    station_id: Union[None, Unset, int] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    valid_range_min: Union[None, Unset, float] = UNSET
+    valid_range_max: Union[None, Unset, float] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         room_name = self.room_name
 
-        factor_id: Union[Unset, str] = UNSET
+        factor_id: Union[None, Unset, str] = UNSET
         if self.factor_id and not isinstance(self.factor_id, Unset):
             factor_id = self.factor_id.value
 
@@ -85,7 +85,7 @@ class QualerApiModelsEnvironmentToEnvironmentModel:
         room_name = d.pop("RoomName", UNSET)
 
         _factor_id = d.pop("FactorId", UNSET)
-        factor_id: Union[Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId]
+        factor_id: Union[None, Unset, QualerApiModelsEnvironmentToEnvironmentModelFactorId]
         if isinstance(_factor_id, Unset):
             factor_id = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_inventory_from_inventory_count_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_inventory_from_inventory_count_model.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsInventoryFromInventoryCountModel")
 class QualerApiModelsInventoryFromInventoryCountModel:
     """
     Attributes:
-        product_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        part_number (Union[Unset, str]):
-        is_stock_item (Union[Unset, bool]):
-        quantity_on_hand (Union[Unset, int]):
+        product_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        part_number (Union[None, Unset, str]):
+        is_stock_item (Union[None, Unset, bool]):
+        quantity_on_hand (Union[None, Unset, int]):
     """
 
-    product_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    is_stock_item: Union[Unset, bool] = UNSET
-    quantity_on_hand: Union[Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    is_stock_item: Union[None, Unset, bool] = UNSET
+    quantity_on_hand: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_inventory_to_inventory_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_inventory_to_inventory_response_model.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsInventoryToInventoryResponseModel")
 class QualerApiModelsInventoryToInventoryResponseModel:
     """
     Attributes:
-        product_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        part_number (Union[Unset, str]):
-        is_stock_item (Union[Unset, bool]):
-        quantity_on_hand (Union[Unset, int]):
+        product_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        part_number (Union[None, Unset, str]):
+        is_stock_item (Union[None, Unset, bool]):
+        quantity_on_hand (Union[None, Unset, int]):
     """
 
-    product_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    is_stock_item: Union[Unset, bool] = UNSET
-    quantity_on_hand: Union[Unset, int] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    is_stock_item: Union[None, Unset, bool] = UNSET
+    quantity_on_hand: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_plan_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_plan_response.py
@@ -19,19 +19,18 @@ T = TypeVar("T", bound="QualerApiModelsMaintenancePlansToMaintenancePlanResponse
 class QualerApiModelsMaintenancePlansToMaintenancePlanResponse:
     """
     Attributes:
-        maintenance_plan_id (Union[Unset, int]):
-        maintenance_plan_name (Union[Unset, str]):
-        is_template (Union[Unset, bool]):
-        company_name (Union[Unset, str]):
-        maintenance_tasks (Union[Unset, list['QualerApiModelsMaintenancePlansToMaintenanceTaskResponse']]):
+        maintenance_plan_id (Union[None, Unset, int]):
+        maintenance_plan_name (Union[None, Unset, str]):
+        is_template (Union[None, Unset, bool]):
+        company_name (Union[None, Unset, str]):
+        maintenance_tasks (Union[None, Unset, list['QualerApiModelsMaintenancePlansToMaintenanceTaskResponse']]):
     """
 
-    maintenance_plan_id: Union[Unset, int] = UNSET
-    maintenance_plan_name: Union[Unset, str] = UNSET
-    is_template: Union[Unset, bool] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    maintenance_tasks: Union[
-        Unset, list["QualerApiModelsMaintenancePlansToMaintenanceTaskResponse"]
+    maintenance_plan_id: Union[None, Unset, int] = UNSET
+    maintenance_plan_name: Union[None, Unset, str] = UNSET
+    is_template: Union[None, Unset, bool] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    maintenance_tasks: Union[None, Unset, list["QualerApiModelsMaintenancePlansToMaintenanceTaskResponse"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -44,7 +43,7 @@ class QualerApiModelsMaintenancePlansToMaintenancePlanResponse:
 
         company_name = self.company_name
 
-        maintenance_tasks: Union[Unset, list[dict[str, Any]]] = UNSET
+        maintenance_tasks: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.maintenance_tasks and not isinstance(self.maintenance_tasks, Unset):
             maintenance_tasks = []
             for maintenance_tasks_item_data in self.maintenance_tasks:

--- a/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_task_response.py
@@ -13,60 +13,60 @@ T = TypeVar("T", bound="QualerApiModelsMaintenancePlansToMaintenanceTaskResponse
 class QualerApiModelsMaintenancePlansToMaintenanceTaskResponse:
     """
     Attributes:
-        segment_name (Union[Unset, str]):
-        service_level_id (Union[Unset, int]):
-        display_order (Union[Unset, int]):
-        service_notes (Union[Unset, str]):
-        interval_cycle (Union[Unset, str]):
-        interval_length (Union[Unset, int]):
-        on_day (Union[Unset, str]):
-        on_month (Union[Unset, str]):
-        on_week_days (Union[Unset, str]):
-        weekday_of_month (Union[Unset, str]):
-        color_code (Union[Unset, int]):
-        service_interval (Union[Unset, str]):
-        on_segment_id (Union[Unset, int]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        as_found_standard_group_id (Union[Unset, int]):
-        as_left_standard_group_id (Union[Unset, int]):
-        task_notes (Union[Unset, str]):
-        advance_recall_period (Union[Unset, str]):
-        days_before_due (Union[Unset, int]):
-        past_due_grace_period (Union[Unset, str]):
-        days_after_due (Union[Unset, int]):
-        use_period_in_reports (Union[Unset, str]):
-        generate_order_automatically (Union[Unset, bool]):
-        approve_upon_generation (Union[Unset, bool]):
-        generate_separate (Union[Unset, bool]):
+        segment_name (Union[None, Unset, str]):
+        service_level_id (Union[None, Unset, int]):
+        display_order (Union[None, Unset, int]):
+        service_notes (Union[None, Unset, str]):
+        interval_cycle (Union[None, Unset, str]):
+        interval_length (Union[None, Unset, int]):
+        on_day (Union[None, Unset, str]):
+        on_month (Union[None, Unset, str]):
+        on_week_days (Union[None, Unset, str]):
+        weekday_of_month (Union[None, Unset, str]):
+        color_code (Union[None, Unset, int]):
+        service_interval (Union[None, Unset, str]):
+        on_segment_id (Union[None, Unset, int]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        as_found_standard_group_id (Union[None, Unset, int]):
+        as_left_standard_group_id (Union[None, Unset, int]):
+        task_notes (Union[None, Unset, str]):
+        advance_recall_period (Union[None, Unset, str]):
+        days_before_due (Union[None, Unset, int]):
+        past_due_grace_period (Union[None, Unset, str]):
+        days_after_due (Union[None, Unset, int]):
+        use_period_in_reports (Union[None, Unset, str]):
+        generate_order_automatically (Union[None, Unset, bool]):
+        approve_upon_generation (Union[None, Unset, bool]):
+        generate_separate (Union[None, Unset, bool]):
     """
 
-    segment_name: Union[Unset, str] = UNSET
-    service_level_id: Union[Unset, int] = UNSET
-    display_order: Union[Unset, int] = UNSET
-    service_notes: Union[Unset, str] = UNSET
-    interval_cycle: Union[Unset, str] = UNSET
-    interval_length: Union[Unset, int] = UNSET
-    on_day: Union[Unset, str] = UNSET
-    on_month: Union[Unset, str] = UNSET
-    on_week_days: Union[Unset, str] = UNSET
-    weekday_of_month: Union[Unset, str] = UNSET
-    color_code: Union[Unset, int] = UNSET
-    service_interval: Union[Unset, str] = UNSET
-    on_segment_id: Union[Unset, int] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    as_found_standard_group_id: Union[Unset, int] = UNSET
-    as_left_standard_group_id: Union[Unset, int] = UNSET
-    task_notes: Union[Unset, str] = UNSET
-    advance_recall_period: Union[Unset, str] = UNSET
-    days_before_due: Union[Unset, int] = UNSET
-    past_due_grace_period: Union[Unset, str] = UNSET
-    days_after_due: Union[Unset, int] = UNSET
-    use_period_in_reports: Union[Unset, str] = UNSET
-    generate_order_automatically: Union[Unset, bool] = UNSET
-    approve_upon_generation: Union[Unset, bool] = UNSET
-    generate_separate: Union[Unset, bool] = UNSET
+    segment_name: Union[None, Unset, str] = UNSET
+    service_level_id: Union[None, Unset, int] = UNSET
+    display_order: Union[None, Unset, int] = UNSET
+    service_notes: Union[None, Unset, str] = UNSET
+    interval_cycle: Union[None, Unset, str] = UNSET
+    interval_length: Union[None, Unset, int] = UNSET
+    on_day: Union[None, Unset, str] = UNSET
+    on_month: Union[None, Unset, str] = UNSET
+    on_week_days: Union[None, Unset, str] = UNSET
+    weekday_of_month: Union[None, Unset, str] = UNSET
+    color_code: Union[None, Unset, int] = UNSET
+    service_interval: Union[None, Unset, str] = UNSET
+    on_segment_id: Union[None, Unset, int] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    as_found_standard_group_id: Union[None, Unset, int] = UNSET
+    as_left_standard_group_id: Union[None, Unset, int] = UNSET
+    task_notes: Union[None, Unset, str] = UNSET
+    advance_recall_period: Union[None, Unset, str] = UNSET
+    days_before_due: Union[None, Unset, int] = UNSET
+    past_due_grace_period: Union[None, Unset, str] = UNSET
+    days_after_due: Union[None, Unset, int] = UNSET
+    use_period_in_reports: Union[None, Unset, str] = UNSET
+    generate_order_automatically: Union[None, Unset, bool] = UNSET
+    approve_upon_generation: Union[None, Unset, bool] = UNSET
+    generate_separate: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_condition_factor_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_condition_factor_model.py
@@ -17,17 +17,17 @@ T = TypeVar(
 class QualerApiModelsMeasurementsFromCreateMeasurementConditionFactorModel:
     """
     Attributes:
-        factor_id (Union[Unset, str]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        factor_uom (Union[Unset, str]):
+        factor_id (Union[None, Unset, str]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        factor_uom (Union[None, Unset, str]):
         last_modified_on_utc (Union[None, Unset, datetime.datetime]):
     """
 
-    factor_id: Union[Unset, str] = UNSET
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    factor_uom: Union[Unset, str] = UNSET
+    factor_id: Union[None, Unset, str] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    factor_uom: Union[None, Unset, str] = UNSET
     last_modified_on_utc: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_field_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_field_model.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementFieldMod
 class QualerApiModelsMeasurementsFromCreateMeasurementFieldModel:
     """
     Attributes:
-        field_id (Union[Unset, str]):
-        valid_values (Union[Unset, str]):
-        name (Union[Unset, str]):
-        type_ (Union[Unset, str]):
-        value (Union[Unset, str]):
+        field_id (Union[None, Unset, str]):
+        valid_values (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        type_ (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    field_id: Union[Unset, str] = UNSET
-    valid_values: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    type_: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    field_id: Union[None, Unset, str] = UNSET
+    valid_values: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    type_: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_form_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_form_model.py
@@ -22,17 +22,16 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementFormMode
 class QualerApiModelsMeasurementsFromCreateMeasurementFormModel:
     """
     Attributes:
-        batch_type (Union[Unset, str]):
-        batch_result (Union[Unset, str]):
-        specification (Union[Unset, QualerApiModelsMeasurementsFromSpecification]):
-        measurement_sets (Union[Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementSetModel']]):
+        batch_type (Union[None, Unset, str]):
+        batch_result (Union[None, Unset, str]):
+        specification (Union[None, Unset, QualerApiModelsMeasurementsFromSpecification]):
+        measurement_sets (Union[None, Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementSetModel']]):
     """
 
-    batch_type: Union[Unset, str] = UNSET
-    batch_result: Union[Unset, str] = UNSET
-    specification: Union[Unset, "QualerApiModelsMeasurementsFromSpecification"] = UNSET
-    measurement_sets: Union[
-        Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementSetModel"]
+    batch_type: Union[None, Unset, str] = UNSET
+    batch_result: Union[None, Unset, str] = UNSET
+    specification: Union[None, Unset, "QualerApiModelsMeasurementsFromSpecification"] = UNSET
+    measurement_sets: Union[None, Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementSetModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -41,11 +40,11 @@ class QualerApiModelsMeasurementsFromCreateMeasurementFormModel:
 
         batch_result = self.batch_result
 
-        specification: Union[Unset, dict[str, Any]] = UNSET
+        specification: Union[None, Unset, dict[str, Any]] = UNSET
         if self.specification and not isinstance(self.specification, Unset):
             specification = self.specification.to_dict()
 
-        measurement_sets: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_sets: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_sets and not isinstance(self.measurement_sets, Unset):
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
@@ -81,7 +80,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementFormModel:
         batch_result = d.pop("BatchResult", UNSET)
 
         _specification = d.pop("Specification", UNSET)
-        specification: Union[Unset, QualerApiModelsMeasurementsFromSpecification]
+        specification: Union[None, Unset, QualerApiModelsMeasurementsFromSpecification]
         if isinstance(_specification, Unset):
             specification = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_model.py
@@ -15,40 +15,40 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementModel")
 class QualerApiModelsMeasurementsFromCreateMeasurementModel:
     """
     Attributes:
-        values (Union[Unset, str]):
-        mean (Union[Unset, float]):
-        sd (Union[Unset, float]):
-        range_ (Union[Unset, float]):
-        delta (Union[Unset, float]):
-        cv (Union[Unset, float]):
-        cmc (Union[Unset, float]):
-        mu (Union[Unset, float]):
-        tur (Union[Unset, float]):
-        tar (Union[Unset, float]):
-        max_value (Union[Unset, float]):
-        min_value (Union[Unset, float]):
-        error (Union[Unset, float]):
-        result (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
-        updated_by (Union[Unset, str]):
+        values (Union[None, Unset, str]):
+        mean (Union[None, Unset, float]):
+        sd (Union[None, Unset, float]):
+        range_ (Union[None, Unset, float]):
+        delta (Union[None, Unset, float]):
+        cv (Union[None, Unset, float]):
+        cmc (Union[None, Unset, float]):
+        mu (Union[None, Unset, float]):
+        tur (Union[None, Unset, float]):
+        tar (Union[None, Unset, float]):
+        max_value (Union[None, Unset, float]):
+        min_value (Union[None, Unset, float]):
+        error (Union[None, Unset, float]):
+        result (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
+        updated_by (Union[None, Unset, str]):
     """
 
-    values: Union[Unset, str] = UNSET
-    mean: Union[Unset, float] = UNSET
-    sd: Union[Unset, float] = UNSET
-    range_: Union[Unset, float] = UNSET
-    delta: Union[Unset, float] = UNSET
-    cv: Union[Unset, float] = UNSET
-    cmc: Union[Unset, float] = UNSET
-    mu: Union[Unset, float] = UNSET
-    tur: Union[Unset, float] = UNSET
-    tar: Union[Unset, float] = UNSET
-    max_value: Union[Unset, float] = UNSET
-    min_value: Union[Unset, float] = UNSET
-    error: Union[Unset, float] = UNSET
-    result: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
-    updated_by: Union[Unset, str] = UNSET
+    values: Union[None, Unset, str] = UNSET
+    mean: Union[None, Unset, float] = UNSET
+    sd: Union[None, Unset, float] = UNSET
+    range_: Union[None, Unset, float] = UNSET
+    delta: Union[None, Unset, float] = UNSET
+    cv: Union[None, Unset, float] = UNSET
+    cmc: Union[None, Unset, float] = UNSET
+    mu: Union[None, Unset, float] = UNSET
+    tur: Union[None, Unset, float] = UNSET
+    tar: Union[None, Unset, float] = UNSET
+    max_value: Union[None, Unset, float] = UNSET
+    min_value: Union[None, Unset, float] = UNSET
+    error: Union[None, Unset, float] = UNSET
+    result: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -80,7 +80,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementModel:
 
         result = self.result
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -156,7 +156,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementModel:
         result = d.pop("Result", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_point_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_point_model.py
@@ -31,76 +31,70 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementPointMod
 class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
     """
     Attributes:
-        specification_name (Union[Unset, str]):
-        measurement_quantity (Union[Unset, str]):
-        unit_of_measure_id (Union[Unset, int]):
-        unit_of_measure (Union[Unset, str]):
-        range_min (Union[Unset, float]):
-        range_max (Union[Unset, float]):
-        specification_mode (Union[Unset, int]):
-        tolerance_type (Union[Unset, str]):
-        tolerance_mode (Union[Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceMode]):
-        tolerance_unit (Union[Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceUnit]):
-        precision_type (Union[Unset, str]):
-        readings (Union[Unset, int]):
-        channels_type (Union[Unset, str]):
-        channel_count (Union[Unset, int]):
-        precision (Union[Unset, float]):
-        tolerance_minimum (Union[Unset, float]):
-        tolerance_maximum (Union[Unset, float]):
-        resolution (Union[Unset, float]):
-        resolution_count (Union[Unset, float]):
-        nominal (Union[Unset, float]):
-        expected_value (Union[Unset, float]):
-        base_value (Union[Unset, float]):
-        test_value (Union[Unset, float]):
-        is_accredited (Union[Unset, bool]):
-        measurements (Union[Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementModel']]):
-        condition_factors (Union[Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementConditionFactorModel']]):
-        primary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel]):
-        secondary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel]):
+        specification_name (Union[None, Unset, str]):
+        measurement_quantity (Union[None, Unset, str]):
+        unit_of_measure_id (Union[None, Unset, int]):
+        unit_of_measure (Union[None, Unset, str]):
+        range_min (Union[None, Unset, float]):
+        range_max (Union[None, Unset, float]):
+        specification_mode (Union[None, Unset, int]):
+        tolerance_type (Union[None, Unset, str]):
+        tolerance_mode (Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceMode]):
+        tolerance_unit (Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceUnit]):
+        precision_type (Union[None, Unset, str]):
+        readings (Union[None, Unset, int]):
+        channels_type (Union[None, Unset, str]):
+        channel_count (Union[None, Unset, int]):
+        precision (Union[None, Unset, float]):
+        tolerance_minimum (Union[None, Unset, float]):
+        tolerance_maximum (Union[None, Unset, float]):
+        resolution (Union[None, Unset, float]):
+        resolution_count (Union[None, Unset, float]):
+        nominal (Union[None, Unset, float]):
+        expected_value (Union[None, Unset, float]):
+        base_value (Union[None, Unset, float]):
+        test_value (Union[None, Unset, float]):
+        is_accredited (Union[None, Unset, bool]):
+        measurements (Union[None, Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementModel']]):
+        condition_factors (Union[None, Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementConditionFactorModel']]):
+        primary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel]):
+        secondary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel]):
     """
 
-    specification_name: Union[Unset, str] = UNSET
-    measurement_quantity: Union[Unset, str] = UNSET
-    unit_of_measure_id: Union[Unset, int] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    range_min: Union[Unset, float] = UNSET
-    range_max: Union[Unset, float] = UNSET
-    specification_mode: Union[Unset, int] = UNSET
-    tolerance_type: Union[Unset, str] = UNSET
-    tolerance_mode: Union[
-        Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceMode
+    specification_name: Union[None, Unset, str] = UNSET
+    measurement_quantity: Union[None, Unset, str] = UNSET
+    unit_of_measure_id: Union[None, Unset, int] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    range_min: Union[None, Unset, float] = UNSET
+    range_max: Union[None, Unset, float] = UNSET
+    specification_mode: Union[None, Unset, int] = UNSET
+    tolerance_type: Union[None, Unset, str] = UNSET
+    tolerance_mode: Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceMode
     ] = UNSET
-    tolerance_unit: Union[
-        Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceUnit
+    tolerance_unit: Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceUnit
     ] = UNSET
-    precision_type: Union[Unset, str] = UNSET
-    readings: Union[Unset, int] = UNSET
-    channels_type: Union[Unset, str] = UNSET
-    channel_count: Union[Unset, int] = UNSET
-    precision: Union[Unset, float] = UNSET
-    tolerance_minimum: Union[Unset, float] = UNSET
-    tolerance_maximum: Union[Unset, float] = UNSET
-    resolution: Union[Unset, float] = UNSET
-    resolution_count: Union[Unset, float] = UNSET
-    nominal: Union[Unset, float] = UNSET
-    expected_value: Union[Unset, float] = UNSET
-    base_value: Union[Unset, float] = UNSET
-    test_value: Union[Unset, float] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    measurements: Union[
-        Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementModel"]
+    precision_type: Union[None, Unset, str] = UNSET
+    readings: Union[None, Unset, int] = UNSET
+    channels_type: Union[None, Unset, str] = UNSET
+    channel_count: Union[None, Unset, int] = UNSET
+    precision: Union[None, Unset, float] = UNSET
+    tolerance_minimum: Union[None, Unset, float] = UNSET
+    tolerance_maximum: Union[None, Unset, float] = UNSET
+    resolution: Union[None, Unset, float] = UNSET
+    resolution_count: Union[None, Unset, float] = UNSET
+    nominal: Union[None, Unset, float] = UNSET
+    expected_value: Union[None, Unset, float] = UNSET
+    base_value: Union[None, Unset, float] = UNSET
+    test_value: Union[None, Unset, float] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    measurements: Union[None, Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementModel"]
     ] = UNSET
-    condition_factors: Union[
-        Unset,
+    condition_factors: Union[None, Unset,
         list["QualerApiModelsMeasurementsFromCreateMeasurementConditionFactorModel"],
     ] = UNSET
-    primary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsFromCreateMeasurementToolModel"
+    primary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsFromCreateMeasurementToolModel"
     ] = UNSET
-    secondary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsFromCreateMeasurementToolModel"
+    secondary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsFromCreateMeasurementToolModel"
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -121,11 +115,11 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
 
         tolerance_type = self.tolerance_type
 
-        tolerance_mode: Union[Unset, int] = UNSET
+        tolerance_mode: Union[None, Unset, int] = UNSET
         if self.tolerance_mode and not isinstance(self.tolerance_mode, Unset):
             tolerance_mode = self.tolerance_mode.value
 
-        tolerance_unit: Union[Unset, int] = UNSET
+        tolerance_unit: Union[None, Unset, int] = UNSET
         if self.tolerance_unit and not isinstance(self.tolerance_unit, Unset):
             tolerance_unit = self.tolerance_unit.value
 
@@ -157,27 +151,27 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
 
         is_accredited = self.is_accredited
 
-        measurements: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurements: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurements and not isinstance(self.measurements, Unset):
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
 
-        condition_factors: Union[Unset, list[dict[str, Any]]] = UNSET
+        condition_factors: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.condition_factors and not isinstance(self.condition_factors, Unset):
             condition_factors = []
             for condition_factors_item_data in self.condition_factors:
                 condition_factors_item = condition_factors_item_data.to_dict()
                 condition_factors.append(condition_factors_item)
 
-        primary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        primary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.primary_measurement_tool and not isinstance(
             self.primary_measurement_tool, Unset
         ):
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
 
-        secondary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        secondary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.secondary_measurement_tool and not isinstance(
             self.secondary_measurement_tool, Unset
         ):
@@ -275,8 +269,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
         tolerance_type = d.pop("ToleranceType", UNSET)
 
         _tolerance_mode = d.pop("ToleranceMode", UNSET)
-        tolerance_mode: Union[
-            Unset,
+        tolerance_mode: Union[None, Unset,
             QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceMode,
         ]
         if isinstance(_tolerance_mode, Unset):
@@ -289,8 +282,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
             )
 
         _tolerance_unit = d.pop("ToleranceUnit", UNSET)
-        tolerance_unit: Union[
-            Unset,
+        tolerance_unit: Union[None, Unset,
             QualerApiModelsMeasurementsFromCreateMeasurementPointModelToleranceUnit,
         ]
         if isinstance(_tolerance_unit, Unset):
@@ -351,8 +343,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
             condition_factors.append(condition_factors_item)
 
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", UNSET)
-        primary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel
+        primary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel
         ]
         if isinstance(_primary_measurement_tool, Unset):
             primary_measurement_tool = UNSET
@@ -364,8 +355,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementPointModel:
             )
 
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", UNSET)
-        secondary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel
+        secondary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsFromCreateMeasurementToolModel
         ]
         if isinstance(_secondary_measurement_tool, Unset):
             secondary_measurement_tool = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_set_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_set_model.py
@@ -25,29 +25,28 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementSetModel
 class QualerApiModelsMeasurementsFromCreateMeasurementSetModel:
     """
     Attributes:
-        measurement_name (Union[Unset, str]):
-        is_accredited (Union[Unset, bool]):
-        measurement_quantity_id (Union[Unset, int]):
-        default_unit_of_measure_id (Union[Unset, int]):
-        decimal_places (Union[Unset, int]):
-        significant_figures (Union[Unset, int]):
-        display_options (Union[Unset, QualerApiModelsMeasurementsFromDisplayOptions]):
-        custom_fields (Union[Unset, QualerApiModelsMeasurementsFromCustomFields]):
-        measurement_points (Union[Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementPointModel']]):
+        measurement_name (Union[None, Unset, str]):
+        is_accredited (Union[None, Unset, bool]):
+        measurement_quantity_id (Union[None, Unset, int]):
+        default_unit_of_measure_id (Union[None, Unset, int]):
+        decimal_places (Union[None, Unset, int]):
+        significant_figures (Union[None, Unset, int]):
+        display_options (Union[None, Unset, QualerApiModelsMeasurementsFromDisplayOptions]):
+        custom_fields (Union[None, Unset, QualerApiModelsMeasurementsFromCustomFields]):
+        measurement_points (Union[None, Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementPointModel']]):
     """
 
-    measurement_name: Union[Unset, str] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    measurement_quantity_id: Union[Unset, int] = UNSET
-    default_unit_of_measure_id: Union[Unset, int] = UNSET
-    decimal_places: Union[Unset, int] = UNSET
-    significant_figures: Union[Unset, int] = UNSET
-    display_options: Union[Unset, "QualerApiModelsMeasurementsFromDisplayOptions"] = (
+    measurement_name: Union[None, Unset, str] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    measurement_quantity_id: Union[None, Unset, int] = UNSET
+    default_unit_of_measure_id: Union[None, Unset, int] = UNSET
+    decimal_places: Union[None, Unset, int] = UNSET
+    significant_figures: Union[None, Unset, int] = UNSET
+    display_options: Union[None, Unset, "QualerApiModelsMeasurementsFromDisplayOptions"] = (
         UNSET
     )
-    custom_fields: Union[Unset, "QualerApiModelsMeasurementsFromCustomFields"] = UNSET
-    measurement_points: Union[
-        Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementPointModel"]
+    custom_fields: Union[None, Unset, "QualerApiModelsMeasurementsFromCustomFields"] = UNSET
+    measurement_points: Union[None, Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementPointModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -64,15 +63,15 @@ class QualerApiModelsMeasurementsFromCreateMeasurementSetModel:
 
         significant_figures = self.significant_figures
 
-        display_options: Union[Unset, dict[str, Any]] = UNSET
+        display_options: Union[None, Unset, dict[str, Any]] = UNSET
         if self.display_options and not isinstance(self.display_options, Unset):
             display_options = self.display_options.to_dict()
 
-        custom_fields: Union[Unset, dict[str, Any]] = UNSET
+        custom_fields: Union[None, Unset, dict[str, Any]] = UNSET
         if self.custom_fields and not isinstance(self.custom_fields, Unset):
             custom_fields = self.custom_fields.to_dict()
 
-        measurement_points: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_points: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_points and not isinstance(self.measurement_points, Unset):
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
@@ -129,7 +128,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementSetModel:
         significant_figures = d.pop("SignificantFigures", UNSET)
 
         _display_options = d.pop("DisplayOptions", UNSET)
-        display_options: Union[Unset, QualerApiModelsMeasurementsFromDisplayOptions]
+        display_options: Union[None, Unset, QualerApiModelsMeasurementsFromDisplayOptions]
         if isinstance(_display_options, Unset):
             display_options = UNSET
         else:
@@ -138,7 +137,7 @@ class QualerApiModelsMeasurementsFromCreateMeasurementSetModel:
             )
 
         _custom_fields = d.pop("CustomFields", UNSET)
-        custom_fields: Union[Unset, QualerApiModelsMeasurementsFromCustomFields]
+        custom_fields: Union[None, Unset, QualerApiModelsMeasurementsFromCustomFields]
         if isinstance(_custom_fields, Unset):
             custom_fields = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_tool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_tool_model.py
@@ -15,36 +15,36 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCreateMeasurementToolMode
 class QualerApiModelsMeasurementsFromCreateMeasurementToolModel:
     """
     Attributes:
-        tool_id (Union[Unset, int]):
-        tool_type_name (Union[Unset, str]):
+        tool_id (Union[None, Unset, int]):
+        tool_type_name (Union[None, Unset, str]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        calibrated_by (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        tool_name (Union[Unset, str]):
-        tool_description (Union[Unset, str]):
-        manufacturer (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
+        calibrated_by (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        tool_name (Union[None, Unset, str]):
+        tool_description (Union[None, Unset, str]):
+        manufacturer (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
     """
 
-    tool_id: Union[Unset, int] = UNSET
-    tool_type_name: Union[Unset, str] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    tool_type_name: Union[None, Unset, str] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    calibrated_by: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    tool_name: Union[Unset, str] = UNSET
-    tool_description: Union[Unset, str] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
+    calibrated_by: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    tool_name: Union[None, Unset, str] = UNSET
+    tool_description: Union[None, Unset, str] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_custom_fields.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_custom_fields.py
@@ -19,15 +19,14 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromCustomFields")
 class QualerApiModelsMeasurementsFromCustomFields:
     """
     Attributes:
-        description (Union[Unset, str]):
-        result (Union[Unset, str]):
-        items (Union[Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementFieldModel']]):
+        description (Union[None, Unset, str]):
+        result (Union[None, Unset, str]):
+        items (Union[None, Unset, list['QualerApiModelsMeasurementsFromCreateMeasurementFieldModel']]):
     """
 
-    description: Union[Unset, str] = UNSET
-    result: Union[Unset, str] = UNSET
-    items: Union[
-        Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementFieldModel"]
+    description: Union[None, Unset, str] = UNSET
+    result: Union[None, Unset, str] = UNSET
+    items: Union[None, Unset, list["QualerApiModelsMeasurementsFromCreateMeasurementFieldModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -36,7 +35,7 @@ class QualerApiModelsMeasurementsFromCustomFields:
 
         result = self.result
 
-        items: Union[Unset, list[dict[str, Any]]] = UNSET
+        items: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.items and not isinstance(self.items, Unset):
             items = []
             for items_item_data in self.items:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_display_options.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_display_options.py
@@ -13,34 +13,34 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromDisplayOptions")
 class QualerApiModelsMeasurementsFromDisplayOptions:
     """
     Attributes:
-        err (Union[Unset, bool]):
-        mean (Union[Unset, bool]):
-        max_ (Union[Unset, bool]):
-        min_ (Union[Unset, bool]):
-        sd (Union[Unset, bool]):
-        cv (Union[Unset, bool]):
-        tar (Union[Unset, bool]):
-        tur (Union[Unset, bool]):
-        mu (Union[Unset, bool]):
-        cmc (Union[Unset, bool]):
-        tol (Union[Unset, bool]):
-        delta (Union[Unset, bool]):
-        range_ (Union[Unset, bool]):
+        err (Union[None, Unset, bool]):
+        mean (Union[None, Unset, bool]):
+        max_ (Union[None, Unset, bool]):
+        min_ (Union[None, Unset, bool]):
+        sd (Union[None, Unset, bool]):
+        cv (Union[None, Unset, bool]):
+        tar (Union[None, Unset, bool]):
+        tur (Union[None, Unset, bool]):
+        mu (Union[None, Unset, bool]):
+        cmc (Union[None, Unset, bool]):
+        tol (Union[None, Unset, bool]):
+        delta (Union[None, Unset, bool]):
+        range_ (Union[None, Unset, bool]):
     """
 
-    err: Union[Unset, bool] = UNSET
-    mean: Union[Unset, bool] = UNSET
-    max_: Union[Unset, bool] = UNSET
-    min_: Union[Unset, bool] = UNSET
-    sd: Union[Unset, bool] = UNSET
-    cv: Union[Unset, bool] = UNSET
-    tar: Union[Unset, bool] = UNSET
-    tur: Union[Unset, bool] = UNSET
-    mu: Union[Unset, bool] = UNSET
-    cmc: Union[Unset, bool] = UNSET
-    tol: Union[Unset, bool] = UNSET
-    delta: Union[Unset, bool] = UNSET
-    range_: Union[Unset, bool] = UNSET
+    err: Union[None, Unset, bool] = UNSET
+    mean: Union[None, Unset, bool] = UNSET
+    max_: Union[None, Unset, bool] = UNSET
+    min_: Union[None, Unset, bool] = UNSET
+    sd: Union[None, Unset, bool] = UNSET
+    cv: Union[None, Unset, bool] = UNSET
+    tar: Union[None, Unset, bool] = UNSET
+    tur: Union[None, Unset, bool] = UNSET
+    mu: Union[None, Unset, bool] = UNSET
+    cmc: Union[None, Unset, bool] = UNSET
+    tol: Union[None, Unset, bool] = UNSET
+    delta: Union[None, Unset, bool] = UNSET
+    range_: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_specification.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_specification.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromSpecification")
 class QualerApiModelsMeasurementsFromSpecification:
     """
     Attributes:
-        title (Union[Unset, str]):
-        subtitle (Union[Unset, str]):
-        group (Union[Unset, str]):
+        title (Union[None, Unset, str]):
+        subtitle (Union[None, Unset, str]):
+        group (Union[None, Unset, str]):
     """
 
-    title: Union[Unset, str] = UNSET
-    subtitle: Union[Unset, str] = UNSET
-    group: Union[Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    subtitle: Union[None, Unset, str] = UNSET
+    group: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_batch_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_batch_model.py
@@ -19,17 +19,16 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementBatchMod
 class QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel:
     """
     Attributes:
-        batch_id (Union[Unset, int]):
-        batch_type (Union[Unset, str]):
-        save_and_delete_empty (Union[Unset, bool]):
-        measurement_sets (Union[Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementSetModel']]):
+        batch_id (Union[None, Unset, int]):
+        batch_type (Union[None, Unset, str]):
+        save_and_delete_empty (Union[None, Unset, bool]):
+        measurement_sets (Union[None, Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementSetModel']]):
     """
 
-    batch_id: Union[Unset, int] = UNSET
-    batch_type: Union[Unset, str] = UNSET
-    save_and_delete_empty: Union[Unset, bool] = UNSET
-    measurement_sets: Union[
-        Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementSetModel"]
+    batch_id: Union[None, Unset, int] = UNSET
+    batch_type: Union[None, Unset, str] = UNSET
+    save_and_delete_empty: Union[None, Unset, bool] = UNSET
+    measurement_sets: Union[None, Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementSetModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -40,7 +39,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel:
 
         save_and_delete_empty = self.save_and_delete_empty
 
-        measurement_sets: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_sets: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_sets and not isinstance(self.measurement_sets, Unset):
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_condition_factor_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_condition_factor_model.py
@@ -15,18 +15,18 @@ T = TypeVar(
 class QualerApiModelsMeasurementsFromUpdateMeasurementConditionFactorModel:
     """
     Attributes:
-        measurement_condition_factor_id (Union[Unset, int]):
-        factor_id (Union[Unset, str]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        factor_uom (Union[Unset, str]):
+        measurement_condition_factor_id (Union[None, Unset, int]):
+        factor_id (Union[None, Unset, str]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        factor_uom (Union[None, Unset, str]):
     """
 
-    measurement_condition_factor_id: Union[Unset, int] = UNSET
-    factor_id: Union[Unset, str] = UNSET
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    factor_uom: Union[Unset, str] = UNSET
+    measurement_condition_factor_id: Union[None, Unset, int] = UNSET
+    factor_id: Union[None, Unset, str] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    factor_uom: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_field_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_field_model.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementFieldMod
 class QualerApiModelsMeasurementsFromUpdateMeasurementFieldModel:
     """
     Attributes:
-        field_id (Union[Unset, str]):
-        name (Union[Unset, str]):
-        type_ (Union[Unset, str]):
-        value (Union[Unset, str]):
+        field_id (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        type_ (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    field_id: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    type_: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    field_id: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    type_: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_form_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_form_model.py
@@ -19,16 +19,15 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementFormMode
 class QualerApiModelsMeasurementsFromUpdateMeasurementFormModel:
     """
     Attributes:
-        measurement_batches (Union[Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel']]):
+        measurement_batches (Union[None, Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel']]):
     """
 
-    measurement_batches: Union[
-        Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel"]
+    measurement_batches: Union[None, Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementBatchModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        measurement_batches: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_batches: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_batches and not isinstance(self.measurement_batches, Unset):
             measurement_batches = []
             for measurement_batches_item_data in self.measurement_batches:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_model.py
@@ -15,18 +15,18 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementModel")
 class QualerApiModelsMeasurementsFromUpdateMeasurementModel:
     """
     Attributes:
-        measurement_id (Union[Unset, int]):
-        values (Union[Unset, str]):
-        channel (Union[Unset, int]):
-        updated_by (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
+        measurement_id (Union[None, Unset, int]):
+        values (Union[None, Unset, str]):
+        channel (Union[None, Unset, int]):
+        updated_by (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
     """
 
-    measurement_id: Union[Unset, int] = UNSET
-    values: Union[Unset, str] = UNSET
-    channel: Union[Unset, int] = UNSET
-    updated_by: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
+    measurement_id: Union[None, Unset, int] = UNSET
+    values: Union[None, Unset, str] = UNSET
+    channel: Union[None, Unset, int] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -38,7 +38,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementModel:
 
         updated_by = self.updated_by
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -70,7 +70,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementModel:
         updated_by = d.pop("UpdatedBy", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_point_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_point_model.py
@@ -40,125 +40,116 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementPointMod
 class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
     """
     Attributes:
-        measurement_point_id (Union[Unset, int]):
-        specification_name (Union[Unset, str]):
-        unit_of_measure (Union[Unset, str]):
-        expected_value (Union[Unset, float]):
-        expected_value_raw (Union[Unset, str]):
-        base_value (Union[Unset, float]):
-        test_value (Union[Unset, float]):
-        nominal (Union[Unset, float]):
-        range_min (Union[Unset, float]):
-        range_max (Union[Unset, float]):
-        tolerance_type (Union[Unset, str]):
-        precision_type (Union[Unset, str]):
-        precision (Union[Unset, float]):
-        tolerance_minimum (Union[Unset, float]):
-        tolerance_maximum (Union[Unset, float]):
-        resolution (Union[Unset, float]):
-        resolution_count (Union[Unset, float]):
-        is_accredited (Union[Unset, bool]):
-        specification_mode (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelSpecificationMode]):
-        tolerance_mode (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceMode]):
-        tolerance_unit (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceUnit]):
-        measurements (Union[Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementModel']]):
-        measurement_condition_factors (Union[Unset,
+        measurement_point_id (Union[None, Unset, int]):
+        specification_name (Union[None, Unset, str]):
+        unit_of_measure (Union[None, Unset, str]):
+        expected_value (Union[None, Unset, float]):
+        expected_value_raw (Union[None, Unset, str]):
+        base_value (Union[None, Unset, float]):
+        test_value (Union[None, Unset, float]):
+        nominal (Union[None, Unset, float]):
+        range_min (Union[None, Unset, float]):
+        range_max (Union[None, Unset, float]):
+        tolerance_type (Union[None, Unset, str]):
+        precision_type (Union[None, Unset, str]):
+        precision (Union[None, Unset, float]):
+        tolerance_minimum (Union[None, Unset, float]):
+        tolerance_maximum (Union[None, Unset, float]):
+        resolution (Union[None, Unset, float]):
+        resolution_count (Union[None, Unset, float]):
+        is_accredited (Union[None, Unset, bool]):
+        specification_mode (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelSpecificationMode]):
+        tolerance_mode (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceMode]):
+        tolerance_unit (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceUnit]):
+        measurements (Union[None, Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementModel']]):
+        measurement_condition_factors (Union[None, Unset,
             list['QualerApiModelsMeasurementsFromUpdateMeasurementConditionFactorModel']]):
-        tool_application_mode (Union[Unset,
+        tool_application_mode (Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToolApplicationMode]):
-        primary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel]):
-        secondary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel]):
-        linked_measurement_point_id (Union[Unset, int]):
-        hysteresis_point (Union[Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelHysteresisPoint]):
-        influence_parameter_1_parameter_id (Union[Unset, int]):
-        influence_parameter_1_value (Union[Unset, str]):
-        influence_parameter_2_parameter_id (Union[Unset, int]):
-        influence_parameter_2_value (Union[Unset, str]):
-        measurement_not_taken_reason (Union[Unset, str]):
-        hide_from_certificate (Union[Unset, bool]):
-        measurement_not_taken_result (Union[Unset, str]):
-        is_measurement_not_taken (Union[Unset, bool]):
-        column_mean (Union[Unset, str]):
-        column_mean_result (Union[Unset, str]):
-        column_sd (Union[Unset, str]):
-        column_sd_result (Union[Unset, str]):
-        column_cv (Union[Unset, str]):
-        column_cv_result (Union[Unset, str]):
-        column_range (Union[Unset, str]):
-        column_range_result (Union[Unset, str]):
-        column_delta (Union[Unset, str]):
-        column_delta_result (Union[Unset, str]):
-        column_result (Union[Unset, str]):
+        primary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel]):
+        secondary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel]):
+        linked_measurement_point_id (Union[None, Unset, int]):
+        hysteresis_point (Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelHysteresisPoint]):
+        influence_parameter_1_parameter_id (Union[None, Unset, int]):
+        influence_parameter_1_value (Union[None, Unset, str]):
+        influence_parameter_2_parameter_id (Union[None, Unset, int]):
+        influence_parameter_2_value (Union[None, Unset, str]):
+        measurement_not_taken_reason (Union[None, Unset, str]):
+        hide_from_certificate (Union[None, Unset, bool]):
+        measurement_not_taken_result (Union[None, Unset, str]):
+        is_measurement_not_taken (Union[None, Unset, bool]):
+        column_mean (Union[None, Unset, str]):
+        column_mean_result (Union[None, Unset, str]):
+        column_sd (Union[None, Unset, str]):
+        column_sd_result (Union[None, Unset, str]):
+        column_cv (Union[None, Unset, str]):
+        column_cv_result (Union[None, Unset, str]):
+        column_range (Union[None, Unset, str]):
+        column_range_result (Union[None, Unset, str]):
+        column_delta (Union[None, Unset, str]):
+        column_delta_result (Union[None, Unset, str]):
+        column_result (Union[None, Unset, str]):
     """
 
-    measurement_point_id: Union[Unset, int] = UNSET
-    specification_name: Union[Unset, str] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    expected_value: Union[Unset, float] = UNSET
-    expected_value_raw: Union[Unset, str] = UNSET
-    base_value: Union[Unset, float] = UNSET
-    test_value: Union[Unset, float] = UNSET
-    nominal: Union[Unset, float] = UNSET
-    range_min: Union[Unset, float] = UNSET
-    range_max: Union[Unset, float] = UNSET
-    tolerance_type: Union[Unset, str] = UNSET
-    precision_type: Union[Unset, str] = UNSET
-    precision: Union[Unset, float] = UNSET
-    tolerance_minimum: Union[Unset, float] = UNSET
-    tolerance_maximum: Union[Unset, float] = UNSET
-    resolution: Union[Unset, float] = UNSET
-    resolution_count: Union[Unset, float] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    specification_mode: Union[
-        Unset,
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    specification_name: Union[None, Unset, str] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    expected_value: Union[None, Unset, float] = UNSET
+    expected_value_raw: Union[None, Unset, str] = UNSET
+    base_value: Union[None, Unset, float] = UNSET
+    test_value: Union[None, Unset, float] = UNSET
+    nominal: Union[None, Unset, float] = UNSET
+    range_min: Union[None, Unset, float] = UNSET
+    range_max: Union[None, Unset, float] = UNSET
+    tolerance_type: Union[None, Unset, str] = UNSET
+    precision_type: Union[None, Unset, str] = UNSET
+    precision: Union[None, Unset, float] = UNSET
+    tolerance_minimum: Union[None, Unset, float] = UNSET
+    tolerance_maximum: Union[None, Unset, float] = UNSET
+    resolution: Union[None, Unset, float] = UNSET
+    resolution_count: Union[None, Unset, float] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    specification_mode: Union[None, Unset,
         QualerApiModelsMeasurementsFromUpdateMeasurementPointModelSpecificationMode,
     ] = UNSET
-    tolerance_mode: Union[
-        Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceMode
+    tolerance_mode: Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceMode
     ] = UNSET
-    tolerance_unit: Union[
-        Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceUnit
+    tolerance_unit: Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceUnit
     ] = UNSET
-    measurements: Union[
-        Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementModel"]
+    measurements: Union[None, Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementModel"]
     ] = UNSET
-    measurement_condition_factors: Union[
-        Unset,
+    measurement_condition_factors: Union[None, Unset,
         list["QualerApiModelsMeasurementsFromUpdateMeasurementConditionFactorModel"],
     ] = UNSET
-    tool_application_mode: Union[
-        Unset,
+    tool_application_mode: Union[None, Unset,
         QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToolApplicationMode,
     ] = UNSET
-    primary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsFromUpdateMeasurementToolModel"
+    primary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsFromUpdateMeasurementToolModel"
     ] = UNSET
-    secondary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsFromUpdateMeasurementToolModel"
+    secondary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsFromUpdateMeasurementToolModel"
     ] = UNSET
-    linked_measurement_point_id: Union[Unset, int] = UNSET
-    hysteresis_point: Union[
-        Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelHysteresisPoint
+    linked_measurement_point_id: Union[None, Unset, int] = UNSET
+    hysteresis_point: Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementPointModelHysteresisPoint
     ] = UNSET
-    influence_parameter_1_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_1_value: Union[Unset, str] = UNSET
-    influence_parameter_2_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_2_value: Union[Unset, str] = UNSET
-    measurement_not_taken_reason: Union[Unset, str] = UNSET
-    hide_from_certificate: Union[Unset, bool] = UNSET
-    measurement_not_taken_result: Union[Unset, str] = UNSET
-    is_measurement_not_taken: Union[Unset, bool] = UNSET
-    column_mean: Union[Unset, str] = UNSET
-    column_mean_result: Union[Unset, str] = UNSET
-    column_sd: Union[Unset, str] = UNSET
-    column_sd_result: Union[Unset, str] = UNSET
-    column_cv: Union[Unset, str] = UNSET
-    column_cv_result: Union[Unset, str] = UNSET
-    column_range: Union[Unset, str] = UNSET
-    column_range_result: Union[Unset, str] = UNSET
-    column_delta: Union[Unset, str] = UNSET
-    column_delta_result: Union[Unset, str] = UNSET
-    column_result: Union[Unset, str] = UNSET
+    influence_parameter_1_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_value: Union[None, Unset, str] = UNSET
+    influence_parameter_2_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_value: Union[None, Unset, str] = UNSET
+    measurement_not_taken_reason: Union[None, Unset, str] = UNSET
+    hide_from_certificate: Union[None, Unset, bool] = UNSET
+    measurement_not_taken_result: Union[None, Unset, str] = UNSET
+    is_measurement_not_taken: Union[None, Unset, bool] = UNSET
+    column_mean: Union[None, Unset, str] = UNSET
+    column_mean_result: Union[None, Unset, str] = UNSET
+    column_sd: Union[None, Unset, str] = UNSET
+    column_sd_result: Union[None, Unset, str] = UNSET
+    column_cv: Union[None, Unset, str] = UNSET
+    column_cv_result: Union[None, Unset, str] = UNSET
+    column_range: Union[None, Unset, str] = UNSET
+    column_range_result: Union[None, Unset, str] = UNSET
+    column_delta: Union[None, Unset, str] = UNSET
+    column_delta_result: Union[None, Unset, str] = UNSET
+    column_result: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -198,26 +189,26 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
 
         is_accredited = self.is_accredited
 
-        specification_mode: Union[Unset, int] = UNSET
+        specification_mode: Union[None, Unset, int] = UNSET
         if self.specification_mode and not isinstance(self.specification_mode, Unset):
             specification_mode = self.specification_mode.value
 
-        tolerance_mode: Union[Unset, int] = UNSET
+        tolerance_mode: Union[None, Unset, int] = UNSET
         if self.tolerance_mode and not isinstance(self.tolerance_mode, Unset):
             tolerance_mode = self.tolerance_mode.value
 
-        tolerance_unit: Union[Unset, int] = UNSET
+        tolerance_unit: Union[None, Unset, int] = UNSET
         if self.tolerance_unit and not isinstance(self.tolerance_unit, Unset):
             tolerance_unit = self.tolerance_unit.value
 
-        measurements: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurements: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurements and not isinstance(self.measurements, Unset):
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
 
-        measurement_condition_factors: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_condition_factors: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_condition_factors and not isinstance(
             self.measurement_condition_factors, Unset
         ):
@@ -230,19 +221,19 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
                 )
                 measurement_condition_factors.append(measurement_condition_factors_item)
 
-        tool_application_mode: Union[Unset, str] = UNSET
+        tool_application_mode: Union[None, Unset, str] = UNSET
         if self.tool_application_mode and not isinstance(
             self.tool_application_mode, Unset
         ):
             tool_application_mode = self.tool_application_mode.value
 
-        primary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        primary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.primary_measurement_tool and not isinstance(
             self.primary_measurement_tool, Unset
         ):
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
 
-        secondary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        secondary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.secondary_measurement_tool and not isinstance(
             self.secondary_measurement_tool, Unset
         ):
@@ -250,7 +241,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
 
         linked_measurement_point_id = self.linked_measurement_point_id
 
-        hysteresis_point: Union[Unset, str] = UNSET
+        hysteresis_point: Union[None, Unset, str] = UNSET
         if self.hysteresis_point and not isinstance(self.hysteresis_point, Unset):
             hysteresis_point = self.hysteresis_point.value
 
@@ -446,8 +437,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
         is_accredited = d.pop("IsAccredited", UNSET)
 
         _specification_mode = d.pop("SpecificationMode", UNSET)
-        specification_mode: Union[
-            Unset,
+        specification_mode: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelSpecificationMode,
         ]
         if isinstance(_specification_mode, Unset):
@@ -458,8 +448,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
             )
 
         _tolerance_mode = d.pop("ToleranceMode", UNSET)
-        tolerance_mode: Union[
-            Unset,
+        tolerance_mode: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceMode,
         ]
         if isinstance(_tolerance_mode, Unset):
@@ -472,8 +461,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
             )
 
         _tolerance_unit = d.pop("ToleranceUnit", UNSET)
-        tolerance_unit: Union[
-            Unset,
+        tolerance_unit: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToleranceUnit,
         ]
         if isinstance(_tolerance_unit, Unset):
@@ -508,8 +496,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
             measurement_condition_factors.append(measurement_condition_factors_item)
 
         _tool_application_mode = d.pop("ToolApplicationMode", UNSET)
-        tool_application_mode: Union[
-            Unset,
+        tool_application_mode: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelToolApplicationMode,
         ]
         if isinstance(_tool_application_mode, Unset):
@@ -520,8 +507,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
             )
 
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", UNSET)
-        primary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel
+        primary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel
         ]
         if isinstance(_primary_measurement_tool, Unset):
             primary_measurement_tool = UNSET
@@ -533,8 +519,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
             )
 
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", UNSET)
-        secondary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel
+        secondary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsFromUpdateMeasurementToolModel
         ]
         if isinstance(_secondary_measurement_tool, Unset):
             secondary_measurement_tool = UNSET
@@ -548,8 +533,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementPointModel:
         linked_measurement_point_id = d.pop("LinkedMeasurementPointId", UNSET)
 
         _hysteresis_point = d.pop("HysteresisPoint", UNSET)
-        hysteresis_point: Union[
-            Unset,
+        hysteresis_point: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementPointModelHysteresisPoint,
         ]
         if isinstance(_hysteresis_point, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_set_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_set_model.py
@@ -28,55 +28,51 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementSetModel
 class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
     """
     Attributes:
-        measurement_set_id (Union[Unset, int]):
-        is_accredited (Union[Unset, bool]):
-        measurement_name (Union[Unset, str]):
-        use_expected_value (Union[Unset, bool]):
-        decimal_places (Union[Unset, int]):
-        significant_figures (Union[Unset, int]):
-        influence_parameter_1_type (Union[Unset,
+        measurement_set_id (Union[None, Unset, int]):
+        is_accredited (Union[None, Unset, bool]):
+        measurement_name (Union[None, Unset, str]):
+        use_expected_value (Union[None, Unset, bool]):
+        decimal_places (Union[None, Unset, int]):
+        significant_figures (Union[None, Unset, int]):
+        influence_parameter_1_type (Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter1Type]):
-        influence_parameter_1_tool_type_id (Union[Unset, int]):
-        influence_parameter_1_parameter_id (Union[Unset, int]):
-        influence_parameter_1_source (Union[Unset, str]):
-        influence_parameter_1_value (Union[Unset, str]):
-        influence_parameter_2_type (Union[Unset,
+        influence_parameter_1_tool_type_id (Union[None, Unset, int]):
+        influence_parameter_1_parameter_id (Union[None, Unset, int]):
+        influence_parameter_1_source (Union[None, Unset, str]):
+        influence_parameter_1_value (Union[None, Unset, str]):
+        influence_parameter_2_type (Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter2Type]):
-        influence_parameter_2_tool_type_id (Union[Unset, int]):
-        influence_parameter_2_parameter_id (Union[Unset, int]):
-        influence_parameter_2_source (Union[Unset, str]):
-        influence_parameter_2_value (Union[Unset, str]):
-        measurement_points (Union[Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementPointModel']]):
-        measurement_fields (Union[Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementFieldModel']]):
+        influence_parameter_2_tool_type_id (Union[None, Unset, int]):
+        influence_parameter_2_parameter_id (Union[None, Unset, int]):
+        influence_parameter_2_source (Union[None, Unset, str]):
+        influence_parameter_2_value (Union[None, Unset, str]):
+        measurement_points (Union[None, Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementPointModel']]):
+        measurement_fields (Union[None, Unset, list['QualerApiModelsMeasurementsFromUpdateMeasurementFieldModel']]):
     """
 
-    measurement_set_id: Union[Unset, int] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    measurement_name: Union[Unset, str] = UNSET
-    use_expected_value: Union[Unset, bool] = UNSET
-    decimal_places: Union[Unset, int] = UNSET
-    significant_figures: Union[Unset, int] = UNSET
-    influence_parameter_1_type: Union[
-        Unset,
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    measurement_name: Union[None, Unset, str] = UNSET
+    use_expected_value: Union[None, Unset, bool] = UNSET
+    decimal_places: Union[None, Unset, int] = UNSET
+    significant_figures: Union[None, Unset, int] = UNSET
+    influence_parameter_1_type: Union[None, Unset,
         QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter1Type,
     ] = UNSET
-    influence_parameter_1_tool_type_id: Union[Unset, int] = UNSET
-    influence_parameter_1_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_1_source: Union[Unset, str] = UNSET
-    influence_parameter_1_value: Union[Unset, str] = UNSET
-    influence_parameter_2_type: Union[
-        Unset,
+    influence_parameter_1_tool_type_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_source: Union[None, Unset, str] = UNSET
+    influence_parameter_1_value: Union[None, Unset, str] = UNSET
+    influence_parameter_2_type: Union[None, Unset,
         QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter2Type,
     ] = UNSET
-    influence_parameter_2_tool_type_id: Union[Unset, int] = UNSET
-    influence_parameter_2_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_2_source: Union[Unset, str] = UNSET
-    influence_parameter_2_value: Union[Unset, str] = UNSET
-    measurement_points: Union[
-        Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementPointModel"]
+    influence_parameter_2_tool_type_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_source: Union[None, Unset, str] = UNSET
+    influence_parameter_2_value: Union[None, Unset, str] = UNSET
+    measurement_points: Union[None, Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementPointModel"]
     ] = UNSET
-    measurement_fields: Union[
-        Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementFieldModel"]
+    measurement_fields: Union[None, Unset, list["QualerApiModelsMeasurementsFromUpdateMeasurementFieldModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -93,7 +89,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
 
         significant_figures = self.significant_figures
 
-        influence_parameter_1_type: Union[Unset, str] = UNSET
+        influence_parameter_1_type: Union[None, Unset, str] = UNSET
         if self.influence_parameter_1_type and not isinstance(
             self.influence_parameter_1_type, Unset
         ):
@@ -107,7 +103,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
 
         influence_parameter_1_value = self.influence_parameter_1_value
 
-        influence_parameter_2_type: Union[Unset, str] = UNSET
+        influence_parameter_2_type: Union[None, Unset, str] = UNSET
         if self.influence_parameter_2_type and not isinstance(
             self.influence_parameter_2_type, Unset
         ):
@@ -121,14 +117,14 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
 
         influence_parameter_2_value = self.influence_parameter_2_value
 
-        measurement_points: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_points: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_points and not isinstance(self.measurement_points, Unset):
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
 
-        measurement_fields: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_fields: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_fields and not isinstance(self.measurement_fields, Unset):
             measurement_fields = []
             for measurement_fields_item_data in self.measurement_fields:
@@ -208,8 +204,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
         significant_figures = d.pop("SignificantFigures", UNSET)
 
         _influence_parameter_1_type = d.pop("InfluenceParameter1Type", UNSET)
-        influence_parameter_1_type: Union[
-            Unset,
+        influence_parameter_1_type: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter1Type,
         ]
         if isinstance(_influence_parameter_1_type, Unset):
@@ -232,8 +227,7 @@ class QualerApiModelsMeasurementsFromUpdateMeasurementSetModel:
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", UNSET)
 
         _influence_parameter_2_type = d.pop("InfluenceParameter2Type", UNSET)
-        influence_parameter_2_type: Union[
-            Unset,
+        influence_parameter_2_type: Union[None, Unset,
             QualerApiModelsMeasurementsFromUpdateMeasurementSetModelInfluenceParameter2Type,
         ]
         if isinstance(_influence_parameter_2_type, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_tool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_tool_model.py
@@ -15,38 +15,38 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsFromUpdateMeasurementToolMode
 class QualerApiModelsMeasurementsFromUpdateMeasurementToolModel:
     """
     Attributes:
-        measurement_tool_id (Union[Unset, int]):
-        tool_id (Union[Unset, int]):
-        tool_type_name (Union[Unset, str]):
+        measurement_tool_id (Union[None, Unset, int]):
+        tool_id (Union[None, Unset, int]):
+        tool_type_name (Union[None, Unset, str]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        calibrated_by (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        tool_name (Union[Unset, str]):
-        tool_description (Union[Unset, str]):
-        manufacturer (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
+        calibrated_by (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        tool_name (Union[None, Unset, str]):
+        tool_description (Union[None, Unset, str]):
+        manufacturer (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
     """
 
-    measurement_tool_id: Union[Unset, int] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    tool_type_name: Union[Unset, str] = UNSET
+    measurement_tool_id: Union[None, Unset, int] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    tool_type_name: Union[None, Unset, str] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    calibrated_by: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    tool_name: Union[Unset, str] = UNSET
-    tool_description: Union[Unset, str] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
+    calibrated_by: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    tool_name: Union[None, Unset, str] = UNSET
+    tool_description: Union[None, Unset, str] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model.py
@@ -21,78 +21,77 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsToMeasurementRecordResponseMo
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModel:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        certificate_number (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        certificate_number (Union[None, Unset, str]):
         result_status (Union[None, Unset, str]):
-        as_found_result (Union[Unset, str]):
+        as_found_result (Union[None, Unset, str]):
         as_left_result (Union[None, Unset, str]):
         service_date (Union[None, Unset, datetime.datetime]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_tag_change (Union[Unset, str]):
-        asset_user_change (Union[Unset, str]):
-        service_notes (Union[Unset, str]):
-        serial_number_change (Union[Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_tag_change (Union[None, Unset, str]):
+        asset_user_change (Union[None, Unset, str]):
+        service_notes (Union[None, Unset, str]):
+        serial_number_change (Union[None, Unset, str]):
         due_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        service_level (Union[Unset, str]):
-        service_level_code (Union[Unset, str]):
-        next_service_level (Union[Unset, str]):
-        next_service_level_code (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        parts_charge (Union[Unset, float]):
-        parts_charge_before_discount (Union[Unset, float]):
-        service_charge (Union[Unset, float]):
-        repairs_charge (Union[Unset, float]):
-        segment_name (Union[Unset, str]):
-        schedule_name (Union[Unset, str]):
-        service_schedule_segment_id (Union[Unset, int]):
-        forward_next_service (Union[Unset, bool]):
-        forward_segment_id (Union[Unset, int]):
-        measurement_batches (Union[Unset,
+        service_level (Union[None, Unset, str]):
+        service_level_code (Union[None, Unset, str]):
+        next_service_level (Union[None, Unset, str]):
+        next_service_level_code (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        parts_charge (Union[None, Unset, float]):
+        parts_charge_before_discount (Union[None, Unset, float]):
+        service_charge (Union[None, Unset, float]):
+        repairs_charge (Union[None, Unset, float]):
+        segment_name (Union[None, Unset, str]):
+        schedule_name (Union[None, Unset, str]):
+        service_schedule_segment_id (Union[None, Unset, int]):
+        forward_next_service (Union[None, Unset, bool]):
+        forward_segment_id (Union[None, Unset, int]):
+        measurement_batches (Union[None, Unset,
             list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel']]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     result_status: Union[None, Unset, str] = UNSET
     as_found_result: Union[None, Unset, str] = UNSET
     as_left_result: Union[None, Unset, str] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_tag_change: Union[Unset, str] = UNSET
-    asset_user_change: Union[Unset, str] = UNSET
-    service_notes: Union[Unset, str] = UNSET
-    serial_number_change: Union[Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_tag_change: Union[None, Unset, str] = UNSET
+    asset_user_change: Union[None, Unset, str] = UNSET
+    service_notes: Union[None, Unset, str] = UNSET
+    serial_number_change: Union[None, Unset, str] = UNSET
     due_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    service_level: Union[Unset, str] = UNSET
-    service_level_code: Union[Unset, str] = UNSET
-    next_service_level: Union[Unset, str] = UNSET
-    next_service_level_code: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    parts_charge: Union[Unset, float] = UNSET
-    parts_charge_before_discount: Union[Unset, float] = UNSET
-    service_charge: Union[Unset, float] = UNSET
-    repairs_charge: Union[Unset, float] = UNSET
-    segment_name: Union[Unset, str] = UNSET
-    schedule_name: Union[Unset, str] = UNSET
-    service_schedule_segment_id: Union[Unset, int] = UNSET
-    forward_next_service: Union[Unset, bool] = UNSET
-    forward_segment_id: Union[Unset, int] = UNSET
-    measurement_batches: Union[
-        Unset,
+    service_level: Union[None, Unset, str] = UNSET
+    service_level_code: Union[None, Unset, str] = UNSET
+    next_service_level: Union[None, Unset, str] = UNSET
+    next_service_level_code: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    parts_charge: Union[None, Unset, float] = UNSET
+    parts_charge_before_discount: Union[None, Unset, float] = UNSET
+    service_charge: Union[None, Unset, float] = UNSET
+    repairs_charge: Union[None, Unset, float] = UNSET
+    segment_name: Union[None, Unset, str] = UNSET
+    schedule_name: Union[None, Unset, str] = UNSET
+    service_schedule_segment_id: Union[None, Unset, int] = UNSET
+    forward_next_service: Union[None, Unset, bool] = UNSET
+    forward_segment_id: Union[None, Unset, int] = UNSET
+    measurement_batches: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel"
         ],
@@ -213,7 +212,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModel:
 
         forward_segment_id = self.forward_segment_id
 
-        measurement_batches: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_batches: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_batches and not isinstance(self.measurement_batches, Unset):
             measurement_batches = []
             for measurement_batches_item_data in self.measurement_batches:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model.py
@@ -25,22 +25,20 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel:
     """
     Attributes:
-        batch_type (Union[Unset, str]):
-        batch_result (Union[Unset, str]):
-        specification (Union[Unset,
+        batch_type (Union[None, Unset, str]):
+        batch_result (Union[None, Unset, str]):
+        specification (Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelSpecificationResponseModel]):
-        measurement_sets (Union[Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatch
+        measurement_sets (Union[None, Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatch
             ResponseModelMeasurementSetResponseModel']]):
     """
 
-    batch_type: Union[Unset, str] = UNSET
-    batch_result: Union[Unset, str] = UNSET
-    specification: Union[
-        Unset,
+    batch_type: Union[None, Unset, str] = UNSET
+    batch_result: Union[None, Unset, str] = UNSET
+    specification: Union[None, Unset,
         "QualerApiModelsMeasurementsToMeasurementRecordResponseModelSpecificationResponseModel",
     ] = UNSET
-    measurement_sets: Union[
-        Unset,
+    measurement_sets: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModel"
         ],
@@ -52,11 +50,11 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         batch_result = self.batch_result
 
-        specification: Union[Unset, dict[str, Any]] = UNSET
+        specification: Union[None, Unset, dict[str, Any]] = UNSET
         if self.specification and not isinstance(self.specification, Unset):
             specification = self.specification.to_dict()
 
-        measurement_sets: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_sets: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_sets and not isinstance(self.measurement_sets, Unset):
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
@@ -92,8 +90,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
         batch_result = d.pop("BatchResult", UNSET)
 
         _specification = d.pop("Specification", UNSET)
-        specification: Union[
-            Unset,
+        specification: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelSpecificationResponseModel,
         ]
         if isinstance(_specification, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields.py
@@ -22,16 +22,15 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields:
     """
     Attributes:
-        description (Union[Unset, str]):
-        result (Union[Unset, str]):
-        items (Union[Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseMod
+        description (Union[None, Unset, str]):
+        result (Union[None, Unset, str]):
+        items (Union[None, Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseMod
             elCustomFieldsCreateMeasurementFieldResponseModel']]):
     """
 
-    description: Union[Unset, str] = UNSET
-    result: Union[Unset, str] = UNSET
-    items: Union[
-        Unset,
+    description: Union[None, Unset, str] = UNSET
+    result: Union[None, Unset, str] = UNSET
+    items: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFieldsCreateMeasurementFieldResponseModel"
         ],
@@ -43,7 +42,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         result = self.result
 
-        items: Union[Unset, list[dict[str, Any]]] = UNSET
+        items: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.items and not isinstance(self.items, Unset):
             items = []
             for items_item_data in self.items:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model.py
@@ -16,18 +16,18 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFieldsCreateMeasurementFieldResponseModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        type_ (Union[Unset, str]):
-        value (Union[Unset, str]):
-        field_id (Union[Unset, str]):
-        valid_values (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        type_ (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
+        field_id (Union[None, Unset, str]):
+        valid_values (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    type_: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
-    field_id: Union[Unset, str] = UNSET
-    valid_values: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    type_: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
+    field_id: Union[None, Unset, str] = UNSET
+    valid_values: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options.py
@@ -16,34 +16,34 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions:
     """
     Attributes:
-        err (Union[Unset, bool]):
-        mean (Union[Unset, bool]):
-        max_ (Union[Unset, bool]):
-        min_ (Union[Unset, bool]):
-        sd (Union[Unset, bool]):
-        cv (Union[Unset, bool]):
-        tar (Union[Unset, bool]):
-        tur (Union[Unset, bool]):
-        mu (Union[Unset, bool]):
-        cmc (Union[Unset, bool]):
-        tol (Union[Unset, bool]):
-        delta (Union[Unset, bool]):
-        range_ (Union[Unset, bool]):
+        err (Union[None, Unset, bool]):
+        mean (Union[None, Unset, bool]):
+        max_ (Union[None, Unset, bool]):
+        min_ (Union[None, Unset, bool]):
+        sd (Union[None, Unset, bool]):
+        cv (Union[None, Unset, bool]):
+        tar (Union[None, Unset, bool]):
+        tur (Union[None, Unset, bool]):
+        mu (Union[None, Unset, bool]):
+        cmc (Union[None, Unset, bool]):
+        tol (Union[None, Unset, bool]):
+        delta (Union[None, Unset, bool]):
+        range_ (Union[None, Unset, bool]):
     """
 
-    err: Union[Unset, bool] = UNSET
-    mean: Union[Unset, bool] = UNSET
-    max_: Union[Unset, bool] = UNSET
-    min_: Union[Unset, bool] = UNSET
-    sd: Union[Unset, bool] = UNSET
-    cv: Union[Unset, bool] = UNSET
-    tar: Union[Unset, bool] = UNSET
-    tur: Union[Unset, bool] = UNSET
-    mu: Union[Unset, bool] = UNSET
-    cmc: Union[Unset, bool] = UNSET
-    tol: Union[Unset, bool] = UNSET
-    delta: Union[Unset, bool] = UNSET
-    range_: Union[Unset, bool] = UNSET
+    err: Union[None, Unset, bool] = UNSET
+    mean: Union[None, Unset, bool] = UNSET
+    max_: Union[None, Unset, bool] = UNSET
+    min_: Union[None, Unset, bool] = UNSET
+    sd: Union[None, Unset, bool] = UNSET
+    cv: Union[None, Unset, bool] = UNSET
+    tar: Union[None, Unset, bool] = UNSET
+    tur: Union[None, Unset, bool] = UNSET
+    mu: Union[None, Unset, bool] = UNSET
+    cmc: Union[None, Unset, bool] = UNSET
+    tol: Union[None, Unset, bool] = UNSET
+    delta: Union[None, Unset, bool] = UNSET
+    range_: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model.py
@@ -28,36 +28,33 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModel:
     """
     Attributes:
-        measurement_name (Union[Unset, str]):
-        is_accredited (Union[Unset, bool]):
-        measurement_quantity_id (Union[Unset, int]):
-        default_unit_of_measure_id (Union[Unset, int]):
-        decimal_places (Union[Unset, int]):
-        significant_figures (Union[Unset, int]):
-        display_options (Union[Unset,
+        measurement_name (Union[None, Unset, str]):
+        is_accredited (Union[None, Unset, bool]):
+        measurement_quantity_id (Union[None, Unset, int]):
+        default_unit_of_measure_id (Union[None, Unset, int]):
+        decimal_places (Union[None, Unset, int]):
+        significant_figures (Union[None, Unset, int]):
+        display_options (Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions]):
-        custom_fields (Union[Unset,
+        custom_fields (Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields]):
-        measurement_points (Union[Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBat
+        measurement_points (Union[None, Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBat
             chResponseModelMeasurementSetResponseModelMeasurementPointResponseModel']]):
     """
 
-    measurement_name: Union[Unset, str] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    measurement_quantity_id: Union[Unset, int] = UNSET
-    default_unit_of_measure_id: Union[Unset, int] = UNSET
-    decimal_places: Union[Unset, int] = UNSET
-    significant_figures: Union[Unset, int] = UNSET
-    display_options: Union[
-        Unset,
+    measurement_name: Union[None, Unset, str] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    measurement_quantity_id: Union[None, Unset, int] = UNSET
+    default_unit_of_measure_id: Union[None, Unset, int] = UNSET
+    decimal_places: Union[None, Unset, int] = UNSET
+    significant_figures: Union[None, Unset, int] = UNSET
+    display_options: Union[None, Unset,
         "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions",
     ] = UNSET
-    custom_fields: Union[
-        Unset,
+    custom_fields: Union[None, Unset,
         "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields",
     ] = UNSET
-    measurement_points: Union[
-        Unset,
+    measurement_points: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModel"
         ],
@@ -77,15 +74,15 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         significant_figures = self.significant_figures
 
-        display_options: Union[Unset, dict[str, Any]] = UNSET
+        display_options: Union[None, Unset, dict[str, Any]] = UNSET
         if self.display_options and not isinstance(self.display_options, Unset):
             display_options = self.display_options.to_dict()
 
-        custom_fields: Union[Unset, dict[str, Any]] = UNSET
+        custom_fields: Union[None, Unset, dict[str, Any]] = UNSET
         if self.custom_fields and not isinstance(self.custom_fields, Unset):
             custom_fields = self.custom_fields.to_dict()
 
-        measurement_points: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_points: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_points and not isinstance(self.measurement_points, Unset):
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
@@ -142,8 +139,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
         significant_figures = d.pop("SignificantFigures", UNSET)
 
         _display_options = d.pop("DisplayOptions", UNSET)
-        display_options: Union[
-            Unset,
+        display_options: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions,
         ]
         if isinstance(_display_options, Unset):
@@ -154,8 +150,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             )
 
         _custom_fields = d.pop("CustomFields", UNSET)
-        custom_fields: Union[
-            Unset,
+        custom_fields: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields,
         ]
         if isinstance(_custom_fields, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model.py
@@ -37,95 +37,88 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModel:
     """
     Attributes:
-        specification_name (Union[Unset, str]):
-        measurement_quantity (Union[Unset, str]):
-        unit_of_measure_id (Union[Unset, int]):
-        unit_of_measure (Union[Unset, str]):
-        range_min (Union[Unset, float]):
-        range_max (Union[Unset, float]):
-        tolerance_type (Union[Unset, str]):
-        specification_mode (Union[Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResp
+        specification_name (Union[None, Unset, str]):
+        measurement_quantity (Union[None, Unset, str]):
+        unit_of_measure_id (Union[None, Unset, int]):
+        unit_of_measure (Union[None, Unset, str]):
+        range_min (Union[None, Unset, float]):
+        range_max (Union[None, Unset, float]):
+        tolerance_type (Union[None, Unset, str]):
+        specification_mode (Union[None, Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResp
             onseModelMeasurementSetResponseModelMeasurementPointResponseModelSpecificationMode]):
-        tolerance_mode (Union[Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponse
+        tolerance_mode (Union[None, Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponse
             ModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceMode]):
-        tolerance_unit (Union[Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponse
+        tolerance_unit (Union[None, Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponse
             ModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceUnit]):
-        precision_type (Union[Unset, str]):
-        readings (Union[Unset, int]):
-        channels_type (Union[Unset, str]):
-        channel_count (Union[Unset, int]):
-        precision (Union[Unset, float]):
-        tolerance_minimum (Union[Unset, float]):
-        tolerance_maximum (Union[Unset, float]):
-        resolution (Union[Unset, float]):
-        resolution_count (Union[Unset, float]):
-        nominal (Union[Unset, float]):
-        expected_value (Union[Unset, float]):
-        base_value (Union[Unset, float]):
-        test_value (Union[Unset, float]):
-        is_accredited (Union[Unset, bool]):
-        measurements (Union[Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResp
+        precision_type (Union[None, Unset, str]):
+        readings (Union[None, Unset, int]):
+        channels_type (Union[None, Unset, str]):
+        channel_count (Union[None, Unset, int]):
+        precision (Union[None, Unset, float]):
+        tolerance_minimum (Union[None, Unset, float]):
+        tolerance_maximum (Union[None, Unset, float]):
+        resolution (Union[None, Unset, float]):
+        resolution_count (Union[None, Unset, float]):
+        nominal (Union[None, Unset, float]):
+        expected_value (Union[None, Unset, float]):
+        base_value (Union[None, Unset, float]):
+        test_value (Union[None, Unset, float]):
+        is_accredited (Union[None, Unset, bool]):
+        measurements (Union[None, Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResp
             onseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementResponseModel']]):
-        condition_factors (Union[Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
+        condition_factors (Union[None, Unset, list['QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             hResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementConditionFactorResponseModel']]
             ):
-        primary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBat
+        primary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBat
             chResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel]):
-        secondary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementB
+        secondary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementB
             atchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel]):
     """
 
-    specification_name: Union[Unset, str] = UNSET
-    measurement_quantity: Union[Unset, str] = UNSET
-    unit_of_measure_id: Union[Unset, int] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    range_min: Union[Unset, float] = UNSET
-    range_max: Union[Unset, float] = UNSET
-    tolerance_type: Union[Unset, str] = UNSET
-    specification_mode: Union[
-        Unset,
+    specification_name: Union[None, Unset, str] = UNSET
+    measurement_quantity: Union[None, Unset, str] = UNSET
+    unit_of_measure_id: Union[None, Unset, int] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    range_min: Union[None, Unset, float] = UNSET
+    range_max: Union[None, Unset, float] = UNSET
+    tolerance_type: Union[None, Unset, str] = UNSET
+    specification_mode: Union[None, Unset,
         QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelSpecificationMode,
     ] = UNSET
-    tolerance_mode: Union[
-        Unset,
+    tolerance_mode: Union[None, Unset,
         QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceMode,
     ] = UNSET
-    tolerance_unit: Union[
-        Unset,
+    tolerance_unit: Union[None, Unset,
         QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceUnit,
     ] = UNSET
-    precision_type: Union[Unset, str] = UNSET
-    readings: Union[Unset, int] = UNSET
-    channels_type: Union[Unset, str] = UNSET
-    channel_count: Union[Unset, int] = UNSET
-    precision: Union[Unset, float] = UNSET
-    tolerance_minimum: Union[Unset, float] = UNSET
-    tolerance_maximum: Union[Unset, float] = UNSET
-    resolution: Union[Unset, float] = UNSET
-    resolution_count: Union[Unset, float] = UNSET
-    nominal: Union[Unset, float] = UNSET
-    expected_value: Union[Unset, float] = UNSET
-    base_value: Union[Unset, float] = UNSET
-    test_value: Union[Unset, float] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    measurements: Union[
-        Unset,
+    precision_type: Union[None, Unset, str] = UNSET
+    readings: Union[None, Unset, int] = UNSET
+    channels_type: Union[None, Unset, str] = UNSET
+    channel_count: Union[None, Unset, int] = UNSET
+    precision: Union[None, Unset, float] = UNSET
+    tolerance_minimum: Union[None, Unset, float] = UNSET
+    tolerance_maximum: Union[None, Unset, float] = UNSET
+    resolution: Union[None, Unset, float] = UNSET
+    resolution_count: Union[None, Unset, float] = UNSET
+    nominal: Union[None, Unset, float] = UNSET
+    expected_value: Union[None, Unset, float] = UNSET
+    base_value: Union[None, Unset, float] = UNSET
+    test_value: Union[None, Unset, float] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    measurements: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementResponseModel"
         ],
     ] = UNSET
-    condition_factors: Union[
-        Unset,
+    condition_factors: Union[None, Unset,
         list[
             "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementConditionFactorResponseModel"
         ],
     ] = UNSET
-    primary_measurement_tool: Union[
-        Unset,
+    primary_measurement_tool: Union[None, Unset,
         "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel",
     ] = UNSET
-    secondary_measurement_tool: Union[
-        Unset,
+    secondary_measurement_tool: Union[None, Unset,
         "QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel",
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -145,15 +138,15 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         tolerance_type = self.tolerance_type
 
-        specification_mode: Union[Unset, int] = UNSET
+        specification_mode: Union[None, Unset, int] = UNSET
         if self.specification_mode and not isinstance(self.specification_mode, Unset):
             specification_mode = self.specification_mode.value
 
-        tolerance_mode: Union[Unset, int] = UNSET
+        tolerance_mode: Union[None, Unset, int] = UNSET
         if self.tolerance_mode and not isinstance(self.tolerance_mode, Unset):
             tolerance_mode = self.tolerance_mode.value
 
-        tolerance_unit: Union[Unset, int] = UNSET
+        tolerance_unit: Union[None, Unset, int] = UNSET
         if self.tolerance_unit and not isinstance(self.tolerance_unit, Unset):
             tolerance_unit = self.tolerance_unit.value
 
@@ -185,27 +178,27 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         is_accredited = self.is_accredited
 
-        measurements: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurements: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurements and not isinstance(self.measurements, Unset):
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
 
-        condition_factors: Union[Unset, list[dict[str, Any]]] = UNSET
+        condition_factors: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.condition_factors and not isinstance(self.condition_factors, Unset):
             condition_factors = []
             for condition_factors_item_data in self.condition_factors:
                 condition_factors_item = condition_factors_item_data.to_dict()
                 condition_factors.append(condition_factors_item)
 
-        primary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        primary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.primary_measurement_tool and not isinstance(
             self.primary_measurement_tool, Unset
         ):
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
 
-        secondary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        secondary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.secondary_measurement_tool and not isinstance(
             self.secondary_measurement_tool, Unset
         ):
@@ -301,8 +294,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
         tolerance_type = d.pop("ToleranceType", UNSET)
 
         _specification_mode = d.pop("SpecificationMode", UNSET)
-        specification_mode: Union[
-            Unset,
+        specification_mode: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelSpecificationMode,
         ]
         if isinstance(_specification_mode, Unset):
@@ -313,8 +305,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             )
 
         _tolerance_mode = d.pop("ToleranceMode", UNSET)
-        tolerance_mode: Union[
-            Unset,
+        tolerance_mode: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceMode,
         ]
         if isinstance(_tolerance_mode, Unset):
@@ -325,8 +316,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             )
 
         _tolerance_unit = d.pop("ToleranceUnit", UNSET)
-        tolerance_unit: Union[
-            Unset,
+        tolerance_unit: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceUnit,
         ]
         if isinstance(_tolerance_unit, Unset):
@@ -383,8 +373,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             condition_factors.append(condition_factors_item)
 
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", UNSET)
-        primary_measurement_tool: Union[
-            Unset,
+        primary_measurement_tool: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel,
         ]
         if isinstance(_primary_measurement_tool, Unset):
@@ -395,8 +384,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
             )
 
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", UNSET)
-        secondary_measurement_tool: Union[
-            Unset,
+        secondary_measurement_tool: Union[None, Unset,
             QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel,
         ]
         if isinstance(_secondary_measurement_tool, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model.py
@@ -18,17 +18,17 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementConditionFactorResponseModel:
     """
     Attributes:
-        factor_id (Union[Unset, str]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        factor_uom (Union[Unset, str]):
+        factor_id (Union[None, Unset, str]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        factor_uom (Union[None, Unset, str]):
         last_modified_on_utc (Union[None, Unset, datetime.datetime]):
     """
 
-    factor_id: Union[Unset, str] = UNSET
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    factor_uom: Union[Unset, str] = UNSET
+    factor_id: Union[None, Unset, str] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    factor_uom: Union[None, Unset, str] = UNSET
     last_modified_on_utc: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model.py
@@ -18,40 +18,40 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementResponseModel:
     """
     Attributes:
-        values (Union[Unset, str]):
-        mean (Union[Unset, float]):
-        sd (Union[Unset, float]):
-        range_ (Union[Unset, float]):
-        delta (Union[Unset, float]):
-        cv (Union[Unset, float]):
-        cmc (Union[Unset, float]):
-        mu (Union[Unset, float]):
-        tur (Union[Unset, float]):
-        tar (Union[Unset, float]):
-        max_value (Union[Unset, float]):
-        min_value (Union[Unset, float]):
-        error (Union[Unset, float]):
-        result (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
-        updated_by (Union[Unset, str]):
+        values (Union[None, Unset, str]):
+        mean (Union[None, Unset, float]):
+        sd (Union[None, Unset, float]):
+        range_ (Union[None, Unset, float]):
+        delta (Union[None, Unset, float]):
+        cv (Union[None, Unset, float]):
+        cmc (Union[None, Unset, float]):
+        mu (Union[None, Unset, float]):
+        tur (Union[None, Unset, float]):
+        tar (Union[None, Unset, float]):
+        max_value (Union[None, Unset, float]):
+        min_value (Union[None, Unset, float]):
+        error (Union[None, Unset, float]):
+        result (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
+        updated_by (Union[None, Unset, str]):
     """
 
-    values: Union[Unset, str] = UNSET
-    mean: Union[Unset, float] = UNSET
-    sd: Union[Unset, float] = UNSET
-    range_: Union[Unset, float] = UNSET
-    delta: Union[Unset, float] = UNSET
-    cv: Union[Unset, float] = UNSET
-    cmc: Union[Unset, float] = UNSET
-    mu: Union[Unset, float] = UNSET
-    tur: Union[Unset, float] = UNSET
-    tar: Union[Unset, float] = UNSET
-    max_value: Union[Unset, float] = UNSET
-    min_value: Union[Unset, float] = UNSET
-    error: Union[Unset, float] = UNSET
-    result: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
-    updated_by: Union[Unset, str] = UNSET
+    values: Union[None, Unset, str] = UNSET
+    mean: Union[None, Unset, float] = UNSET
+    sd: Union[None, Unset, float] = UNSET
+    range_: Union[None, Unset, float] = UNSET
+    delta: Union[None, Unset, float] = UNSET
+    cv: Union[None, Unset, float] = UNSET
+    cmc: Union[None, Unset, float] = UNSET
+    mu: Union[None, Unset, float] = UNSET
+    tur: Union[None, Unset, float] = UNSET
+    tar: Union[None, Unset, float] = UNSET
+    max_value: Union[None, Unset, float] = UNSET
+    min_value: Union[None, Unset, float] = UNSET
+    error: Union[None, Unset, float] = UNSET
+    result: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -83,7 +83,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
 
         result = self.result
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -159,7 +159,7 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
         result = d.pop("Result", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model.py
@@ -20,30 +20,30 @@ class QualerApiModelsMeasurementsToMeasurementRecordResponseModelMeasurementBatc
     Attributes:
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        calibrated_by (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        tool_name (Union[Unset, str]):
-        tool_description (Union[Unset, str]):
-        manufacturer (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
+        calibrated_by (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        tool_name (Union[None, Unset, str]):
+        tool_description (Union[None, Unset, str]):
+        manufacturer (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
     """
 
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    calibrated_by: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    tool_name: Union[Unset, str] = UNSET
-    tool_description: Union[Unset, str] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
+    calibrated_by: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    tool_name: Union[None, Unset, str] = UNSET
+    tool_description: Union[None, Unset, str] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model.py
@@ -16,14 +16,14 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToMeasurementRecordResponseModelSpecificationResponseModel:
     """
     Attributes:
-        title (Union[Unset, str]):
-        subtitle (Union[Unset, str]):
-        group (Union[Unset, str]):
+        title (Union[None, Unset, str]):
+        subtitle (Union[None, Unset, str]):
+        group (Union[None, Unset, str]):
     """
 
-    title: Union[Unset, str] = UNSET
-    subtitle: Union[Unset, str] = UNSET
-    group: Union[Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    subtitle: Union[None, Unset, str] = UNSET
+    group: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_batch_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_batch_response_model.py
@@ -21,15 +21,14 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel:
     """
     Attributes:
-        batch_id (Union[Unset, int]):
-        batch_type (Union[Unset, str]):
-        measurement_sets (Union[Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel']]):
+        batch_id (Union[None, Unset, int]):
+        batch_type (Union[None, Unset, str]):
+        measurement_sets (Union[None, Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel']]):
     """
 
-    batch_id: Union[Unset, int] = UNSET
-    batch_type: Union[Unset, str] = UNSET
-    measurement_sets: Union[
-        Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel"]
+    batch_id: Union[None, Unset, int] = UNSET
+    batch_type: Union[None, Unset, str] = UNSET
+    measurement_sets: Union[None, Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -38,7 +37,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel:
 
         batch_type = self.batch_type
 
-        measurement_sets: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_sets: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_sets and not isinstance(self.measurement_sets, Unset):
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_condition_factor_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_condition_factor_response.py
@@ -15,18 +15,18 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementConditionFactorResponse:
     """
     Attributes:
-        measurement_condition_factor_id (Union[Unset, int]):
-        factor_id (Union[Unset, str]):
-        factor_name (Union[Unset, str]):
-        factor_value (Union[Unset, float]):
-        factor_uom (Union[Unset, str]):
+        measurement_condition_factor_id (Union[None, Unset, int]):
+        factor_id (Union[None, Unset, str]):
+        factor_name (Union[None, Unset, str]):
+        factor_value (Union[None, Unset, float]):
+        factor_uom (Union[None, Unset, str]):
     """
 
-    measurement_condition_factor_id: Union[Unset, int] = UNSET
-    factor_id: Union[Unset, str] = UNSET
-    factor_name: Union[Unset, str] = UNSET
-    factor_value: Union[Unset, float] = UNSET
-    factor_uom: Union[Unset, str] = UNSET
+    measurement_condition_factor_id: Union[None, Unset, int] = UNSET
+    factor_id: Union[None, Unset, str] = UNSET
+    factor_name: Union[None, Unset, str] = UNSET
+    factor_value: Union[None, Unset, float] = UNSET
+    factor_uom: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_field_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_field_response_model.py
@@ -15,16 +15,16 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementFieldResponseModel:
     """
     Attributes:
-        field_id (Union[Unset, str]):
-        name (Union[Unset, str]):
-        type_ (Union[Unset, str]):
-        value (Union[Unset, str]):
+        field_id (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        type_ (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    field_id: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    type_: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    field_id: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    type_: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_form_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_form_response_model.py
@@ -21,16 +21,15 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementFormResponseModel:
     """
     Attributes:
-        measurement_batches (Union[Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel']]):
+        measurement_batches (Union[None, Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel']]):
     """
 
-    measurement_batches: Union[
-        Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel"]
+    measurement_batches: Union[None, Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementBatchResponseModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        measurement_batches: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_batches: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_batches and not isinstance(self.measurement_batches, Unset):
             measurement_batches = []
             for measurement_batches_item_data in self.measurement_batches:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_point_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_point_response_model.py
@@ -33,89 +33,83 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
     """
     Attributes:
-        measurement_point_id (Union[Unset, int]):
-        specification_name (Union[Unset, str]):
-        unit_of_measure (Union[Unset, str]):
-        expected_value (Union[Unset, float]):
-        base_value (Union[Unset, float]):
-        test_value (Union[Unset, float]):
-        nominal (Union[Unset, float]):
-        range_min (Union[Unset, float]):
-        range_max (Union[Unset, float]):
-        tolerance_type (Union[Unset, str]):
-        tolerance_mode (Union[Unset, QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceMode]):
-        tolerance_unit (Union[Unset, QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceUnit]):
-        precision_type (Union[Unset, str]):
-        precision (Union[Unset, float]):
-        tolerance_minimum (Union[Unset, float]):
-        tolerance_maximum (Union[Unset, float]):
-        resolution (Union[Unset, float]):
-        resolution_count (Union[Unset, float]):
-        is_accredited (Union[Unset, bool]):
-        linked_measurement_point_id (Union[Unset, int]):
-        hysteresis_point (Union[Unset, str]):
-        hide_from_certificate (Union[Unset, bool]):
-        is_measurement_not_taken (Union[Unset, bool]):
-        measurement_not_taken_result (Union[Unset, str]):
-        measurement_not_taken_reason (Union[Unset, str]):
-        influence_parameter_1_parameter_id (Union[Unset, int]):
-        influence_parameter_1_value (Union[Unset, str]):
-        influence_parameter_2_parameter_id (Union[Unset, int]):
-        influence_parameter_2_value (Union[Unset, str]):
-        measurements (Union[Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementResponseModel']]):
-        measurement_condition_factors (Union[Unset,
+        measurement_point_id (Union[None, Unset, int]):
+        specification_name (Union[None, Unset, str]):
+        unit_of_measure (Union[None, Unset, str]):
+        expected_value (Union[None, Unset, float]):
+        base_value (Union[None, Unset, float]):
+        test_value (Union[None, Unset, float]):
+        nominal (Union[None, Unset, float]):
+        range_min (Union[None, Unset, float]):
+        range_max (Union[None, Unset, float]):
+        tolerance_type (Union[None, Unset, str]):
+        tolerance_mode (Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceMode]):
+        tolerance_unit (Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceUnit]):
+        precision_type (Union[None, Unset, str]):
+        precision (Union[None, Unset, float]):
+        tolerance_minimum (Union[None, Unset, float]):
+        tolerance_maximum (Union[None, Unset, float]):
+        resolution (Union[None, Unset, float]):
+        resolution_count (Union[None, Unset, float]):
+        is_accredited (Union[None, Unset, bool]):
+        linked_measurement_point_id (Union[None, Unset, int]):
+        hysteresis_point (Union[None, Unset, str]):
+        hide_from_certificate (Union[None, Unset, bool]):
+        is_measurement_not_taken (Union[None, Unset, bool]):
+        measurement_not_taken_result (Union[None, Unset, str]):
+        measurement_not_taken_reason (Union[None, Unset, str]):
+        influence_parameter_1_parameter_id (Union[None, Unset, int]):
+        influence_parameter_1_value (Union[None, Unset, str]):
+        influence_parameter_2_parameter_id (Union[None, Unset, int]):
+        influence_parameter_2_value (Union[None, Unset, str]):
+        measurements (Union[None, Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementResponseModel']]):
+        measurement_condition_factors (Union[None, Unset,
             list['QualerApiModelsMeasurementsToUpdateMeasurementConditionFactorResponse']]):
-        primary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel]):
-        secondary_measurement_tool (Union[Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel]):
+        primary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel]):
+        secondary_measurement_tool (Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel]):
     """
 
-    measurement_point_id: Union[Unset, int] = UNSET
-    specification_name: Union[Unset, str] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    expected_value: Union[Unset, float] = UNSET
-    base_value: Union[Unset, float] = UNSET
-    test_value: Union[Unset, float] = UNSET
-    nominal: Union[Unset, float] = UNSET
-    range_min: Union[Unset, float] = UNSET
-    range_max: Union[Unset, float] = UNSET
-    tolerance_type: Union[Unset, str] = UNSET
-    tolerance_mode: Union[
-        Unset,
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    specification_name: Union[None, Unset, str] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    expected_value: Union[None, Unset, float] = UNSET
+    base_value: Union[None, Unset, float] = UNSET
+    test_value: Union[None, Unset, float] = UNSET
+    nominal: Union[None, Unset, float] = UNSET
+    range_min: Union[None, Unset, float] = UNSET
+    range_max: Union[None, Unset, float] = UNSET
+    tolerance_type: Union[None, Unset, str] = UNSET
+    tolerance_mode: Union[None, Unset,
         QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceMode,
     ] = UNSET
-    tolerance_unit: Union[
-        Unset,
+    tolerance_unit: Union[None, Unset,
         QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceUnit,
     ] = UNSET
-    precision_type: Union[Unset, str] = UNSET
-    precision: Union[Unset, float] = UNSET
-    tolerance_minimum: Union[Unset, float] = UNSET
-    tolerance_maximum: Union[Unset, float] = UNSET
-    resolution: Union[Unset, float] = UNSET
-    resolution_count: Union[Unset, float] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    linked_measurement_point_id: Union[Unset, int] = UNSET
-    hysteresis_point: Union[Unset, str] = UNSET
-    hide_from_certificate: Union[Unset, bool] = UNSET
-    is_measurement_not_taken: Union[Unset, bool] = UNSET
-    measurement_not_taken_result: Union[Unset, str] = UNSET
-    measurement_not_taken_reason: Union[Unset, str] = UNSET
-    influence_parameter_1_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_1_value: Union[Unset, str] = UNSET
-    influence_parameter_2_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_2_value: Union[Unset, str] = UNSET
-    measurements: Union[
-        Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementResponseModel"]
+    precision_type: Union[None, Unset, str] = UNSET
+    precision: Union[None, Unset, float] = UNSET
+    tolerance_minimum: Union[None, Unset, float] = UNSET
+    tolerance_maximum: Union[None, Unset, float] = UNSET
+    resolution: Union[None, Unset, float] = UNSET
+    resolution_count: Union[None, Unset, float] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    linked_measurement_point_id: Union[None, Unset, int] = UNSET
+    hysteresis_point: Union[None, Unset, str] = UNSET
+    hide_from_certificate: Union[None, Unset, bool] = UNSET
+    is_measurement_not_taken: Union[None, Unset, bool] = UNSET
+    measurement_not_taken_result: Union[None, Unset, str] = UNSET
+    measurement_not_taken_reason: Union[None, Unset, str] = UNSET
+    influence_parameter_1_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_value: Union[None, Unset, str] = UNSET
+    influence_parameter_2_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_value: Union[None, Unset, str] = UNSET
+    measurements: Union[None, Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementResponseModel"]
     ] = UNSET
-    measurement_condition_factors: Union[
-        Unset,
+    measurement_condition_factors: Union[None, Unset,
         list["QualerApiModelsMeasurementsToUpdateMeasurementConditionFactorResponse"],
     ] = UNSET
-    primary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel"
+    primary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel"
     ] = UNSET
-    secondary_measurement_tool: Union[
-        Unset, "QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel"
+    secondary_measurement_tool: Union[None, Unset, "QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel"
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -140,11 +134,11 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
 
         tolerance_type = self.tolerance_type
 
-        tolerance_mode: Union[Unset, int] = UNSET
+        tolerance_mode: Union[None, Unset, int] = UNSET
         if self.tolerance_mode and not isinstance(self.tolerance_mode, Unset):
             tolerance_mode = self.tolerance_mode.value
 
-        tolerance_unit: Union[Unset, int] = UNSET
+        tolerance_unit: Union[None, Unset, int] = UNSET
         if self.tolerance_unit and not isinstance(self.tolerance_unit, Unset):
             tolerance_unit = self.tolerance_unit.value
 
@@ -182,14 +176,14 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
 
         influence_parameter_2_value = self.influence_parameter_2_value
 
-        measurements: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurements: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurements and not isinstance(self.measurements, Unset):
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
 
-        measurement_condition_factors: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_condition_factors: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_condition_factors and not isinstance(
             self.measurement_condition_factors, Unset
         ):
@@ -202,13 +196,13 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
                 )
                 measurement_condition_factors.append(measurement_condition_factors_item)
 
-        primary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        primary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.primary_measurement_tool and not isinstance(
             self.primary_measurement_tool, Unset
         ):
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
 
-        secondary_measurement_tool: Union[Unset, dict[str, Any]] = UNSET
+        secondary_measurement_tool: Union[None, Unset, dict[str, Any]] = UNSET
         if self.secondary_measurement_tool and not isinstance(
             self.secondary_measurement_tool, Unset
         ):
@@ -324,8 +318,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
         tolerance_type = d.pop("ToleranceType", UNSET)
 
         _tolerance_mode = d.pop("ToleranceMode", UNSET)
-        tolerance_mode: Union[
-            Unset,
+        tolerance_mode: Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceMode,
         ]
         if isinstance(_tolerance_mode, Unset):
@@ -336,8 +329,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
             )
 
         _tolerance_unit = d.pop("ToleranceUnit", UNSET)
-        tolerance_unit: Union[
-            Unset,
+        tolerance_unit: Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModelToleranceUnit,
         ]
         if isinstance(_tolerance_unit, Unset):
@@ -408,8 +400,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
             measurement_condition_factors.append(measurement_condition_factors_item)
 
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", UNSET)
-        primary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel
+        primary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel
         ]
         if isinstance(_primary_measurement_tool, Unset):
             primary_measurement_tool = UNSET
@@ -419,8 +410,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel:
             )
 
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", UNSET)
-        secondary_measurement_tool: Union[
-            Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel
+        secondary_measurement_tool: Union[None, Unset, QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel
         ]
         if isinstance(_secondary_measurement_tool, Unset):
             secondary_measurement_tool = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_response_model.py
@@ -15,18 +15,18 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsToUpdateMeasurementResponseMo
 class QualerApiModelsMeasurementsToUpdateMeasurementResponseModel:
     """
     Attributes:
-        measurement_id (Union[Unset, int]):
-        values (Union[Unset, str]):
-        channel (Union[Unset, int]):
-        updated_by (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
+        measurement_id (Union[None, Unset, int]):
+        values (Union[None, Unset, str]):
+        channel (Union[None, Unset, int]):
+        updated_by (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
     """
 
-    measurement_id: Union[Unset, int] = UNSET
-    values: Union[Unset, str] = UNSET
-    channel: Union[Unset, int] = UNSET
-    updated_by: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
+    measurement_id: Union[None, Unset, int] = UNSET
+    values: Union[None, Unset, str] = UNSET
+    channel: Union[None, Unset, int] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -38,7 +38,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementResponseModel:
 
         updated_by = self.updated_by
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -70,7 +70,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementResponseModel:
         updated_by = d.pop("UpdatedBy", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_set_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_set_response_model.py
@@ -28,55 +28,51 @@ T = TypeVar("T", bound="QualerApiModelsMeasurementsToUpdateMeasurementSetRespons
 class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
     """
     Attributes:
-        measurement_set_id (Union[Unset, int]):
-        measurement_name (Union[Unset, str]):
-        is_accredited (Union[Unset, bool]):
-        use_expected_value (Union[Unset, bool]):
-        decimal_places (Union[Unset, int]):
-        significant_figures (Union[Unset, int]):
-        influence_parameter_1_type (Union[Unset,
+        measurement_set_id (Union[None, Unset, int]):
+        measurement_name (Union[None, Unset, str]):
+        is_accredited (Union[None, Unset, bool]):
+        use_expected_value (Union[None, Unset, bool]):
+        decimal_places (Union[None, Unset, int]):
+        significant_figures (Union[None, Unset, int]):
+        influence_parameter_1_type (Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter1Type]):
-        influence_parameter_1_tool_type_id (Union[Unset, int]):
-        influence_parameter_1_parameter_id (Union[Unset, int]):
-        influence_parameter_1_source (Union[Unset, str]):
-        influence_parameter_1_value (Union[Unset, str]):
-        influence_parameter_2_type (Union[Unset,
+        influence_parameter_1_tool_type_id (Union[None, Unset, int]):
+        influence_parameter_1_parameter_id (Union[None, Unset, int]):
+        influence_parameter_1_source (Union[None, Unset, str]):
+        influence_parameter_1_value (Union[None, Unset, str]):
+        influence_parameter_2_type (Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter2Type]):
-        influence_parameter_2_tool_type_id (Union[Unset, int]):
-        influence_parameter_2_parameter_id (Union[Unset, int]):
-        influence_parameter_2_source (Union[Unset, str]):
-        influence_parameter_2_value (Union[Unset, str]):
-        measurement_points (Union[Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel']]):
-        measurement_fields (Union[Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementFieldResponseModel']]):
+        influence_parameter_2_tool_type_id (Union[None, Unset, int]):
+        influence_parameter_2_parameter_id (Union[None, Unset, int]):
+        influence_parameter_2_source (Union[None, Unset, str]):
+        influence_parameter_2_value (Union[None, Unset, str]):
+        measurement_points (Union[None, Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel']]):
+        measurement_fields (Union[None, Unset, list['QualerApiModelsMeasurementsToUpdateMeasurementFieldResponseModel']]):
     """
 
-    measurement_set_id: Union[Unset, int] = UNSET
-    measurement_name: Union[Unset, str] = UNSET
-    is_accredited: Union[Unset, bool] = UNSET
-    use_expected_value: Union[Unset, bool] = UNSET
-    decimal_places: Union[Unset, int] = UNSET
-    significant_figures: Union[Unset, int] = UNSET
-    influence_parameter_1_type: Union[
-        Unset,
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    measurement_name: Union[None, Unset, str] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    use_expected_value: Union[None, Unset, bool] = UNSET
+    decimal_places: Union[None, Unset, int] = UNSET
+    significant_figures: Union[None, Unset, int] = UNSET
+    influence_parameter_1_type: Union[None, Unset,
         QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter1Type,
     ] = UNSET
-    influence_parameter_1_tool_type_id: Union[Unset, int] = UNSET
-    influence_parameter_1_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_1_source: Union[Unset, str] = UNSET
-    influence_parameter_1_value: Union[Unset, str] = UNSET
-    influence_parameter_2_type: Union[
-        Unset,
+    influence_parameter_1_tool_type_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_1_source: Union[None, Unset, str] = UNSET
+    influence_parameter_1_value: Union[None, Unset, str] = UNSET
+    influence_parameter_2_type: Union[None, Unset,
         QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter2Type,
     ] = UNSET
-    influence_parameter_2_tool_type_id: Union[Unset, int] = UNSET
-    influence_parameter_2_parameter_id: Union[Unset, int] = UNSET
-    influence_parameter_2_source: Union[Unset, str] = UNSET
-    influence_parameter_2_value: Union[Unset, str] = UNSET
-    measurement_points: Union[
-        Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel"]
+    influence_parameter_2_tool_type_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_parameter_id: Union[None, Unset, int] = UNSET
+    influence_parameter_2_source: Union[None, Unset, str] = UNSET
+    influence_parameter_2_value: Union[None, Unset, str] = UNSET
+    measurement_points: Union[None, Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementPointResponseModel"]
     ] = UNSET
-    measurement_fields: Union[
-        Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementFieldResponseModel"]
+    measurement_fields: Union[None, Unset, list["QualerApiModelsMeasurementsToUpdateMeasurementFieldResponseModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -93,7 +89,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
 
         significant_figures = self.significant_figures
 
-        influence_parameter_1_type: Union[Unset, str] = UNSET
+        influence_parameter_1_type: Union[None, Unset, str] = UNSET
         if self.influence_parameter_1_type and not isinstance(
             self.influence_parameter_1_type, Unset
         ):
@@ -107,7 +103,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
 
         influence_parameter_1_value = self.influence_parameter_1_value
 
-        influence_parameter_2_type: Union[Unset, str] = UNSET
+        influence_parameter_2_type: Union[None, Unset, str] = UNSET
         if self.influence_parameter_2_type and not isinstance(
             self.influence_parameter_2_type, Unset
         ):
@@ -121,14 +117,14 @@ class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
 
         influence_parameter_2_value = self.influence_parameter_2_value
 
-        measurement_points: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_points: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_points and not isinstance(self.measurement_points, Unset):
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
 
-        measurement_fields: Union[Unset, list[dict[str, Any]]] = UNSET
+        measurement_fields: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.measurement_fields and not isinstance(self.measurement_fields, Unset):
             measurement_fields = []
             for measurement_fields_item_data in self.measurement_fields:
@@ -208,8 +204,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
         significant_figures = d.pop("SignificantFigures", UNSET)
 
         _influence_parameter_1_type = d.pop("InfluenceParameter1Type", UNSET)
-        influence_parameter_1_type: Union[
-            Unset,
+        influence_parameter_1_type: Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter1Type,
         ]
         if isinstance(_influence_parameter_1_type, Unset):
@@ -232,8 +227,7 @@ class QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModel:
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", UNSET)
 
         _influence_parameter_2_type = d.pop("InfluenceParameter2Type", UNSET)
-        influence_parameter_2_type: Union[
-            Unset,
+        influence_parameter_2_type: Union[None, Unset,
             QualerApiModelsMeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter2Type,
         ]
         if isinstance(_influence_parameter_2_type, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_tool_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_tool_response_model.py
@@ -17,34 +17,34 @@ T = TypeVar(
 class QualerApiModelsMeasurementsToUpdateMeasurementToolResponseModel:
     """
     Attributes:
-        measurement_tool_id (Union[Unset, int]):
+        measurement_tool_id (Union[None, Unset, int]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        calibrated_by (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        tool_name (Union[Unset, str]):
-        tool_description (Union[Unset, str]):
-        manufacturer (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
+        calibrated_by (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        tool_name (Union[None, Unset, str]):
+        tool_description (Union[None, Unset, str]):
+        manufacturer (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
     """
 
-    measurement_tool_id: Union[Unset, int] = UNSET
+    measurement_tool_id: Union[None, Unset, int] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    calibrated_by: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    tool_name: Union[Unset, str] = UNSET
-    tool_description: Union[Unset, str] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
+    calibrated_by: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    tool_name: Union[None, Unset, str] = UNSET
+    tool_description: Union[None, Unset, str] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_product_to_manufacturer_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_product_to_manufacturer_response_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsProductToManufacturerResponseModel")
 class QualerApiModelsProductToManufacturerResponseModel:
     """
     Attributes:
-        manufacturer_id (Union[Unset, int]):
-        manufacturer_name (Union[Unset, str]):
+        manufacturer_id (Union[None, Unset, int]):
+        manufacturer_name (Union[None, Unset, str]):
     """
 
-    manufacturer_id: Union[Unset, int] = UNSET
-    manufacturer_name: Union[Unset, str] = UNSET
+    manufacturer_id: Union[None, Unset, int] = UNSET
+    manufacturer_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_product_to_product_api_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_product_to_product_api_response_model.py
@@ -13,44 +13,44 @@ T = TypeVar("T", bound="QualerApiModelsProductToProductApiResponseModel")
 class QualerApiModelsProductToProductApiResponseModel:
     """
     Attributes:
-        product_id (Union[Unset, int]):
-        parent_product_id (Union[Unset, int]):
-        category_id (Union[Unset, int]):
-        manufacturer_id (Union[Unset, int]):
-        manufacturer_name (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        parent_product_name (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        is_family (Union[Unset, bool]):
-        is_discontinued (Union[Unset, bool]):
-        is_stock_item (Union[Unset, bool]):
-        unit_sale_price (Union[Unset, float]):
-        supplier_information (Union[Unset, str]):
-        quantity_on_hand (Union[Unset, int]):
-        product_code (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        parent_category_name (Union[Unset, str]):
+        product_id (Union[None, Unset, int]):
+        parent_product_id (Union[None, Unset, int]):
+        category_id (Union[None, Unset, int]):
+        manufacturer_id (Union[None, Unset, int]):
+        manufacturer_name (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        parent_product_name (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        is_family (Union[None, Unset, bool]):
+        is_discontinued (Union[None, Unset, bool]):
+        is_stock_item (Union[None, Unset, bool]):
+        unit_sale_price (Union[None, Unset, float]):
+        supplier_information (Union[None, Unset, str]):
+        quantity_on_hand (Union[None, Unset, int]):
+        product_code (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        parent_category_name (Union[None, Unset, str]):
     """
 
-    product_id: Union[Unset, int] = UNSET
-    parent_product_id: Union[Unset, int] = UNSET
-    category_id: Union[Unset, int] = UNSET
-    manufacturer_id: Union[Unset, int] = UNSET
-    manufacturer_name: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    parent_product_name: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    is_family: Union[Unset, bool] = UNSET
-    is_discontinued: Union[Unset, bool] = UNSET
-    is_stock_item: Union[Unset, bool] = UNSET
-    unit_sale_price: Union[Unset, float] = UNSET
-    supplier_information: Union[Unset, str] = UNSET
-    quantity_on_hand: Union[Unset, int] = UNSET
-    product_code: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    parent_category_name: Union[Unset, str] = UNSET
+    product_id: Union[None, Unset, int] = UNSET
+    parent_product_id: Union[None, Unset, int] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    manufacturer_id: Union[None, Unset, int] = UNSET
+    manufacturer_name: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    parent_product_name: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    is_family: Union[None, Unset, bool] = UNSET
+    is_discontinued: Union[None, Unset, bool] = UNSET
+    is_stock_item: Union[None, Unset, bool] = UNSET
+    unit_sale_price: Union[None, Unset, float] = UNSET
+    supplier_information: Union[None, Unset, str] = UNSET
+    quantity_on_hand: Union[None, Unset, int] = UNSET
+    product_code: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    parent_category_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_reference_to_measurement_quantity_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_reference_to_measurement_quantity_response.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsReferenceToMeasurementQuantityResponse")
 class QualerApiModelsReferenceToMeasurementQuantityResponse:
     """
     Attributes:
-        measurement_quantity_id (Union[Unset, int]):
-        measurement_quantity (Union[Unset, str]):
+        measurement_quantity_id (Union[None, Unset, int]):
+        measurement_quantity (Union[None, Unset, str]):
     """
 
-    measurement_quantity_id: Union[Unset, int] = UNSET
-    measurement_quantity: Union[Unset, str] = UNSET
+    measurement_quantity_id: Union[None, Unset, int] = UNSET
+    measurement_quantity: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_reference_to_unit_of_measure_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_reference_to_unit_of_measure_response.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="QualerApiModelsReferenceToUnitOfMeasureResponse")
 class QualerApiModelsReferenceToUnitOfMeasureResponse:
     """
     Attributes:
-        measurement_quantity_id (Union[Unset, int]):
-        measurement_quantity (Union[Unset, str]):
-        unit_of_measure_id (Union[Unset, int]):
-        unit_of_measure (Union[Unset, str]):
+        measurement_quantity_id (Union[None, Unset, int]):
+        measurement_quantity (Union[None, Unset, str]):
+        unit_of_measure_id (Union[None, Unset, int]):
+        unit_of_measure (Union[None, Unset, str]):
     """
 
-    measurement_quantity_id: Union[Unset, int] = UNSET
-    measurement_quantity: Union[Unset, str] = UNSET
-    unit_of_measure_id: Union[Unset, int] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
+    measurement_quantity_id: Union[None, Unset, int] = UNSET
+    measurement_quantity: Union[None, Unset, str] = UNSET
+    unit_of_measure_id: Union[None, Unset, int] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
@@ -13,16 +13,16 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToAssetAttributeResponse")
 class QualerApiModelsReportDatasetsToAssetAttributeResponse:
     """
     Attributes:
-        asset_id (Union[Unset, int]):
-        attribute_name (Union[Unset, str]):
-        attribute_value (Union[Unset, str]):
-        is_service (Union[Unset, bool]):
+        asset_id (Union[None, Unset, int]):
+        attribute_name (Union[None, Unset, str]):
+        attribute_value (Union[None, Unset, str]):
+        is_service (Union[None, Unset, bool]):
     """
 
-    asset_id: Union[Unset, int] = UNSET
-    attribute_name: Union[Unset, str] = UNSET
-    attribute_value: Union[Unset, str] = UNSET
-    is_service: Union[Unset, bool] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    attribute_name: Union[None, Unset, str] = UNSET
+    attribute_value: Union[None, Unset, str] = UNSET
+    is_service: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_summary_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_summary_response.py
@@ -15,36 +15,36 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToAssetSummaryResponse")
 class QualerApiModelsReportDatasetsToAssetSummaryResponse:
     """
     Attributes:
-        service_order_number (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        is_limited (Union[Unset, bool]):
-        certificate_number (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
+        service_order_number (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        is_limited (Union[None, Unset, bool]):
+        certificate_number (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
         next_service_date (Union[None, Unset, datetime.datetime]):
         service_date (Union[None, Unset, datetime.datetime]):
-        part_number (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        class_ (Union[Unset, str]):
-        condition (Union[Unset, str]):
-        criticality (Union[Unset, str]):
-        asset_pool (Union[Unset, str]):
-        room (Union[Unset, str]):
-        station (Union[Unset, str]):
-        service_notes (Union[Unset, str]):
-        service_level (Union[Unset, str]):
-        service_level_code (Union[Unset, str]):
-        next_service_level (Union[Unset, str]):
-        next_service_level_code (Union[Unset, str]):
-        asset_id (Union[Unset, int]):
+        part_number (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        class_ (Union[None, Unset, str]):
+        condition (Union[None, Unset, str]):
+        criticality (Union[None, Unset, str]):
+        asset_pool (Union[None, Unset, str]):
+        room (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        service_notes (Union[None, Unset, str]):
+        service_level (Union[None, Unset, str]):
+        service_level_code (Union[None, Unset, str]):
+        next_service_level (Union[None, Unset, str]):
+        next_service_level_code (Union[None, Unset, str]):
+        asset_id (Union[None, Unset, int]):
         result_status (Union[None, Unset, int]):
         serial_number_change (Union[None, Unset, str]):
         provider_technician (Union[None, Unset, str]):
@@ -73,36 +73,36 @@ class QualerApiModelsReportDatasetsToAssetSummaryResponse:
         interval_cycle (Union[None, Unset, str]):
     """
 
-    service_order_number: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    class_: Union[Unset, str] = UNSET
-    condition: Union[Unset, str] = UNSET
-    criticality: Union[Unset, str] = UNSET
-    asset_pool: Union[Unset, str] = UNSET
-    room: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    service_notes: Union[Unset, str] = UNSET
-    service_level: Union[Unset, str] = UNSET
-    service_level_code: Union[Unset, str] = UNSET
-    next_service_level: Union[Unset, str] = UNSET
-    next_service_level_code: Union[Unset, str] = UNSET
-    asset_id: Union[Unset, int] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    class_: Union[None, Unset, str] = UNSET
+    condition: Union[None, Unset, str] = UNSET
+    criticality: Union[None, Unset, str] = UNSET
+    asset_pool: Union[None, Unset, str] = UNSET
+    room: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    service_notes: Union[None, Unset, str] = UNSET
+    service_level: Union[None, Unset, str] = UNSET
+    service_level_code: Union[None, Unset, str] = UNSET
+    next_service_level: Union[None, Unset, str] = UNSET
+    next_service_level_code: Union[None, Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
     result_status: Union[None, Unset, int] = UNSET
     serial_number_change: Union[None, Unset, str] = UNSET
     provider_technician: Union[None, Unset, str] = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_client_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_client_attribute_response.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToClientAttributeResponse")
 class QualerApiModelsReportDatasetsToClientAttributeResponse:
     """
     Attributes:
-        attribute_name (Union[Unset, str]):
-        attribute_value (Union[Unset, str]):
+        attribute_name (Union[None, Unset, str]):
+        attribute_value (Union[None, Unset, str]):
     """
 
-    attribute_name: Union[Unset, str] = UNSET
-    attribute_value: Union[Unset, str] = UNSET
+    attribute_name: Union[None, Unset, str] = UNSET
+    attribute_value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_company_certification_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_company_certification_response.py
@@ -15,38 +15,38 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToCompanyCertificationRespo
 class QualerApiModelsReportDatasetsToCompanyCertificationResponse:
     """
     Attributes:
-        logo (Union[Unset, str]):
-        initial_date (Union[Unset, datetime.datetime]):
-        certification_date (Union[Unset, datetime.datetime]):
-        expiration_date (Union[Unset, datetime.datetime]):
-        certification_name (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        certification_authority (Union[Unset, str]):
-        certification_standard (Union[Unset, str]):
+        logo (Union[None, Unset, str]):
+        initial_date (Union[None, Unset, datetime.datetime]):
+        certification_date (Union[None, Unset, datetime.datetime]):
+        expiration_date (Union[None, Unset, datetime.datetime]):
+        certification_name (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        certification_authority (Union[None, Unset, str]):
+        certification_standard (Union[None, Unset, str]):
     """
 
-    logo: Union[Unset, str] = UNSET
-    initial_date: Union[Unset, datetime.datetime] = UNSET
-    certification_date: Union[Unset, datetime.datetime] = UNSET
-    expiration_date: Union[Unset, datetime.datetime] = UNSET
-    certification_name: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
-    certification_authority: Union[Unset, str] = UNSET
-    certification_standard: Union[Unset, str] = UNSET
+    logo: Union[None, Unset, str] = UNSET
+    initial_date: Union[None, Unset, datetime.datetime] = UNSET
+    certification_date: Union[None, Unset, datetime.datetime] = UNSET
+    expiration_date: Union[None, Unset, datetime.datetime] = UNSET
+    certification_name: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    certification_authority: Union[None, Unset, str] = UNSET
+    certification_standard: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         logo = self.logo
 
-        initial_date: Union[Unset, str] = UNSET
+        initial_date: Union[None, Unset, str] = UNSET
         if self.initial_date and not isinstance(self.initial_date, Unset):
             initial_date = self.initial_date.isoformat()
 
-        certification_date: Union[Unset, str] = UNSET
+        certification_date: Union[None, Unset, str] = UNSET
         if self.certification_date and not isinstance(self.certification_date, Unset):
             certification_date = self.certification_date.isoformat()
 
-        expiration_date: Union[Unset, str] = UNSET
+        expiration_date: Union[None, Unset, str] = UNSET
         if self.expiration_date and not isinstance(self.expiration_date, Unset):
             expiration_date = self.expiration_date.isoformat()
 
@@ -86,21 +86,21 @@ class QualerApiModelsReportDatasetsToCompanyCertificationResponse:
         logo = d.pop("Logo", UNSET)
 
         _initial_date = d.pop("InitialDate", UNSET)
-        initial_date: Union[Unset, datetime.datetime]
+        initial_date: Union[None, Unset, datetime.datetime]
         if isinstance(_initial_date, Unset):
             initial_date = UNSET
         else:
             initial_date = isoparse(_initial_date)
 
         _certification_date = d.pop("CertificationDate", UNSET)
-        certification_date: Union[Unset, datetime.datetime]
+        certification_date: Union[None, Unset, datetime.datetime]
         if isinstance(_certification_date, Unset):
             certification_date = UNSET
         else:
             certification_date = isoparse(_certification_date)
 
         _expiration_date = d.pop("ExpirationDate", UNSET)
-        expiration_date: Union[Unset, datetime.datetime]
+        expiration_date: Union[None, Unset, datetime.datetime]
         if isinstance(_expiration_date, Unset):
             expiration_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_external_data_report_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_external_data_report_response.py
@@ -13,66 +13,66 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToExternalDataReportRespons
 class QualerApiModelsReportDatasetsToExternalDataReportResponse:
     """
     Attributes:
-        measurement_set_id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        row (Union[Unset, int]):
-        a (Union[Unset, str]):
-        b (Union[Unset, str]):
-        c (Union[Unset, str]):
-        d (Union[Unset, str]):
-        e (Union[Unset, str]):
-        f (Union[Unset, str]):
-        g (Union[Unset, str]):
-        h (Union[Unset, str]):
-        i (Union[Unset, str]):
-        j (Union[Unset, str]):
-        k (Union[Unset, str]):
-        l (Union[Unset, str]):
-        m (Union[Unset, str]):
-        n (Union[Unset, str]):
-        o (Union[Unset, str]):
-        p (Union[Unset, str]):
-        q (Union[Unset, str]):
-        r (Union[Unset, str]):
-        s (Union[Unset, str]):
-        t (Union[Unset, str]):
-        u (Union[Unset, str]):
-        v (Union[Unset, str]):
-        w (Union[Unset, str]):
-        x (Union[Unset, str]):
-        y (Union[Unset, str]):
-        z (Union[Unset, str]):
+        measurement_set_id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        row (Union[None, Unset, int]):
+        a (Union[None, Unset, str]):
+        b (Union[None, Unset, str]):
+        c (Union[None, Unset, str]):
+        d (Union[None, Unset, str]):
+        e (Union[None, Unset, str]):
+        f (Union[None, Unset, str]):
+        g (Union[None, Unset, str]):
+        h (Union[None, Unset, str]):
+        i (Union[None, Unset, str]):
+        j (Union[None, Unset, str]):
+        k (Union[None, Unset, str]):
+        l (Union[None, Unset, str]):
+        m (Union[None, Unset, str]):
+        n (Union[None, Unset, str]):
+        o (Union[None, Unset, str]):
+        p (Union[None, Unset, str]):
+        q (Union[None, Unset, str]):
+        r (Union[None, Unset, str]):
+        s (Union[None, Unset, str]):
+        t (Union[None, Unset, str]):
+        u (Union[None, Unset, str]):
+        v (Union[None, Unset, str]):
+        w (Union[None, Unset, str]):
+        x (Union[None, Unset, str]):
+        y (Union[None, Unset, str]):
+        z (Union[None, Unset, str]):
     """
 
-    measurement_set_id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    row: Union[Unset, int] = UNSET
-    a: Union[Unset, str] = UNSET
-    b: Union[Unset, str] = UNSET
-    c: Union[Unset, str] = UNSET
-    d: Union[Unset, str] = UNSET
-    e: Union[Unset, str] = UNSET
-    f: Union[Unset, str] = UNSET
-    g: Union[Unset, str] = UNSET
-    h: Union[Unset, str] = UNSET
-    i: Union[Unset, str] = UNSET
-    j: Union[Unset, str] = UNSET
-    k: Union[Unset, str] = UNSET
-    l: Union[Unset, str] = UNSET
-    m: Union[Unset, str] = UNSET
-    n: Union[Unset, str] = UNSET
-    o: Union[Unset, str] = UNSET
-    p: Union[Unset, str] = UNSET
-    q: Union[Unset, str] = UNSET
-    r: Union[Unset, str] = UNSET
-    s: Union[Unset, str] = UNSET
-    t: Union[Unset, str] = UNSET
-    u: Union[Unset, str] = UNSET
-    v: Union[Unset, str] = UNSET
-    w: Union[Unset, str] = UNSET
-    x: Union[Unset, str] = UNSET
-    y: Union[Unset, str] = UNSET
-    z: Union[Unset, str] = UNSET
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    row: Union[None, Unset, int] = UNSET
+    a: Union[None, Unset, str] = UNSET
+    b: Union[None, Unset, str] = UNSET
+    c: Union[None, Unset, str] = UNSET
+    d: Union[None, Unset, str] = UNSET
+    e: Union[None, Unset, str] = UNSET
+    f: Union[None, Unset, str] = UNSET
+    g: Union[None, Unset, str] = UNSET
+    h: Union[None, Unset, str] = UNSET
+    i: Union[None, Unset, str] = UNSET
+    j: Union[None, Unset, str] = UNSET
+    k: Union[None, Unset, str] = UNSET
+    l: Union[None, Unset, str] = UNSET
+    m: Union[None, Unset, str] = UNSET
+    n: Union[None, Unset, str] = UNSET
+    o: Union[None, Unset, str] = UNSET
+    p: Union[None, Unset, str] = UNSET
+    q: Union[None, Unset, str] = UNSET
+    r: Union[None, Unset, str] = UNSET
+    s: Union[None, Unset, str] = UNSET
+    t: Union[None, Unset, str] = UNSET
+    u: Union[None, Unset, str] = UNSET
+    v: Union[None, Unset, str] = UNSET
+    w: Union[None, Unset, str] = UNSET
+    x: Union[None, Unset, str] = UNSET
+    y: Union[None, Unset, str] = UNSET
+    z: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
@@ -46,1282 +46,1272 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToMeasurementAllResponse")
 class QualerApiModelsReportDatasetsToMeasurementAllResponse:
     """
     Attributes:
-        barcode (Union[Unset, str]):
-        display_name (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        part_number (Union[Unset, str]):
-        vendor_company_id (Union[Unset, int]):
-        service_order_number (Union[Unset, int]):
-        completed_by_name (Union[Unset, str]):
-        completed_on (Union[Unset, datetime.datetime]):
-        is_limited (Union[Unset, bool]):
-        vendor_tag (Union[Unset, str]):
-        room (Union[Unset, str]):
-        segment_name (Union[Unset, str]):
-        schedule_name (Union[Unset, str]):
-        next_segment_name (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        work_status (Union[Unset, WorkStatus]):
-        service_type (Union[Unset, str]):
-        service_level (Union[Unset, str]):
-        service_comments (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        asset_tag_change (Union[Unset, str]):
-        asset_user_change (Union[Unset, str]):
-        serial_number_change (Union[Unset, str]):
+        barcode (Union[None, Unset, str]):
+        display_name (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        part_number (Union[None, Unset, str]):
+        vendor_company_id (Union[None, Unset, int]):
+        service_order_number (Union[None, Unset, int]):
+        completed_by_name (Union[None, Unset, str]):
+        completed_on (Union[None, Unset, datetime.datetime]):
+        is_limited (Union[None, Unset, bool]):
+        vendor_tag (Union[None, Unset, str]):
+        room (Union[None, Unset, str]):
+        segment_name (Union[None, Unset, str]):
+        schedule_name (Union[None, Unset, str]):
+        next_segment_name (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        work_status (Union[None, Unset, WorkStatus]):
+        service_type (Union[None, Unset, str]):
+        service_level (Union[None, Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        asset_tag_change (Union[None, Unset, str]):
+        asset_user_change (Union[None, Unset, str]):
+        serial_number_change (Union[None, Unset, str]):
         service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        service_order_item_id (Union[Unset, int]):
-        site_name (Union[Unset, str]):
-        po_number (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        site_name (Union[None, Unset, str]):
+        po_number (Union[None, Unset, str]):
         shipped_date (Union[None, Unset, datetime.datetime]):
-        tracking_number (Union[Unset, str]):
-        payment_terms (Union[Unset, int]):
-        shipping_method (Union[Unset, str]):
-        location (Union[Unset, str]):
-        site_access_notes (Union[Unset, str]):
-        as_left_decimal_places (Union[Unset, int]):
-        as_left_measurement_set_name (Union[Unset, str]):
-        as_left_measurement_set_id (Union[Unset, int]):
-        as_left_adjustment_threshold (Union[Unset, float]):
-        as_left_mean_extended (Union[Unset, str]):
-        as_left_sd_extended (Union[Unset, str]):
-        as_left_range_extended (Union[Unset, str]):
-        as_left_delta_extended (Union[Unset, str]):
-        as_left_cv_extended (Union[Unset, str]):
-        as_left_nominal_extended (Union[Unset, str]):
-        as_left_min_max_header (Union[Unset, str]):
-        as_left_accuracy_class (Union[Unset, str]):
-        as_left_accuracy_class_min (Union[Unset, float]):
-        as_left_accuracy_class_max (Union[Unset, float]):
-        as_left_minimum_measured_value (Union[Unset, float]):
-        as_left_maxi_mum_measured_value (Union[Unset, float]):
-        as_left_min_max_value_extended (Union[Unset, str]):
-        as_left_tool_range_name (Union[Unset, str]):
-        as_left_tool_range_uncertainty (Union[Unset, str]):
+        tracking_number (Union[None, Unset, str]):
+        payment_terms (Union[None, Unset, int]):
+        shipping_method (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        site_access_notes (Union[None, Unset, str]):
+        as_left_decimal_places (Union[None, Unset, int]):
+        as_left_measurement_set_name (Union[None, Unset, str]):
+        as_left_measurement_set_id (Union[None, Unset, int]):
+        as_left_adjustment_threshold (Union[None, Unset, float]):
+        as_left_mean_extended (Union[None, Unset, str]):
+        as_left_sd_extended (Union[None, Unset, str]):
+        as_left_range_extended (Union[None, Unset, str]):
+        as_left_delta_extended (Union[None, Unset, str]):
+        as_left_cv_extended (Union[None, Unset, str]):
+        as_left_nominal_extended (Union[None, Unset, str]):
+        as_left_min_max_header (Union[None, Unset, str]):
+        as_left_accuracy_class (Union[None, Unset, str]):
+        as_left_accuracy_class_min (Union[None, Unset, float]):
+        as_left_accuracy_class_max (Union[None, Unset, float]):
+        as_left_minimum_measured_value (Union[None, Unset, float]):
+        as_left_maxi_mum_measured_value (Union[None, Unset, float]):
+        as_left_min_max_value_extended (Union[None, Unset, str]):
+        as_left_tool_range_name (Union[None, Unset, str]):
+        as_left_tool_range_uncertainty (Union[None, Unset, str]):
         as_left_primary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         as_left_primary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        as_left_primary_tool_calibrated_by (Union[Unset, str]):
-        as_left_primary_tool_tool_name (Union[Unset, str]):
-        as_left_primary_tool_tool_description (Union[Unset, str]):
-        as_left_primary_tool_tool_type_name (Union[Unset, str]):
-        as_left_primary_tool_manufacturer (Union[Unset, str]):
-        as_left_primary_tool_manufacturer_part_number (Union[Unset, str]):
-        as_left_primary_tool_serial_number (Union[Unset, str]):
-        as_found_measurement_set_name (Union[Unset, str]):
-        as_found_measurement_set_id (Union[Unset, int]):
-        as_found_adjustment_threshold (Union[Unset, float]):
-        as_found_decimal_places (Union[Unset, int]):
-        as_found_mean_extended (Union[Unset, str]):
-        as_found_sd_extended (Union[Unset, str]):
-        as_found_range_extended (Union[Unset, str]):
-        as_found_delta_extended (Union[Unset, str]):
-        as_found_cv_extended (Union[Unset, str]):
-        as_found_nominal_extended (Union[Unset, str]):
-        as_found_min_max_header (Union[Unset, str]):
-        as_found_accuracy_class (Union[Unset, str]):
-        as_found_accuracy_class_min (Union[Unset, float]):
-        as_found_accuracy_class_max (Union[Unset, float]):
-        as_found_minimum_measured_value (Union[Unset, float]):
-        as_found_maxi_mum_measured_value (Union[Unset, float]):
-        as_found_min_max_value_extended (Union[Unset, str]):
-        as_found_tool_range_name (Union[Unset, str]):
-        as_found_tool_range_uncertainty (Union[Unset, str]):
+        as_left_primary_tool_calibrated_by (Union[None, Unset, str]):
+        as_left_primary_tool_tool_name (Union[None, Unset, str]):
+        as_left_primary_tool_tool_description (Union[None, Unset, str]):
+        as_left_primary_tool_tool_type_name (Union[None, Unset, str]):
+        as_left_primary_tool_manufacturer (Union[None, Unset, str]):
+        as_left_primary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        as_left_primary_tool_serial_number (Union[None, Unset, str]):
+        as_found_measurement_set_name (Union[None, Unset, str]):
+        as_found_measurement_set_id (Union[None, Unset, int]):
+        as_found_adjustment_threshold (Union[None, Unset, float]):
+        as_found_decimal_places (Union[None, Unset, int]):
+        as_found_mean_extended (Union[None, Unset, str]):
+        as_found_sd_extended (Union[None, Unset, str]):
+        as_found_range_extended (Union[None, Unset, str]):
+        as_found_delta_extended (Union[None, Unset, str]):
+        as_found_cv_extended (Union[None, Unset, str]):
+        as_found_nominal_extended (Union[None, Unset, str]):
+        as_found_min_max_header (Union[None, Unset, str]):
+        as_found_accuracy_class (Union[None, Unset, str]):
+        as_found_accuracy_class_min (Union[None, Unset, float]):
+        as_found_accuracy_class_max (Union[None, Unset, float]):
+        as_found_minimum_measured_value (Union[None, Unset, float]):
+        as_found_maxi_mum_measured_value (Union[None, Unset, float]):
+        as_found_min_max_value_extended (Union[None, Unset, str]):
+        as_found_tool_range_name (Union[None, Unset, str]):
+        as_found_tool_range_uncertainty (Union[None, Unset, str]):
         as_found_primary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         as_found_primary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        as_found_primary_tool_calibrated_by (Union[Unset, str]):
-        as_found_primary_tool_tool_name (Union[Unset, str]):
-        as_found_primary_tool_tool_description (Union[Unset, str]):
-        as_found_primary_tool_tool_type_name (Union[Unset, str]):
-        as_found_primary_tool_manufacturer (Union[Unset, str]):
-        as_found_primary_tool_manufacturer_part_number (Union[Unset, str]):
-        as_found_primary_tool_serial_number (Union[Unset, str]):
+        as_found_primary_tool_calibrated_by (Union[None, Unset, str]):
+        as_found_primary_tool_tool_name (Union[None, Unset, str]):
+        as_found_primary_tool_tool_description (Union[None, Unset, str]):
+        as_found_primary_tool_tool_type_name (Union[None, Unset, str]):
+        as_found_primary_tool_manufacturer (Union[None, Unset, str]):
+        as_found_primary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        as_found_primary_tool_serial_number (Union[None, Unset, str]):
         as_left_secondary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         as_left_secondary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        as_left_secondary_tool_calibrated_by (Union[Unset, str]):
-        as_left_secondary_tool_tool_name (Union[Unset, str]):
-        as_left_secondary_tool_tool_description (Union[Unset, str]):
-        as_left_secondary_tool_tool_type_name (Union[Unset, str]):
-        as_left_secondary_tool_manufacturer (Union[Unset, str]):
-        as_left_secondary_tool_manufacturer_part_number (Union[Unset, str]):
-        as_left_secondary_tool_serial_number (Union[Unset, str]):
+        as_left_secondary_tool_calibrated_by (Union[None, Unset, str]):
+        as_left_secondary_tool_tool_name (Union[None, Unset, str]):
+        as_left_secondary_tool_tool_description (Union[None, Unset, str]):
+        as_left_secondary_tool_tool_type_name (Union[None, Unset, str]):
+        as_left_secondary_tool_manufacturer (Union[None, Unset, str]):
+        as_left_secondary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        as_left_secondary_tool_serial_number (Union[None, Unset, str]):
         as_found_secondary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         as_found_secondary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        as_found_secondary_tool_calibrated_by (Union[Unset, str]):
-        as_found_secondary_tool_tool_name (Union[Unset, str]):
-        as_found_secondary_tool_tool_description (Union[Unset, str]):
-        as_found_secondary_tool_tool_type_name (Union[Unset, str]):
-        as_found_secondary_tool_manufacturer (Union[Unset, str]):
-        as_found_secondary_tool_manufacturer_part_number (Union[Unset, str]):
-        as_found_secondary_tool_serial_number (Union[Unset, str]):
-        as_found_measurement_not_taken_result (Union[Unset,
+        as_found_secondary_tool_calibrated_by (Union[None, Unset, str]):
+        as_found_secondary_tool_tool_name (Union[None, Unset, str]):
+        as_found_secondary_tool_tool_description (Union[None, Unset, str]):
+        as_found_secondary_tool_tool_type_name (Union[None, Unset, str]):
+        as_found_secondary_tool_manufacturer (Union[None, Unset, str]):
+        as_found_secondary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        as_found_secondary_tool_serial_number (Union[None, Unset, str]):
+        as_found_measurement_not_taken_result (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementNotTakenResult]):
-        as_found_hide_from_certificate (Union[Unset, bool]):
-        as_found_measurement_not_taken_reason (Union[Unset, str]):
-        as_left_values (Union[Unset, str]):
-        as_left_is_accredited (Union[Unset, bool]):
-        as_left_is_range_accredited (Union[Unset, bool]):
-        as_found_values (Union[Unset, str]):
-        as_found_is_accredited (Union[Unset, bool]):
-        as_found_is_range_accredited (Union[Unset, bool]):
-        as_found_parameter_id (Union[Unset, int]):
-        as_found_sd_header (Union[Unset, float]):
-        as_found_cv_header (Union[Unset, float]):
-        as_found_measurement_local_time (Union[Unset, datetime.datetime]):
-        as_found_tur (Union[Unset, float]):
-        as_found_tur_raw (Union[Unset, float]):
-        as_left_tur (Union[Unset, float]):
-        as_left_tur_raw (Union[Unset, float]):
-        as_found_tar (Union[Unset, float]):
-        as_found_tar_raw (Union[Unset, float]):
-        as_left_tar (Union[Unset, float]):
-        as_left_tar_raw (Union[Unset, float]):
-        as_found_guard_band (Union[Unset, str]):
-        as_left_guard_band (Union[Unset, str]):
-        as_found_guard_band_logic (Union[Unset,
+        as_found_hide_from_certificate (Union[None, Unset, bool]):
+        as_found_measurement_not_taken_reason (Union[None, Unset, str]):
+        as_left_values (Union[None, Unset, str]):
+        as_left_is_accredited (Union[None, Unset, bool]):
+        as_left_is_range_accredited (Union[None, Unset, bool]):
+        as_found_values (Union[None, Unset, str]):
+        as_found_is_accredited (Union[None, Unset, bool]):
+        as_found_is_range_accredited (Union[None, Unset, bool]):
+        as_found_parameter_id (Union[None, Unset, int]):
+        as_found_sd_header (Union[None, Unset, float]):
+        as_found_cv_header (Union[None, Unset, float]):
+        as_found_measurement_local_time (Union[None, Unset, datetime.datetime]):
+        as_found_tur (Union[None, Unset, float]):
+        as_found_tur_raw (Union[None, Unset, float]):
+        as_left_tur (Union[None, Unset, float]):
+        as_left_tur_raw (Union[None, Unset, float]):
+        as_found_tar (Union[None, Unset, float]):
+        as_found_tar_raw (Union[None, Unset, float]):
+        as_left_tar (Union[None, Unset, float]):
+        as_left_tar_raw (Union[None, Unset, float]):
+        as_found_guard_band (Union[None, Unset, str]):
+        as_left_guard_band (Union[None, Unset, str]):
+        as_found_guard_band_logic (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundGuardBandLogic]):
-        as_left_guard_band_logic (Union[Unset,
+        as_left_guard_band_logic (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftGuardBandLogic]):
-        as_found_error (Union[Unset, float]):
-        as_found_error_extended (Union[Unset, str]):
-        as_left_error (Union[Unset, float]):
-        as_left_error_extended (Union[Unset, str]):
-        as_found_percent_of_tolerance (Union[Unset, float]):
-        as_found_percent_of_tolerance_extended (Union[Unset, str]):
-        as_left_percent_of_tolerance (Union[Unset, float]):
-        as_left_percent_of_tolerance_extended (Union[Unset, str]):
-        as_found_tolerance_maximum (Union[Unset, float]):
-        as_found_tolerance_minimum (Union[Unset, float]):
-        as_found_tolerance_type (Union[Unset, int]):
-        as_found_tolerance_mode (Union[Unset, int]):
-        as_found_tolerance_string (Union[Unset, str]):
-        as_left_tolerance_maximum (Union[Unset, float]):
-        as_left_tolerance_minimum (Union[Unset, float]):
-        as_left_tolerance_type (Union[Unset, int]):
-        as_left_tolerance_mode (Union[Unset, int]):
-        as_left_tolerance_string (Union[Unset, str]):
-        as_found_max_hysteresis (Union[Unset, float]):
-        as_found_run (Union[Unset, int]):
-        as_found_direction (Union[Unset, int]):
-        as_found_hysteresis (Union[Unset, float]):
-        as_left_max_hysteresis (Union[Unset, float]):
-        as_left_run (Union[Unset, int]):
-        as_left_direction (Union[Unset, int]):
-        as_left_hysteresis (Union[Unset, float]):
-        as_found_reading_entry_math (Union[Unset,
+        as_found_error (Union[None, Unset, float]):
+        as_found_error_extended (Union[None, Unset, str]):
+        as_left_error (Union[None, Unset, float]):
+        as_left_error_extended (Union[None, Unset, str]):
+        as_found_percent_of_tolerance (Union[None, Unset, float]):
+        as_found_percent_of_tolerance_extended (Union[None, Unset, str]):
+        as_left_percent_of_tolerance (Union[None, Unset, float]):
+        as_left_percent_of_tolerance_extended (Union[None, Unset, str]):
+        as_found_tolerance_maximum (Union[None, Unset, float]):
+        as_found_tolerance_minimum (Union[None, Unset, float]):
+        as_found_tolerance_type (Union[None, Unset, int]):
+        as_found_tolerance_mode (Union[None, Unset, int]):
+        as_found_tolerance_string (Union[None, Unset, str]):
+        as_left_tolerance_maximum (Union[None, Unset, float]):
+        as_left_tolerance_minimum (Union[None, Unset, float]):
+        as_left_tolerance_type (Union[None, Unset, int]):
+        as_left_tolerance_mode (Union[None, Unset, int]):
+        as_left_tolerance_string (Union[None, Unset, str]):
+        as_found_max_hysteresis (Union[None, Unset, float]):
+        as_found_run (Union[None, Unset, int]):
+        as_found_direction (Union[None, Unset, int]):
+        as_found_hysteresis (Union[None, Unset, float]):
+        as_left_max_hysteresis (Union[None, Unset, float]):
+        as_left_run (Union[None, Unset, int]):
+        as_left_direction (Union[None, Unset, int]):
+        as_left_hysteresis (Union[None, Unset, float]):
+        as_found_reading_entry_math (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundReadingEntryMath]):
-        as_found_reading_entry_math_string (Union[Unset, str]):
-        as_found_value_1 (Union[Unset, str]):
-        as_found_value_2 (Union[Unset, str]):
-        as_found_value_3 (Union[Unset, str]):
-        as_found_value_4 (Union[Unset, str]):
-        as_found_value_5 (Union[Unset, str]):
-        as_found_value_6 (Union[Unset, str]):
-        as_found_value_7 (Union[Unset, str]):
-        as_found_value_8 (Union[Unset, str]):
-        as_found_value_9 (Union[Unset, str]):
-        as_found_value_10 (Union[Unset, str]):
-        as_found_value_11 (Union[Unset, str]):
-        as_found_value_12 (Union[Unset, str]):
-        as_found_value_13 (Union[Unset, str]):
-        as_found_value_14 (Union[Unset, str]):
-        as_found_value_15 (Union[Unset, str]):
-        as_found_value_16 (Union[Unset, str]):
-        as_found_value_17 (Union[Unset, str]):
-        as_found_value_18 (Union[Unset, str]):
-        as_found_value_19 (Union[Unset, str]):
-        as_found_value_20 (Union[Unset, str]):
-        as_found_value_21 (Union[Unset, str]):
-        as_found_value_22 (Union[Unset, str]):
-        as_found_value_23 (Union[Unset, str]):
-        as_found_value_24 (Union[Unset, str]):
-        as_found_value_25 (Union[Unset, str]):
-        as_found_value_26 (Union[Unset, str]):
-        as_found_value_27 (Union[Unset, str]):
-        as_found_value_28 (Union[Unset, str]):
-        as_found_value_29 (Union[Unset, str]):
-        as_found_value_30 (Union[Unset, str]):
-        as_found_value_31 (Union[Unset, str]):
-        as_found_value_32 (Union[Unset, str]):
-        as_found_value_33 (Union[Unset, str]):
-        as_found_value_34 (Union[Unset, str]):
-        as_found_value_35 (Union[Unset, str]):
-        as_found_value_36 (Union[Unset, str]):
-        as_found_value_37 (Union[Unset, str]):
-        as_found_value_38 (Union[Unset, str]):
-        as_found_value_39 (Union[Unset, str]):
-        as_found_value_40 (Union[Unset, str]):
-        as_found_raw_value_1 (Union[Unset, str]):
-        as_found_raw_value_2 (Union[Unset, str]):
-        as_found_raw_value_3 (Union[Unset, str]):
-        as_found_raw_value_4 (Union[Unset, str]):
-        as_found_raw_value_5 (Union[Unset, str]):
-        as_found_raw_value_6 (Union[Unset, str]):
-        as_found_raw_value_7 (Union[Unset, str]):
-        as_found_raw_value_8 (Union[Unset, str]):
-        as_found_raw_value_9 (Union[Unset, str]):
-        as_found_raw_value_10 (Union[Unset, str]):
-        as_found_raw_value_11 (Union[Unset, str]):
-        as_found_raw_value_12 (Union[Unset, str]):
-        as_found_raw_value_13 (Union[Unset, str]):
-        as_found_raw_value_14 (Union[Unset, str]):
-        as_found_raw_value_15 (Union[Unset, str]):
-        as_found_raw_value_16 (Union[Unset, str]):
-        as_found_raw_value_17 (Union[Unset, str]):
-        as_found_raw_value_18 (Union[Unset, str]):
-        as_found_raw_value_19 (Union[Unset, str]):
-        as_found_raw_value_20 (Union[Unset, str]):
-        as_found_raw_value_21 (Union[Unset, str]):
-        as_found_raw_value_22 (Union[Unset, str]):
-        as_found_raw_value_23 (Union[Unset, str]):
-        as_found_raw_value_24 (Union[Unset, str]):
-        as_found_raw_value_25 (Union[Unset, str]):
-        as_found_raw_value_26 (Union[Unset, str]):
-        as_found_raw_value_27 (Union[Unset, str]):
-        as_found_raw_value_28 (Union[Unset, str]):
-        as_found_raw_value_29 (Union[Unset, str]):
-        as_found_raw_value_30 (Union[Unset, str]):
-        as_found_raw_value_31 (Union[Unset, str]):
-        as_found_raw_value_32 (Union[Unset, str]):
-        as_found_raw_value_33 (Union[Unset, str]):
-        as_found_raw_value_34 (Union[Unset, str]):
-        as_found_raw_value_35 (Union[Unset, str]):
-        as_found_raw_value_36 (Union[Unset, str]):
-        as_found_raw_value_37 (Union[Unset, str]):
-        as_found_raw_value_38 (Union[Unset, str]):
-        as_found_raw_value_39 (Union[Unset, str]):
-        as_found_raw_value_40 (Union[Unset, str]):
-        as_found_value_subtitle_1 (Union[Unset, str]):
-        as_found_value_subtitle_2 (Union[Unset, str]):
-        as_found_value_subtitle_3 (Union[Unset, str]):
-        as_found_value_subtitle_4 (Union[Unset, str]):
-        as_found_value_subtitle_5 (Union[Unset, str]):
-        as_found_value_subtitle_6 (Union[Unset, str]):
-        as_found_value_subtitle_7 (Union[Unset, str]):
-        as_found_value_subtitle_8 (Union[Unset, str]):
-        as_found_value_subtitle_9 (Union[Unset, str]):
-        as_found_value_subtitle_10 (Union[Unset, str]):
-        as_found_value_subtitle_11 (Union[Unset, str]):
-        as_found_value_subtitle_12 (Union[Unset, str]):
-        as_found_value_subtitle_13 (Union[Unset, str]):
-        as_found_value_subtitle_14 (Union[Unset, str]):
-        as_found_value_subtitle_15 (Union[Unset, str]):
-        as_found_value_subtitle_16 (Union[Unset, str]):
-        as_found_value_subtitle_17 (Union[Unset, str]):
-        as_found_value_subtitle_18 (Union[Unset, str]):
-        as_found_value_subtitle_19 (Union[Unset, str]):
-        as_found_value_subtitle_20 (Union[Unset, str]):
-        as_found_value_subtitle_21 (Union[Unset, str]):
-        as_found_value_subtitle_22 (Union[Unset, str]):
-        as_found_value_subtitle_23 (Union[Unset, str]):
-        as_found_value_subtitle_24 (Union[Unset, str]):
-        as_found_value_subtitle_25 (Union[Unset, str]):
-        as_found_value_subtitle_26 (Union[Unset, str]):
-        as_found_value_subtitle_27 (Union[Unset, str]):
-        as_found_value_subtitle_28 (Union[Unset, str]):
-        as_found_value_subtitle_29 (Union[Unset, str]):
-        as_found_value_subtitle_30 (Union[Unset, str]):
-        as_found_value_subtitle_31 (Union[Unset, str]):
-        as_found_value_subtitle_32 (Union[Unset, str]):
-        as_found_value_subtitle_33 (Union[Unset, str]):
-        as_found_value_subtitle_34 (Union[Unset, str]):
-        as_found_value_subtitle_35 (Union[Unset, str]):
-        as_found_value_subtitle_36 (Union[Unset, str]):
-        as_found_value_subtitle_37 (Union[Unset, str]):
-        as_found_value_subtitle_38 (Union[Unset, str]):
-        as_found_value_subtitle_39 (Union[Unset, str]):
-        as_found_value_subtitle_40 (Union[Unset, str]):
-        as_found_mean (Union[Unset, float]):
-        as_found_mean_raw (Union[Unset, float]):
-        as_found_sd (Union[Unset, float]):
-        as_found_sd_raw (Union[Unset, float]):
-        as_found_delta (Union[Unset, float]):
-        as_found_range (Union[Unset, float]):
-        as_found_cv (Union[Unset, float]):
-        as_found_cv_raw (Union[Unset, float]):
-        as_found_result (Union[Unset, int]):
-        as_found_range_result (Union[Unset, bool]):
-        as_found_delta_result (Union[Unset, bool]):
-        as_found_min_result (Union[Unset, bool]):
-        as_found_max_result (Union[Unset, bool]):
-        as_found_tar_result (Union[Unset, bool]):
-        as_found_tur_result (Union[Unset, bool]):
-        as_found_error_result (Union[Unset, bool]):
-        as_found_sd_result (Union[Unset, bool]):
-        as_found_cv_result (Union[Unset, bool]):
-        as_found_custom_field_result (Union[Unset, int]):
-        as_found_mu (Union[Unset, float]):
-        as_found_mu_raw (Union[Unset, float]):
-        as_found_mu_effective_dof (Union[Unset, float]):
-        as_found_mu_coverage_factor (Union[Unset, float]):
-        as_found_cmc (Union[Unset, float]):
-        as_found_cmc_comments (Union[Unset, str]):
-        as_found_calculated_uncertainty (Union[Unset, float]):
-        as_found_lab_mu (Union[Unset, float]):
-        as_found_uncertainty_budget (Union[Unset, str]):
-        as_found_mu_extended (Union[Unset, str]):
-        as_found_channel (Union[Unset, int]):
-        as_found_measurement_type (Union[Unset,
+        as_found_reading_entry_math_string (Union[None, Unset, str]):
+        as_found_value_1 (Union[None, Unset, str]):
+        as_found_value_2 (Union[None, Unset, str]):
+        as_found_value_3 (Union[None, Unset, str]):
+        as_found_value_4 (Union[None, Unset, str]):
+        as_found_value_5 (Union[None, Unset, str]):
+        as_found_value_6 (Union[None, Unset, str]):
+        as_found_value_7 (Union[None, Unset, str]):
+        as_found_value_8 (Union[None, Unset, str]):
+        as_found_value_9 (Union[None, Unset, str]):
+        as_found_value_10 (Union[None, Unset, str]):
+        as_found_value_11 (Union[None, Unset, str]):
+        as_found_value_12 (Union[None, Unset, str]):
+        as_found_value_13 (Union[None, Unset, str]):
+        as_found_value_14 (Union[None, Unset, str]):
+        as_found_value_15 (Union[None, Unset, str]):
+        as_found_value_16 (Union[None, Unset, str]):
+        as_found_value_17 (Union[None, Unset, str]):
+        as_found_value_18 (Union[None, Unset, str]):
+        as_found_value_19 (Union[None, Unset, str]):
+        as_found_value_20 (Union[None, Unset, str]):
+        as_found_value_21 (Union[None, Unset, str]):
+        as_found_value_22 (Union[None, Unset, str]):
+        as_found_value_23 (Union[None, Unset, str]):
+        as_found_value_24 (Union[None, Unset, str]):
+        as_found_value_25 (Union[None, Unset, str]):
+        as_found_value_26 (Union[None, Unset, str]):
+        as_found_value_27 (Union[None, Unset, str]):
+        as_found_value_28 (Union[None, Unset, str]):
+        as_found_value_29 (Union[None, Unset, str]):
+        as_found_value_30 (Union[None, Unset, str]):
+        as_found_value_31 (Union[None, Unset, str]):
+        as_found_value_32 (Union[None, Unset, str]):
+        as_found_value_33 (Union[None, Unset, str]):
+        as_found_value_34 (Union[None, Unset, str]):
+        as_found_value_35 (Union[None, Unset, str]):
+        as_found_value_36 (Union[None, Unset, str]):
+        as_found_value_37 (Union[None, Unset, str]):
+        as_found_value_38 (Union[None, Unset, str]):
+        as_found_value_39 (Union[None, Unset, str]):
+        as_found_value_40 (Union[None, Unset, str]):
+        as_found_raw_value_1 (Union[None, Unset, str]):
+        as_found_raw_value_2 (Union[None, Unset, str]):
+        as_found_raw_value_3 (Union[None, Unset, str]):
+        as_found_raw_value_4 (Union[None, Unset, str]):
+        as_found_raw_value_5 (Union[None, Unset, str]):
+        as_found_raw_value_6 (Union[None, Unset, str]):
+        as_found_raw_value_7 (Union[None, Unset, str]):
+        as_found_raw_value_8 (Union[None, Unset, str]):
+        as_found_raw_value_9 (Union[None, Unset, str]):
+        as_found_raw_value_10 (Union[None, Unset, str]):
+        as_found_raw_value_11 (Union[None, Unset, str]):
+        as_found_raw_value_12 (Union[None, Unset, str]):
+        as_found_raw_value_13 (Union[None, Unset, str]):
+        as_found_raw_value_14 (Union[None, Unset, str]):
+        as_found_raw_value_15 (Union[None, Unset, str]):
+        as_found_raw_value_16 (Union[None, Unset, str]):
+        as_found_raw_value_17 (Union[None, Unset, str]):
+        as_found_raw_value_18 (Union[None, Unset, str]):
+        as_found_raw_value_19 (Union[None, Unset, str]):
+        as_found_raw_value_20 (Union[None, Unset, str]):
+        as_found_raw_value_21 (Union[None, Unset, str]):
+        as_found_raw_value_22 (Union[None, Unset, str]):
+        as_found_raw_value_23 (Union[None, Unset, str]):
+        as_found_raw_value_24 (Union[None, Unset, str]):
+        as_found_raw_value_25 (Union[None, Unset, str]):
+        as_found_raw_value_26 (Union[None, Unset, str]):
+        as_found_raw_value_27 (Union[None, Unset, str]):
+        as_found_raw_value_28 (Union[None, Unset, str]):
+        as_found_raw_value_29 (Union[None, Unset, str]):
+        as_found_raw_value_30 (Union[None, Unset, str]):
+        as_found_raw_value_31 (Union[None, Unset, str]):
+        as_found_raw_value_32 (Union[None, Unset, str]):
+        as_found_raw_value_33 (Union[None, Unset, str]):
+        as_found_raw_value_34 (Union[None, Unset, str]):
+        as_found_raw_value_35 (Union[None, Unset, str]):
+        as_found_raw_value_36 (Union[None, Unset, str]):
+        as_found_raw_value_37 (Union[None, Unset, str]):
+        as_found_raw_value_38 (Union[None, Unset, str]):
+        as_found_raw_value_39 (Union[None, Unset, str]):
+        as_found_raw_value_40 (Union[None, Unset, str]):
+        as_found_value_subtitle_1 (Union[None, Unset, str]):
+        as_found_value_subtitle_2 (Union[None, Unset, str]):
+        as_found_value_subtitle_3 (Union[None, Unset, str]):
+        as_found_value_subtitle_4 (Union[None, Unset, str]):
+        as_found_value_subtitle_5 (Union[None, Unset, str]):
+        as_found_value_subtitle_6 (Union[None, Unset, str]):
+        as_found_value_subtitle_7 (Union[None, Unset, str]):
+        as_found_value_subtitle_8 (Union[None, Unset, str]):
+        as_found_value_subtitle_9 (Union[None, Unset, str]):
+        as_found_value_subtitle_10 (Union[None, Unset, str]):
+        as_found_value_subtitle_11 (Union[None, Unset, str]):
+        as_found_value_subtitle_12 (Union[None, Unset, str]):
+        as_found_value_subtitle_13 (Union[None, Unset, str]):
+        as_found_value_subtitle_14 (Union[None, Unset, str]):
+        as_found_value_subtitle_15 (Union[None, Unset, str]):
+        as_found_value_subtitle_16 (Union[None, Unset, str]):
+        as_found_value_subtitle_17 (Union[None, Unset, str]):
+        as_found_value_subtitle_18 (Union[None, Unset, str]):
+        as_found_value_subtitle_19 (Union[None, Unset, str]):
+        as_found_value_subtitle_20 (Union[None, Unset, str]):
+        as_found_value_subtitle_21 (Union[None, Unset, str]):
+        as_found_value_subtitle_22 (Union[None, Unset, str]):
+        as_found_value_subtitle_23 (Union[None, Unset, str]):
+        as_found_value_subtitle_24 (Union[None, Unset, str]):
+        as_found_value_subtitle_25 (Union[None, Unset, str]):
+        as_found_value_subtitle_26 (Union[None, Unset, str]):
+        as_found_value_subtitle_27 (Union[None, Unset, str]):
+        as_found_value_subtitle_28 (Union[None, Unset, str]):
+        as_found_value_subtitle_29 (Union[None, Unset, str]):
+        as_found_value_subtitle_30 (Union[None, Unset, str]):
+        as_found_value_subtitle_31 (Union[None, Unset, str]):
+        as_found_value_subtitle_32 (Union[None, Unset, str]):
+        as_found_value_subtitle_33 (Union[None, Unset, str]):
+        as_found_value_subtitle_34 (Union[None, Unset, str]):
+        as_found_value_subtitle_35 (Union[None, Unset, str]):
+        as_found_value_subtitle_36 (Union[None, Unset, str]):
+        as_found_value_subtitle_37 (Union[None, Unset, str]):
+        as_found_value_subtitle_38 (Union[None, Unset, str]):
+        as_found_value_subtitle_39 (Union[None, Unset, str]):
+        as_found_value_subtitle_40 (Union[None, Unset, str]):
+        as_found_mean (Union[None, Unset, float]):
+        as_found_mean_raw (Union[None, Unset, float]):
+        as_found_sd (Union[None, Unset, float]):
+        as_found_sd_raw (Union[None, Unset, float]):
+        as_found_delta (Union[None, Unset, float]):
+        as_found_range (Union[None, Unset, float]):
+        as_found_cv (Union[None, Unset, float]):
+        as_found_cv_raw (Union[None, Unset, float]):
+        as_found_result (Union[None, Unset, int]):
+        as_found_range_result (Union[None, Unset, bool]):
+        as_found_delta_result (Union[None, Unset, bool]):
+        as_found_min_result (Union[None, Unset, bool]):
+        as_found_max_result (Union[None, Unset, bool]):
+        as_found_tar_result (Union[None, Unset, bool]):
+        as_found_tur_result (Union[None, Unset, bool]):
+        as_found_error_result (Union[None, Unset, bool]):
+        as_found_sd_result (Union[None, Unset, bool]):
+        as_found_cv_result (Union[None, Unset, bool]):
+        as_found_custom_field_result (Union[None, Unset, int]):
+        as_found_mu (Union[None, Unset, float]):
+        as_found_mu_raw (Union[None, Unset, float]):
+        as_found_mu_effective_dof (Union[None, Unset, float]):
+        as_found_mu_coverage_factor (Union[None, Unset, float]):
+        as_found_cmc (Union[None, Unset, float]):
+        as_found_cmc_comments (Union[None, Unset, str]):
+        as_found_calculated_uncertainty (Union[None, Unset, float]):
+        as_found_lab_mu (Union[None, Unset, float]):
+        as_found_uncertainty_budget (Union[None, Unset, str]):
+        as_found_mu_extended (Union[None, Unset, str]):
+        as_found_channel (Union[None, Unset, int]):
+        as_found_measurement_type (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementType]):
-        as_found_updated_by (Union[Unset, str]):
-        as_found_updated_on (Union[Unset, datetime.datetime]):
-        as_left_abbreviated_uom (Union[Unset, str]):
-        as_left_unit_scale_factor (Union[Unset, float]):
-        as_found_specification_title (Union[Unset, str]):
-        as_found_specification_subtitle (Union[Unset, str]):
-        as_found_specification_group (Union[Unset, str]):
-        as_found_batch_type (Union[Unset, int]):
-        as_found_batch_result (Union[Unset, int]):
-        as_found_is_by_channel (Union[Unset, bool]):
-        as_found_channel_count (Union[Unset, int]):
-        as_found_commenced_on (Union[Unset, datetime.datetime]):
-        as_found_commenced_by (Union[Unset, str]):
-        as_found_z_factor (Union[Unset, float]):
-        as_found_air_buoyancy (Union[Unset, float]):
-        as_found_evaporation_rate (Union[Unset, float]):
-        as_found_ambient_temperature (Union[Unset, float]):
-        as_found_air_humidity (Union[Unset, float]):
-        as_found_barometric_pressure (Union[Unset, float]):
-        as_found_altitude (Union[Unset, float]):
-        as_found_wind_speed (Union[Unset, float]):
-        as_found_solar_radiation (Union[Unset, float]):
-        as_found_light_intensity (Union[Unset, float]):
-        as_found_noise_level (Union[Unset, float]):
-        as_found_ph_level (Union[Unset, float]):
-        as_found_water_conductivity (Union[Unset, float]):
-        as_found_water_temperature (Union[Unset, float]):
-        as_found_z_factor_uom (Union[Unset, str]):
-        as_found_air_buoyancy_uom (Union[Unset, str]):
-        as_found_evaporation_rate_uom (Union[Unset, str]):
-        as_found_ambient_temperature_uom (Union[Unset, str]):
-        as_found_air_humidity_uom (Union[Unset, str]):
-        as_found_barometric_pressure_uom (Union[Unset, str]):
-        as_found_altitude_uom (Union[Unset, str]):
-        as_found_wind_speed_uom (Union[Unset, str]):
-        as_found_solar_radiation_uom (Union[Unset, str]):
-        as_found_light_intensity_uom (Union[Unset, str]):
-        as_found_noise_level_uom (Union[Unset, str]):
-        as_found_ph_level_uom (Union[Unset, str]):
-        as_found_water_conductivity_uom (Union[Unset, str]):
-        as_found_water_temperature_uom (Union[Unset, str]):
-        as_found_abbreviated_uom (Union[Unset, str]):
-        as_found_unit_scale_factor (Union[Unset, float]):
-        as_found_specification_name (Union[Unset, str]):
-        as_found_parameter_name (Union[Unset, str]):
-        as_found_display_order (Union[Unset, int]):
-        as_found_unit_of_measure (Union[Unset, str]):
-        as_found_display_format (Union[Unset, str]):
-        as_found_precision (Union[Unset, float]):
-        as_found_precision_type (Union[Unset,
+        as_found_updated_by (Union[None, Unset, str]):
+        as_found_updated_on (Union[None, Unset, datetime.datetime]):
+        as_left_abbreviated_uom (Union[None, Unset, str]):
+        as_left_unit_scale_factor (Union[None, Unset, float]):
+        as_found_specification_title (Union[None, Unset, str]):
+        as_found_specification_subtitle (Union[None, Unset, str]):
+        as_found_specification_group (Union[None, Unset, str]):
+        as_found_batch_type (Union[None, Unset, int]):
+        as_found_batch_result (Union[None, Unset, int]):
+        as_found_is_by_channel (Union[None, Unset, bool]):
+        as_found_channel_count (Union[None, Unset, int]):
+        as_found_commenced_on (Union[None, Unset, datetime.datetime]):
+        as_found_commenced_by (Union[None, Unset, str]):
+        as_found_z_factor (Union[None, Unset, float]):
+        as_found_air_buoyancy (Union[None, Unset, float]):
+        as_found_evaporation_rate (Union[None, Unset, float]):
+        as_found_ambient_temperature (Union[None, Unset, float]):
+        as_found_air_humidity (Union[None, Unset, float]):
+        as_found_barometric_pressure (Union[None, Unset, float]):
+        as_found_altitude (Union[None, Unset, float]):
+        as_found_wind_speed (Union[None, Unset, float]):
+        as_found_solar_radiation (Union[None, Unset, float]):
+        as_found_light_intensity (Union[None, Unset, float]):
+        as_found_noise_level (Union[None, Unset, float]):
+        as_found_ph_level (Union[None, Unset, float]):
+        as_found_water_conductivity (Union[None, Unset, float]):
+        as_found_water_temperature (Union[None, Unset, float]):
+        as_found_z_factor_uom (Union[None, Unset, str]):
+        as_found_air_buoyancy_uom (Union[None, Unset, str]):
+        as_found_evaporation_rate_uom (Union[None, Unset, str]):
+        as_found_ambient_temperature_uom (Union[None, Unset, str]):
+        as_found_air_humidity_uom (Union[None, Unset, str]):
+        as_found_barometric_pressure_uom (Union[None, Unset, str]):
+        as_found_altitude_uom (Union[None, Unset, str]):
+        as_found_wind_speed_uom (Union[None, Unset, str]):
+        as_found_solar_radiation_uom (Union[None, Unset, str]):
+        as_found_light_intensity_uom (Union[None, Unset, str]):
+        as_found_noise_level_uom (Union[None, Unset, str]):
+        as_found_ph_level_uom (Union[None, Unset, str]):
+        as_found_water_conductivity_uom (Union[None, Unset, str]):
+        as_found_water_temperature_uom (Union[None, Unset, str]):
+        as_found_abbreviated_uom (Union[None, Unset, str]):
+        as_found_unit_scale_factor (Union[None, Unset, float]):
+        as_found_specification_name (Union[None, Unset, str]):
+        as_found_parameter_name (Union[None, Unset, str]):
+        as_found_display_order (Union[None, Unset, int]):
+        as_found_unit_of_measure (Union[None, Unset, str]):
+        as_found_display_format (Union[None, Unset, str]):
+        as_found_precision (Union[None, Unset, float]):
+        as_found_precision_type (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundPrecisionType]):
-        as_found_minimum (Union[Unset, float]):
-        as_found_nominal (Union[Unset, float]):
-        as_found_expected_value (Union[Unset, float]):
-        as_found_expected_value_raw (Union[Unset, str]):
-        as_found_test_value (Union[Unset, float]):
-        as_found_base_value (Union[Unset, float]):
-        as_found_maxi_mum (Union[Unset, float]):
-        as_found_resolution (Union[Unset, float]):
-        as_found_resolution_count (Union[Unset, int]):
-        as_found_measurement_batch_id (Union[Unset, int]):
-        as_found_measurement_id (Union[Unset, int]):
-        as_found_standard_id (Union[Unset, int]):
-        as_found_tool_id (Union[Unset, int]):
-        as_found_measurement_condition_id (Union[Unset, int]):
-        as_found_measurement_point_id (Union[Unset, int]):
-        as_left_parameter_id (Union[Unset, int]):
-        as_left_sd_header (Union[Unset, float]):
-        as_left_cv_header (Union[Unset, float]):
-        as_left_measurement_local_time (Union[Unset, datetime.datetime]):
-        as_left_reading_entry_math (Union[Unset,
+        as_found_minimum (Union[None, Unset, float]):
+        as_found_nominal (Union[None, Unset, float]):
+        as_found_expected_value (Union[None, Unset, float]):
+        as_found_expected_value_raw (Union[None, Unset, str]):
+        as_found_test_value (Union[None, Unset, float]):
+        as_found_base_value (Union[None, Unset, float]):
+        as_found_maxi_mum (Union[None, Unset, float]):
+        as_found_resolution (Union[None, Unset, float]):
+        as_found_resolution_count (Union[None, Unset, int]):
+        as_found_measurement_batch_id (Union[None, Unset, int]):
+        as_found_measurement_id (Union[None, Unset, int]):
+        as_found_standard_id (Union[None, Unset, int]):
+        as_found_tool_id (Union[None, Unset, int]):
+        as_found_measurement_condition_id (Union[None, Unset, int]):
+        as_found_measurement_point_id (Union[None, Unset, int]):
+        as_left_parameter_id (Union[None, Unset, int]):
+        as_left_sd_header (Union[None, Unset, float]):
+        as_left_cv_header (Union[None, Unset, float]):
+        as_left_measurement_local_time (Union[None, Unset, datetime.datetime]):
+        as_left_reading_entry_math (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftReadingEntryMath]):
-        as_left_reading_entry_math_string (Union[Unset, str]):
-        as_left_value_1 (Union[Unset, str]):
-        as_left_value_2 (Union[Unset, str]):
-        as_left_value_3 (Union[Unset, str]):
-        as_left_value_4 (Union[Unset, str]):
-        as_left_value_5 (Union[Unset, str]):
-        as_left_value_6 (Union[Unset, str]):
-        as_left_value_7 (Union[Unset, str]):
-        as_left_value_8 (Union[Unset, str]):
-        as_left_value_9 (Union[Unset, str]):
-        as_left_value_10 (Union[Unset, str]):
-        as_left_value_11 (Union[Unset, str]):
-        as_left_value_12 (Union[Unset, str]):
-        as_left_value_13 (Union[Unset, str]):
-        as_left_value_14 (Union[Unset, str]):
-        as_left_value_15 (Union[Unset, str]):
-        as_left_value_16 (Union[Unset, str]):
-        as_left_value_17 (Union[Unset, str]):
-        as_left_value_18 (Union[Unset, str]):
-        as_left_value_19 (Union[Unset, str]):
-        as_left_value_20 (Union[Unset, str]):
-        as_left_value_21 (Union[Unset, str]):
-        as_left_value_22 (Union[Unset, str]):
-        as_left_value_23 (Union[Unset, str]):
-        as_left_value_24 (Union[Unset, str]):
-        as_left_value_25 (Union[Unset, str]):
-        as_left_value_26 (Union[Unset, str]):
-        as_left_value_27 (Union[Unset, str]):
-        as_left_value_28 (Union[Unset, str]):
-        as_left_value_29 (Union[Unset, str]):
-        as_left_value_30 (Union[Unset, str]):
-        as_left_value_31 (Union[Unset, str]):
-        as_left_value_32 (Union[Unset, str]):
-        as_left_value_33 (Union[Unset, str]):
-        as_left_value_34 (Union[Unset, str]):
-        as_left_value_35 (Union[Unset, str]):
-        as_left_value_36 (Union[Unset, str]):
-        as_left_value_37 (Union[Unset, str]):
-        as_left_value_38 (Union[Unset, str]):
-        as_left_value_39 (Union[Unset, str]):
-        as_left_value_40 (Union[Unset, str]):
-        as_left_raw_value_1 (Union[Unset, str]):
-        as_left_raw_value_2 (Union[Unset, str]):
-        as_left_raw_value_3 (Union[Unset, str]):
-        as_left_raw_value_4 (Union[Unset, str]):
-        as_left_raw_value_5 (Union[Unset, str]):
-        as_left_raw_value_6 (Union[Unset, str]):
-        as_left_raw_value_7 (Union[Unset, str]):
-        as_left_raw_value_8 (Union[Unset, str]):
-        as_left_raw_value_9 (Union[Unset, str]):
-        as_left_raw_value_10 (Union[Unset, str]):
-        as_left_raw_value_11 (Union[Unset, str]):
-        as_left_raw_value_12 (Union[Unset, str]):
-        as_left_raw_value_13 (Union[Unset, str]):
-        as_left_raw_value_14 (Union[Unset, str]):
-        as_left_raw_value_15 (Union[Unset, str]):
-        as_left_raw_value_16 (Union[Unset, str]):
-        as_left_raw_value_17 (Union[Unset, str]):
-        as_left_raw_value_18 (Union[Unset, str]):
-        as_left_raw_value_19 (Union[Unset, str]):
-        as_left_raw_value_20 (Union[Unset, str]):
-        as_left_raw_value_21 (Union[Unset, str]):
-        as_left_raw_value_22 (Union[Unset, str]):
-        as_left_raw_value_23 (Union[Unset, str]):
-        as_left_raw_value_24 (Union[Unset, str]):
-        as_left_raw_value_25 (Union[Unset, str]):
-        as_left_raw_value_26 (Union[Unset, str]):
-        as_left_raw_value_27 (Union[Unset, str]):
-        as_left_raw_value_28 (Union[Unset, str]):
-        as_left_raw_value_29 (Union[Unset, str]):
-        as_left_raw_value_30 (Union[Unset, str]):
-        as_left_raw_value_31 (Union[Unset, str]):
-        as_left_raw_value_32 (Union[Unset, str]):
-        as_left_raw_value_33 (Union[Unset, str]):
-        as_left_raw_value_34 (Union[Unset, str]):
-        as_left_raw_value_35 (Union[Unset, str]):
-        as_left_raw_value_36 (Union[Unset, str]):
-        as_left_raw_value_37 (Union[Unset, str]):
-        as_left_raw_value_38 (Union[Unset, str]):
-        as_left_raw_value_39 (Union[Unset, str]):
-        as_left_raw_value_40 (Union[Unset, str]):
-        as_left_value_subtitle_1 (Union[Unset, str]):
-        as_left_value_subtitle_2 (Union[Unset, str]):
-        as_left_value_subtitle_3 (Union[Unset, str]):
-        as_left_value_subtitle_4 (Union[Unset, str]):
-        as_left_value_subtitle_5 (Union[Unset, str]):
-        as_left_value_subtitle_6 (Union[Unset, str]):
-        as_left_value_subtitle_7 (Union[Unset, str]):
-        as_left_value_subtitle_8 (Union[Unset, str]):
-        as_left_value_subtitle_9 (Union[Unset, str]):
-        as_left_value_subtitle_10 (Union[Unset, str]):
-        as_left_value_subtitle_11 (Union[Unset, str]):
-        as_left_value_subtitle_12 (Union[Unset, str]):
-        as_left_value_subtitle_13 (Union[Unset, str]):
-        as_left_value_subtitle_14 (Union[Unset, str]):
-        as_left_value_subtitle_15 (Union[Unset, str]):
-        as_left_value_subtitle_16 (Union[Unset, str]):
-        as_left_value_subtitle_17 (Union[Unset, str]):
-        as_left_value_subtitle_18 (Union[Unset, str]):
-        as_left_value_subtitle_19 (Union[Unset, str]):
-        as_left_value_subtitle_20 (Union[Unset, str]):
-        as_left_value_subtitle_21 (Union[Unset, str]):
-        as_left_value_subtitle_22 (Union[Unset, str]):
-        as_left_value_subtitle_23 (Union[Unset, str]):
-        as_left_value_subtitle_24 (Union[Unset, str]):
-        as_left_value_subtitle_25 (Union[Unset, str]):
-        as_left_value_subtitle_26 (Union[Unset, str]):
-        as_left_value_subtitle_27 (Union[Unset, str]):
-        as_left_value_subtitle_28 (Union[Unset, str]):
-        as_left_value_subtitle_29 (Union[Unset, str]):
-        as_left_value_subtitle_30 (Union[Unset, str]):
-        as_left_value_subtitle_31 (Union[Unset, str]):
-        as_left_value_subtitle_32 (Union[Unset, str]):
-        as_left_value_subtitle_33 (Union[Unset, str]):
-        as_left_value_subtitle_34 (Union[Unset, str]):
-        as_left_value_subtitle_35 (Union[Unset, str]):
-        as_left_value_subtitle_36 (Union[Unset, str]):
-        as_left_value_subtitle_37 (Union[Unset, str]):
-        as_left_value_subtitle_38 (Union[Unset, str]):
-        as_left_value_subtitle_39 (Union[Unset, str]):
-        as_left_value_subtitle_40 (Union[Unset, str]):
-        as_left_mean (Union[Unset, float]):
-        as_left_mean_raw (Union[Unset, float]):
-        as_left_sd (Union[Unset, float]):
-        as_left_sd_raw (Union[Unset, float]):
-        as_left_cv (Union[Unset, float]):
-        as_left_cv_raw (Union[Unset, float]):
-        as_left_delta (Union[Unset, float]):
-        as_left_range (Union[Unset, float]):
+        as_left_reading_entry_math_string (Union[None, Unset, str]):
+        as_left_value_1 (Union[None, Unset, str]):
+        as_left_value_2 (Union[None, Unset, str]):
+        as_left_value_3 (Union[None, Unset, str]):
+        as_left_value_4 (Union[None, Unset, str]):
+        as_left_value_5 (Union[None, Unset, str]):
+        as_left_value_6 (Union[None, Unset, str]):
+        as_left_value_7 (Union[None, Unset, str]):
+        as_left_value_8 (Union[None, Unset, str]):
+        as_left_value_9 (Union[None, Unset, str]):
+        as_left_value_10 (Union[None, Unset, str]):
+        as_left_value_11 (Union[None, Unset, str]):
+        as_left_value_12 (Union[None, Unset, str]):
+        as_left_value_13 (Union[None, Unset, str]):
+        as_left_value_14 (Union[None, Unset, str]):
+        as_left_value_15 (Union[None, Unset, str]):
+        as_left_value_16 (Union[None, Unset, str]):
+        as_left_value_17 (Union[None, Unset, str]):
+        as_left_value_18 (Union[None, Unset, str]):
+        as_left_value_19 (Union[None, Unset, str]):
+        as_left_value_20 (Union[None, Unset, str]):
+        as_left_value_21 (Union[None, Unset, str]):
+        as_left_value_22 (Union[None, Unset, str]):
+        as_left_value_23 (Union[None, Unset, str]):
+        as_left_value_24 (Union[None, Unset, str]):
+        as_left_value_25 (Union[None, Unset, str]):
+        as_left_value_26 (Union[None, Unset, str]):
+        as_left_value_27 (Union[None, Unset, str]):
+        as_left_value_28 (Union[None, Unset, str]):
+        as_left_value_29 (Union[None, Unset, str]):
+        as_left_value_30 (Union[None, Unset, str]):
+        as_left_value_31 (Union[None, Unset, str]):
+        as_left_value_32 (Union[None, Unset, str]):
+        as_left_value_33 (Union[None, Unset, str]):
+        as_left_value_34 (Union[None, Unset, str]):
+        as_left_value_35 (Union[None, Unset, str]):
+        as_left_value_36 (Union[None, Unset, str]):
+        as_left_value_37 (Union[None, Unset, str]):
+        as_left_value_38 (Union[None, Unset, str]):
+        as_left_value_39 (Union[None, Unset, str]):
+        as_left_value_40 (Union[None, Unset, str]):
+        as_left_raw_value_1 (Union[None, Unset, str]):
+        as_left_raw_value_2 (Union[None, Unset, str]):
+        as_left_raw_value_3 (Union[None, Unset, str]):
+        as_left_raw_value_4 (Union[None, Unset, str]):
+        as_left_raw_value_5 (Union[None, Unset, str]):
+        as_left_raw_value_6 (Union[None, Unset, str]):
+        as_left_raw_value_7 (Union[None, Unset, str]):
+        as_left_raw_value_8 (Union[None, Unset, str]):
+        as_left_raw_value_9 (Union[None, Unset, str]):
+        as_left_raw_value_10 (Union[None, Unset, str]):
+        as_left_raw_value_11 (Union[None, Unset, str]):
+        as_left_raw_value_12 (Union[None, Unset, str]):
+        as_left_raw_value_13 (Union[None, Unset, str]):
+        as_left_raw_value_14 (Union[None, Unset, str]):
+        as_left_raw_value_15 (Union[None, Unset, str]):
+        as_left_raw_value_16 (Union[None, Unset, str]):
+        as_left_raw_value_17 (Union[None, Unset, str]):
+        as_left_raw_value_18 (Union[None, Unset, str]):
+        as_left_raw_value_19 (Union[None, Unset, str]):
+        as_left_raw_value_20 (Union[None, Unset, str]):
+        as_left_raw_value_21 (Union[None, Unset, str]):
+        as_left_raw_value_22 (Union[None, Unset, str]):
+        as_left_raw_value_23 (Union[None, Unset, str]):
+        as_left_raw_value_24 (Union[None, Unset, str]):
+        as_left_raw_value_25 (Union[None, Unset, str]):
+        as_left_raw_value_26 (Union[None, Unset, str]):
+        as_left_raw_value_27 (Union[None, Unset, str]):
+        as_left_raw_value_28 (Union[None, Unset, str]):
+        as_left_raw_value_29 (Union[None, Unset, str]):
+        as_left_raw_value_30 (Union[None, Unset, str]):
+        as_left_raw_value_31 (Union[None, Unset, str]):
+        as_left_raw_value_32 (Union[None, Unset, str]):
+        as_left_raw_value_33 (Union[None, Unset, str]):
+        as_left_raw_value_34 (Union[None, Unset, str]):
+        as_left_raw_value_35 (Union[None, Unset, str]):
+        as_left_raw_value_36 (Union[None, Unset, str]):
+        as_left_raw_value_37 (Union[None, Unset, str]):
+        as_left_raw_value_38 (Union[None, Unset, str]):
+        as_left_raw_value_39 (Union[None, Unset, str]):
+        as_left_raw_value_40 (Union[None, Unset, str]):
+        as_left_value_subtitle_1 (Union[None, Unset, str]):
+        as_left_value_subtitle_2 (Union[None, Unset, str]):
+        as_left_value_subtitle_3 (Union[None, Unset, str]):
+        as_left_value_subtitle_4 (Union[None, Unset, str]):
+        as_left_value_subtitle_5 (Union[None, Unset, str]):
+        as_left_value_subtitle_6 (Union[None, Unset, str]):
+        as_left_value_subtitle_7 (Union[None, Unset, str]):
+        as_left_value_subtitle_8 (Union[None, Unset, str]):
+        as_left_value_subtitle_9 (Union[None, Unset, str]):
+        as_left_value_subtitle_10 (Union[None, Unset, str]):
+        as_left_value_subtitle_11 (Union[None, Unset, str]):
+        as_left_value_subtitle_12 (Union[None, Unset, str]):
+        as_left_value_subtitle_13 (Union[None, Unset, str]):
+        as_left_value_subtitle_14 (Union[None, Unset, str]):
+        as_left_value_subtitle_15 (Union[None, Unset, str]):
+        as_left_value_subtitle_16 (Union[None, Unset, str]):
+        as_left_value_subtitle_17 (Union[None, Unset, str]):
+        as_left_value_subtitle_18 (Union[None, Unset, str]):
+        as_left_value_subtitle_19 (Union[None, Unset, str]):
+        as_left_value_subtitle_20 (Union[None, Unset, str]):
+        as_left_value_subtitle_21 (Union[None, Unset, str]):
+        as_left_value_subtitle_22 (Union[None, Unset, str]):
+        as_left_value_subtitle_23 (Union[None, Unset, str]):
+        as_left_value_subtitle_24 (Union[None, Unset, str]):
+        as_left_value_subtitle_25 (Union[None, Unset, str]):
+        as_left_value_subtitle_26 (Union[None, Unset, str]):
+        as_left_value_subtitle_27 (Union[None, Unset, str]):
+        as_left_value_subtitle_28 (Union[None, Unset, str]):
+        as_left_value_subtitle_29 (Union[None, Unset, str]):
+        as_left_value_subtitle_30 (Union[None, Unset, str]):
+        as_left_value_subtitle_31 (Union[None, Unset, str]):
+        as_left_value_subtitle_32 (Union[None, Unset, str]):
+        as_left_value_subtitle_33 (Union[None, Unset, str]):
+        as_left_value_subtitle_34 (Union[None, Unset, str]):
+        as_left_value_subtitle_35 (Union[None, Unset, str]):
+        as_left_value_subtitle_36 (Union[None, Unset, str]):
+        as_left_value_subtitle_37 (Union[None, Unset, str]):
+        as_left_value_subtitle_38 (Union[None, Unset, str]):
+        as_left_value_subtitle_39 (Union[None, Unset, str]):
+        as_left_value_subtitle_40 (Union[None, Unset, str]):
+        as_left_mean (Union[None, Unset, float]):
+        as_left_mean_raw (Union[None, Unset, float]):
+        as_left_sd (Union[None, Unset, float]):
+        as_left_sd_raw (Union[None, Unset, float]):
+        as_left_cv (Union[None, Unset, float]):
+        as_left_cv_raw (Union[None, Unset, float]):
+        as_left_delta (Union[None, Unset, float]):
+        as_left_range (Union[None, Unset, float]):
         as_left_result (Union[None, Unset, int]):
-        as_left_range_result (Union[Unset, bool]):
-        as_left_delta_result (Union[Unset, bool]):
-        as_left_min_result (Union[Unset, bool]):
-        as_left_max_result (Union[Unset, bool]):
-        as_left_tar_result (Union[Unset, bool]):
-        as_left_tur_result (Union[Unset, bool]):
-        as_left_error_result (Union[Unset, bool]):
-        as_left_sd_result (Union[Unset, bool]):
-        as_left_cv_result (Union[Unset, bool]):
-        as_left_custom_field_result (Union[Unset, int]):
-        as_left_mu (Union[Unset, float]):
-        as_left_mu_raw (Union[Unset, float]):
-        as_left_mu_effective_dof (Union[Unset, float]):
-        as_left_mu_coverage_factor (Union[Unset, float]):
-        as_left_cmc (Union[Unset, float]):
-        as_left_cmc_comments (Union[Unset, str]):
-        as_left_calculated_uncertainty (Union[Unset, float]):
-        as_left_lab_mu (Union[Unset, float]):
-        as_left_uncertainty_budget (Union[Unset, str]):
-        as_left_mu_extended (Union[Unset, str]):
-        as_left_channel (Union[Unset, int]):
-        as_left_measurement_type (Union[Unset,
+        as_left_range_result (Union[None, Unset, bool]):
+        as_left_delta_result (Union[None, Unset, bool]):
+        as_left_min_result (Union[None, Unset, bool]):
+        as_left_max_result (Union[None, Unset, bool]):
+        as_left_tar_result (Union[None, Unset, bool]):
+        as_left_tur_result (Union[None, Unset, bool]):
+        as_left_error_result (Union[None, Unset, bool]):
+        as_left_sd_result (Union[None, Unset, bool]):
+        as_left_cv_result (Union[None, Unset, bool]):
+        as_left_custom_field_result (Union[None, Unset, int]):
+        as_left_mu (Union[None, Unset, float]):
+        as_left_mu_raw (Union[None, Unset, float]):
+        as_left_mu_effective_dof (Union[None, Unset, float]):
+        as_left_mu_coverage_factor (Union[None, Unset, float]):
+        as_left_cmc (Union[None, Unset, float]):
+        as_left_cmc_comments (Union[None, Unset, str]):
+        as_left_calculated_uncertainty (Union[None, Unset, float]):
+        as_left_lab_mu (Union[None, Unset, float]):
+        as_left_uncertainty_budget (Union[None, Unset, str]):
+        as_left_mu_extended (Union[None, Unset, str]):
+        as_left_channel (Union[None, Unset, int]):
+        as_left_measurement_type (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementType]):
-        as_left_updated_by (Union[Unset, str]):
-        as_left_updated_on (Union[Unset, datetime.datetime]):
-        as_left_specification_title (Union[Unset, str]):
-        as_left_specification_subtitle (Union[Unset, str]):
-        as_left_specification_group (Union[Unset, str]):
-        as_left_batch_type (Union[Unset, int]):
-        as_left_batch_result (Union[Unset, int]):
-        as_left_is_by_channel (Union[Unset, bool]):
-        as_left_channel_count (Union[Unset, int]):
-        as_left_commenced_on (Union[Unset, datetime.datetime]):
-        as_left_commenced_by (Union[Unset, str]):
-        as_left_z_factor (Union[Unset, float]):
-        as_left_air_buoyancy (Union[Unset, float]):
-        as_left_evaporation_rate (Union[Unset, float]):
-        as_left_ambient_temperature (Union[Unset, float]):
-        as_left_air_humidity (Union[Unset, float]):
-        as_left_barometric_pressure (Union[Unset, float]):
-        as_left_altitude (Union[Unset, float]):
-        as_left_wind_speed (Union[Unset, float]):
-        as_left_solar_radiation (Union[Unset, float]):
-        as_left_light_intensity (Union[Unset, float]):
-        as_left_noise_level (Union[Unset, float]):
-        as_left_ph_level (Union[Unset, float]):
-        as_left_water_conductivity (Union[Unset, float]):
-        as_left_water_temperature (Union[Unset, float]):
-        as_left_z_factor_uom (Union[Unset, str]):
-        as_left_air_buoyancy_uom (Union[Unset, str]):
-        as_left_evaporation_rate_uom (Union[Unset, str]):
-        as_left_ambient_temperature_uom (Union[Unset, str]):
-        as_left_air_humidity_uom (Union[Unset, str]):
-        as_left_barometric_pressure_uom (Union[Unset, str]):
-        as_left_altitude_uom (Union[Unset, str]):
-        as_left_wind_speed_uom (Union[Unset, str]):
-        as_left_solar_radiation_uom (Union[Unset, str]):
-        as_left_light_intensity_uom (Union[Unset, str]):
-        as_left_noise_level_uom (Union[Unset, str]):
-        as_left_ph_level_uom (Union[Unset, str]):
-        as_left_water_conductivity_uom (Union[Unset, str]):
-        as_left_water_temperature_uom (Union[Unset, str]):
-        as_left_specification_name (Union[Unset, str]):
-        as_left_parameter_name (Union[Unset, str]):
-        as_left_display_order (Union[Unset, int]):
-        as_left_unit_of_measure (Union[Unset, str]):
-        as_left_display_format (Union[Unset, str]):
-        as_left_precision (Union[Unset, float]):
-        as_left_precision_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftPrecisionType]):
-        as_left_minimum (Union[Unset, float]):
-        as_left_nominal (Union[Unset, float]):
-        as_left_expected_value (Union[Unset, float]):
-        as_left_expected_value_raw (Union[Unset, str]):
-        as_left_test_value (Union[Unset, float]):
-        as_left_base_value (Union[Unset, float]):
-        as_left_maxi_mum (Union[Unset, float]):
-        as_left_resolution (Union[Unset, float]):
-        as_left_resolution_count (Union[Unset, int]):
-        as_left_measurement_not_taken_result (Union[Unset,
+        as_left_updated_by (Union[None, Unset, str]):
+        as_left_updated_on (Union[None, Unset, datetime.datetime]):
+        as_left_specification_title (Union[None, Unset, str]):
+        as_left_specification_subtitle (Union[None, Unset, str]):
+        as_left_specification_group (Union[None, Unset, str]):
+        as_left_batch_type (Union[None, Unset, int]):
+        as_left_batch_result (Union[None, Unset, int]):
+        as_left_is_by_channel (Union[None, Unset, bool]):
+        as_left_channel_count (Union[None, Unset, int]):
+        as_left_commenced_on (Union[None, Unset, datetime.datetime]):
+        as_left_commenced_by (Union[None, Unset, str]):
+        as_left_z_factor (Union[None, Unset, float]):
+        as_left_air_buoyancy (Union[None, Unset, float]):
+        as_left_evaporation_rate (Union[None, Unset, float]):
+        as_left_ambient_temperature (Union[None, Unset, float]):
+        as_left_air_humidity (Union[None, Unset, float]):
+        as_left_barometric_pressure (Union[None, Unset, float]):
+        as_left_altitude (Union[None, Unset, float]):
+        as_left_wind_speed (Union[None, Unset, float]):
+        as_left_solar_radiation (Union[None, Unset, float]):
+        as_left_light_intensity (Union[None, Unset, float]):
+        as_left_noise_level (Union[None, Unset, float]):
+        as_left_ph_level (Union[None, Unset, float]):
+        as_left_water_conductivity (Union[None, Unset, float]):
+        as_left_water_temperature (Union[None, Unset, float]):
+        as_left_z_factor_uom (Union[None, Unset, str]):
+        as_left_air_buoyancy_uom (Union[None, Unset, str]):
+        as_left_evaporation_rate_uom (Union[None, Unset, str]):
+        as_left_ambient_temperature_uom (Union[None, Unset, str]):
+        as_left_air_humidity_uom (Union[None, Unset, str]):
+        as_left_barometric_pressure_uom (Union[None, Unset, str]):
+        as_left_altitude_uom (Union[None, Unset, str]):
+        as_left_wind_speed_uom (Union[None, Unset, str]):
+        as_left_solar_radiation_uom (Union[None, Unset, str]):
+        as_left_light_intensity_uom (Union[None, Unset, str]):
+        as_left_noise_level_uom (Union[None, Unset, str]):
+        as_left_ph_level_uom (Union[None, Unset, str]):
+        as_left_water_conductivity_uom (Union[None, Unset, str]):
+        as_left_water_temperature_uom (Union[None, Unset, str]):
+        as_left_specification_name (Union[None, Unset, str]):
+        as_left_parameter_name (Union[None, Unset, str]):
+        as_left_display_order (Union[None, Unset, int]):
+        as_left_unit_of_measure (Union[None, Unset, str]):
+        as_left_display_format (Union[None, Unset, str]):
+        as_left_precision (Union[None, Unset, float]):
+        as_left_precision_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftPrecisionType]):
+        as_left_minimum (Union[None, Unset, float]):
+        as_left_nominal (Union[None, Unset, float]):
+        as_left_expected_value (Union[None, Unset, float]):
+        as_left_expected_value_raw (Union[None, Unset, str]):
+        as_left_test_value (Union[None, Unset, float]):
+        as_left_base_value (Union[None, Unset, float]):
+        as_left_maxi_mum (Union[None, Unset, float]):
+        as_left_resolution (Union[None, Unset, float]):
+        as_left_resolution_count (Union[None, Unset, int]):
+        as_left_measurement_not_taken_result (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementNotTakenResult]):
-        as_left_hide_from_certificate (Union[Unset, bool]):
-        as_left_measurement_not_taken_reason (Union[Unset, str]):
-        as_left_measurement_batch_id (Union[Unset, int]):
-        as_left_measurement_id (Union[Unset, int]):
-        as_left_standard_id (Union[Unset, int]):
-        as_left_tool_id (Union[Unset, int]):
-        as_left_measurement_condition_id (Union[Unset, int]):
-        as_left_measurement_point_id (Union[Unset, int]):
+        as_left_hide_from_certificate (Union[None, Unset, bool]):
+        as_left_measurement_not_taken_reason (Union[None, Unset, str]):
+        as_left_measurement_batch_id (Union[None, Unset, int]):
+        as_left_measurement_id (Union[None, Unset, int]):
+        as_left_standard_id (Union[None, Unset, int]):
+        as_left_tool_id (Union[None, Unset, int]):
+        as_left_measurement_condition_id (Union[None, Unset, int]):
+        as_left_measurement_point_id (Union[None, Unset, int]):
     """
 
-    barcode: Union[Unset, str] = UNSET
-    display_name: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    vendor_company_id: Union[Unset, int] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    completed_by_name: Union[Unset, str] = UNSET
-    completed_on: Union[Unset, datetime.datetime] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
-    room: Union[Unset, str] = UNSET
-    segment_name: Union[Unset, str] = UNSET
-    schedule_name: Union[Unset, str] = UNSET
-    next_segment_name: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    display_name: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    vendor_company_id: Union[None, Unset, int] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    completed_by_name: Union[None, Unset, str] = UNSET
+    completed_on: Union[None, Unset, datetime.datetime] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
+    room: Union[None, Unset, str] = UNSET
+    segment_name: Union[None, Unset, str] = UNSET
+    schedule_name: Union[None, Unset, str] = UNSET
+    next_segment_name: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     work_status: Union[None, Unset, WorkStatus] = UNSET
-    service_type: Union[Unset, str] = UNSET
-    service_level: Union[Unset, str] = UNSET
-    service_comments: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    asset_tag_change: Union[Unset, str] = UNSET
-    asset_user_change: Union[Unset, str] = UNSET
-    serial_number_change: Union[Unset, str] = UNSET
+    service_type: Union[None, Unset, str] = UNSET
+    service_level: Union[None, Unset, str] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    asset_tag_change: Union[None, Unset, str] = UNSET
+    asset_user_change: Union[None, Unset, str] = UNSET
+    serial_number_change: Union[None, Unset, str] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    po_number: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    po_number: Union[None, Unset, str] = UNSET
     shipped_date: Union[None, Unset, datetime.datetime] = UNSET
-    tracking_number: Union[Unset, str] = UNSET
-    payment_terms: Union[Unset, int] = UNSET
-    shipping_method: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    site_access_notes: Union[Unset, str] = UNSET
-    as_left_decimal_places: Union[Unset, int] = UNSET
-    as_left_measurement_set_name: Union[Unset, str] = UNSET
-    as_left_measurement_set_id: Union[Unset, int] = UNSET
-    as_left_adjustment_threshold: Union[Unset, float] = UNSET
-    as_left_mean_extended: Union[Unset, str] = UNSET
-    as_left_sd_extended: Union[Unset, str] = UNSET
-    as_left_range_extended: Union[Unset, str] = UNSET
-    as_left_delta_extended: Union[Unset, str] = UNSET
-    as_left_cv_extended: Union[Unset, str] = UNSET
-    as_left_nominal_extended: Union[Unset, str] = UNSET
-    as_left_min_max_header: Union[Unset, str] = UNSET
-    as_left_accuracy_class: Union[Unset, str] = UNSET
-    as_left_accuracy_class_min: Union[Unset, float] = UNSET
-    as_left_accuracy_class_max: Union[Unset, float] = UNSET
-    as_left_minimum_measured_value: Union[Unset, float] = UNSET
-    as_left_maxi_mum_measured_value: Union[Unset, float] = UNSET
-    as_left_min_max_value_extended: Union[Unset, str] = UNSET
-    as_left_tool_range_name: Union[Unset, str] = UNSET
-    as_left_tool_range_uncertainty: Union[Unset, str] = UNSET
+    tracking_number: Union[None, Unset, str] = UNSET
+    payment_terms: Union[None, Unset, int] = UNSET
+    shipping_method: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    site_access_notes: Union[None, Unset, str] = UNSET
+    as_left_decimal_places: Union[None, Unset, int] = UNSET
+    as_left_measurement_set_name: Union[None, Unset, str] = UNSET
+    as_left_measurement_set_id: Union[None, Unset, int] = UNSET
+    as_left_adjustment_threshold: Union[None, Unset, float] = UNSET
+    as_left_mean_extended: Union[None, Unset, str] = UNSET
+    as_left_sd_extended: Union[None, Unset, str] = UNSET
+    as_left_range_extended: Union[None, Unset, str] = UNSET
+    as_left_delta_extended: Union[None, Unset, str] = UNSET
+    as_left_cv_extended: Union[None, Unset, str] = UNSET
+    as_left_nominal_extended: Union[None, Unset, str] = UNSET
+    as_left_min_max_header: Union[None, Unset, str] = UNSET
+    as_left_accuracy_class: Union[None, Unset, str] = UNSET
+    as_left_accuracy_class_min: Union[None, Unset, float] = UNSET
+    as_left_accuracy_class_max: Union[None, Unset, float] = UNSET
+    as_left_minimum_measured_value: Union[None, Unset, float] = UNSET
+    as_left_maxi_mum_measured_value: Union[None, Unset, float] = UNSET
+    as_left_min_max_value_extended: Union[None, Unset, str] = UNSET
+    as_left_tool_range_name: Union[None, Unset, str] = UNSET
+    as_left_tool_range_uncertainty: Union[None, Unset, str] = UNSET
     as_left_primary_tool_last_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
     as_left_primary_tool_next_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
-    as_left_primary_tool_calibrated_by: Union[Unset, str] = UNSET
-    as_left_primary_tool_tool_name: Union[Unset, str] = UNSET
-    as_left_primary_tool_tool_description: Union[Unset, str] = UNSET
-    as_left_primary_tool_tool_type_name: Union[Unset, str] = UNSET
-    as_left_primary_tool_manufacturer: Union[Unset, str] = UNSET
-    as_left_primary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    as_left_primary_tool_serial_number: Union[Unset, str] = UNSET
-    as_found_measurement_set_name: Union[Unset, str] = UNSET
-    as_found_measurement_set_id: Union[Unset, int] = UNSET
-    as_found_adjustment_threshold: Union[Unset, float] = UNSET
-    as_found_decimal_places: Union[Unset, int] = UNSET
-    as_found_mean_extended: Union[Unset, str] = UNSET
-    as_found_sd_extended: Union[Unset, str] = UNSET
-    as_found_range_extended: Union[Unset, str] = UNSET
-    as_found_delta_extended: Union[Unset, str] = UNSET
-    as_found_cv_extended: Union[Unset, str] = UNSET
-    as_found_nominal_extended: Union[Unset, str] = UNSET
-    as_found_min_max_header: Union[Unset, str] = UNSET
-    as_found_accuracy_class: Union[Unset, str] = UNSET
-    as_found_accuracy_class_min: Union[Unset, float] = UNSET
-    as_found_accuracy_class_max: Union[Unset, float] = UNSET
-    as_found_minimum_measured_value: Union[Unset, float] = UNSET
-    as_found_maxi_mum_measured_value: Union[Unset, float] = UNSET
-    as_found_min_max_value_extended: Union[Unset, str] = UNSET
-    as_found_tool_range_name: Union[Unset, str] = UNSET
-    as_found_tool_range_uncertainty: Union[Unset, str] = UNSET
+    as_left_primary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_tool_name: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_tool_description: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    as_left_primary_tool_serial_number: Union[None, Unset, str] = UNSET
+    as_found_measurement_set_name: Union[None, Unset, str] = UNSET
+    as_found_measurement_set_id: Union[None, Unset, int] = UNSET
+    as_found_adjustment_threshold: Union[None, Unset, float] = UNSET
+    as_found_decimal_places: Union[None, Unset, int] = UNSET
+    as_found_mean_extended: Union[None, Unset, str] = UNSET
+    as_found_sd_extended: Union[None, Unset, str] = UNSET
+    as_found_range_extended: Union[None, Unset, str] = UNSET
+    as_found_delta_extended: Union[None, Unset, str] = UNSET
+    as_found_cv_extended: Union[None, Unset, str] = UNSET
+    as_found_nominal_extended: Union[None, Unset, str] = UNSET
+    as_found_min_max_header: Union[None, Unset, str] = UNSET
+    as_found_accuracy_class: Union[None, Unset, str] = UNSET
+    as_found_accuracy_class_min: Union[None, Unset, float] = UNSET
+    as_found_accuracy_class_max: Union[None, Unset, float] = UNSET
+    as_found_minimum_measured_value: Union[None, Unset, float] = UNSET
+    as_found_maxi_mum_measured_value: Union[None, Unset, float] = UNSET
+    as_found_min_max_value_extended: Union[None, Unset, str] = UNSET
+    as_found_tool_range_name: Union[None, Unset, str] = UNSET
+    as_found_tool_range_uncertainty: Union[None, Unset, str] = UNSET
     as_found_primary_tool_last_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
     as_found_primary_tool_next_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
-    as_found_primary_tool_calibrated_by: Union[Unset, str] = UNSET
-    as_found_primary_tool_tool_name: Union[Unset, str] = UNSET
-    as_found_primary_tool_tool_description: Union[Unset, str] = UNSET
-    as_found_primary_tool_tool_type_name: Union[Unset, str] = UNSET
-    as_found_primary_tool_manufacturer: Union[Unset, str] = UNSET
-    as_found_primary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    as_found_primary_tool_serial_number: Union[Unset, str] = UNSET
+    as_found_primary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_tool_name: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_tool_description: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    as_found_primary_tool_serial_number: Union[None, Unset, str] = UNSET
     as_left_secondary_tool_last_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
     as_left_secondary_tool_next_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
-    as_left_secondary_tool_calibrated_by: Union[Unset, str] = UNSET
-    as_left_secondary_tool_tool_name: Union[Unset, str] = UNSET
-    as_left_secondary_tool_tool_description: Union[Unset, str] = UNSET
-    as_left_secondary_tool_tool_type_name: Union[Unset, str] = UNSET
-    as_left_secondary_tool_manufacturer: Union[Unset, str] = UNSET
-    as_left_secondary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    as_left_secondary_tool_serial_number: Union[Unset, str] = UNSET
+    as_left_secondary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_tool_name: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_tool_description: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    as_left_secondary_tool_serial_number: Union[None, Unset, str] = UNSET
     as_found_secondary_tool_last_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
     as_found_secondary_tool_next_service_date: Union[None, Unset, datetime.datetime] = (
         UNSET
     )
-    as_found_secondary_tool_calibrated_by: Union[Unset, str] = UNSET
-    as_found_secondary_tool_tool_name: Union[Unset, str] = UNSET
-    as_found_secondary_tool_tool_description: Union[Unset, str] = UNSET
-    as_found_secondary_tool_tool_type_name: Union[Unset, str] = UNSET
-    as_found_secondary_tool_manufacturer: Union[Unset, str] = UNSET
-    as_found_secondary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    as_found_secondary_tool_serial_number: Union[Unset, str] = UNSET
-    as_found_measurement_not_taken_result: Union[
-        Unset,
+    as_found_secondary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_tool_name: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_tool_description: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    as_found_secondary_tool_serial_number: Union[None, Unset, str] = UNSET
+    as_found_measurement_not_taken_result: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementNotTakenResult,
     ] = UNSET
-    as_found_hide_from_certificate: Union[Unset, bool] = UNSET
-    as_found_measurement_not_taken_reason: Union[Unset, str] = UNSET
-    as_left_values: Union[Unset, str] = UNSET
-    as_left_is_accredited: Union[Unset, bool] = UNSET
-    as_left_is_range_accredited: Union[Unset, bool] = UNSET
-    as_found_values: Union[Unset, str] = UNSET
-    as_found_is_accredited: Union[Unset, bool] = UNSET
-    as_found_is_range_accredited: Union[Unset, bool] = UNSET
-    as_found_parameter_id: Union[Unset, int] = UNSET
-    as_found_sd_header: Union[Unset, float] = UNSET
-    as_found_cv_header: Union[Unset, float] = UNSET
-    as_found_measurement_local_time: Union[Unset, datetime.datetime] = UNSET
-    as_found_tur: Union[Unset, float] = UNSET
-    as_found_tur_raw: Union[Unset, float] = UNSET
-    as_left_tur: Union[Unset, float] = UNSET
-    as_left_tur_raw: Union[Unset, float] = UNSET
-    as_found_tar: Union[Unset, float] = UNSET
-    as_found_tar_raw: Union[Unset, float] = UNSET
-    as_left_tar: Union[Unset, float] = UNSET
-    as_left_tar_raw: Union[Unset, float] = UNSET
-    as_found_guard_band: Union[Unset, str] = UNSET
-    as_left_guard_band: Union[Unset, str] = UNSET
-    as_found_guard_band_logic: Union[
-        Unset,
+    as_found_hide_from_certificate: Union[None, Unset, bool] = UNSET
+    as_found_measurement_not_taken_reason: Union[None, Unset, str] = UNSET
+    as_left_values: Union[None, Unset, str] = UNSET
+    as_left_is_accredited: Union[None, Unset, bool] = UNSET
+    as_left_is_range_accredited: Union[None, Unset, bool] = UNSET
+    as_found_values: Union[None, Unset, str] = UNSET
+    as_found_is_accredited: Union[None, Unset, bool] = UNSET
+    as_found_is_range_accredited: Union[None, Unset, bool] = UNSET
+    as_found_parameter_id: Union[None, Unset, int] = UNSET
+    as_found_sd_header: Union[None, Unset, float] = UNSET
+    as_found_cv_header: Union[None, Unset, float] = UNSET
+    as_found_measurement_local_time: Union[None, Unset, datetime.datetime] = UNSET
+    as_found_tur: Union[None, Unset, float] = UNSET
+    as_found_tur_raw: Union[None, Unset, float] = UNSET
+    as_left_tur: Union[None, Unset, float] = UNSET
+    as_left_tur_raw: Union[None, Unset, float] = UNSET
+    as_found_tar: Union[None, Unset, float] = UNSET
+    as_found_tar_raw: Union[None, Unset, float] = UNSET
+    as_left_tar: Union[None, Unset, float] = UNSET
+    as_left_tar_raw: Union[None, Unset, float] = UNSET
+    as_found_guard_band: Union[None, Unset, str] = UNSET
+    as_left_guard_band: Union[None, Unset, str] = UNSET
+    as_found_guard_band_logic: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundGuardBandLogic,
     ] = UNSET
-    as_left_guard_band_logic: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftGuardBandLogic
+    as_left_guard_band_logic: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftGuardBandLogic
     ] = UNSET
-    as_found_error: Union[Unset, float] = UNSET
-    as_found_error_extended: Union[Unset, str] = UNSET
-    as_left_error: Union[Unset, float] = UNSET
-    as_left_error_extended: Union[Unset, str] = UNSET
-    as_found_percent_of_tolerance: Union[Unset, float] = UNSET
-    as_found_percent_of_tolerance_extended: Union[Unset, str] = UNSET
-    as_left_percent_of_tolerance: Union[Unset, float] = UNSET
-    as_left_percent_of_tolerance_extended: Union[Unset, str] = UNSET
-    as_found_tolerance_maximum: Union[Unset, float] = UNSET
-    as_found_tolerance_minimum: Union[Unset, float] = UNSET
-    as_found_tolerance_type: Union[Unset, int] = UNSET
-    as_found_tolerance_mode: Union[Unset, int] = UNSET
-    as_found_tolerance_string: Union[Unset, str] = UNSET
-    as_left_tolerance_maximum: Union[Unset, float] = UNSET
-    as_left_tolerance_minimum: Union[Unset, float] = UNSET
-    as_left_tolerance_type: Union[Unset, int] = UNSET
-    as_left_tolerance_mode: Union[Unset, int] = UNSET
-    as_left_tolerance_string: Union[Unset, str] = UNSET
-    as_found_max_hysteresis: Union[Unset, float] = UNSET
-    as_found_run: Union[Unset, int] = UNSET
-    as_found_direction: Union[Unset, int] = UNSET
-    as_found_hysteresis: Union[Unset, float] = UNSET
-    as_left_max_hysteresis: Union[Unset, float] = UNSET
-    as_left_run: Union[Unset, int] = UNSET
-    as_left_direction: Union[Unset, int] = UNSET
-    as_left_hysteresis: Union[Unset, float] = UNSET
-    as_found_reading_entry_math: Union[
-        Unset,
+    as_found_error: Union[None, Unset, float] = UNSET
+    as_found_error_extended: Union[None, Unset, str] = UNSET
+    as_left_error: Union[None, Unset, float] = UNSET
+    as_left_error_extended: Union[None, Unset, str] = UNSET
+    as_found_percent_of_tolerance: Union[None, Unset, float] = UNSET
+    as_found_percent_of_tolerance_extended: Union[None, Unset, str] = UNSET
+    as_left_percent_of_tolerance: Union[None, Unset, float] = UNSET
+    as_left_percent_of_tolerance_extended: Union[None, Unset, str] = UNSET
+    as_found_tolerance_maximum: Union[None, Unset, float] = UNSET
+    as_found_tolerance_minimum: Union[None, Unset, float] = UNSET
+    as_found_tolerance_type: Union[None, Unset, int] = UNSET
+    as_found_tolerance_mode: Union[None, Unset, int] = UNSET
+    as_found_tolerance_string: Union[None, Unset, str] = UNSET
+    as_left_tolerance_maximum: Union[None, Unset, float] = UNSET
+    as_left_tolerance_minimum: Union[None, Unset, float] = UNSET
+    as_left_tolerance_type: Union[None, Unset, int] = UNSET
+    as_left_tolerance_mode: Union[None, Unset, int] = UNSET
+    as_left_tolerance_string: Union[None, Unset, str] = UNSET
+    as_found_max_hysteresis: Union[None, Unset, float] = UNSET
+    as_found_run: Union[None, Unset, int] = UNSET
+    as_found_direction: Union[None, Unset, int] = UNSET
+    as_found_hysteresis: Union[None, Unset, float] = UNSET
+    as_left_max_hysteresis: Union[None, Unset, float] = UNSET
+    as_left_run: Union[None, Unset, int] = UNSET
+    as_left_direction: Union[None, Unset, int] = UNSET
+    as_left_hysteresis: Union[None, Unset, float] = UNSET
+    as_found_reading_entry_math: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundReadingEntryMath,
     ] = UNSET
-    as_found_reading_entry_math_string: Union[Unset, str] = UNSET
-    as_found_value_1: Union[Unset, str] = UNSET
-    as_found_value_2: Union[Unset, str] = UNSET
-    as_found_value_3: Union[Unset, str] = UNSET
-    as_found_value_4: Union[Unset, str] = UNSET
-    as_found_value_5: Union[Unset, str] = UNSET
-    as_found_value_6: Union[Unset, str] = UNSET
-    as_found_value_7: Union[Unset, str] = UNSET
-    as_found_value_8: Union[Unset, str] = UNSET
-    as_found_value_9: Union[Unset, str] = UNSET
-    as_found_value_10: Union[Unset, str] = UNSET
-    as_found_value_11: Union[Unset, str] = UNSET
-    as_found_value_12: Union[Unset, str] = UNSET
-    as_found_value_13: Union[Unset, str] = UNSET
-    as_found_value_14: Union[Unset, str] = UNSET
-    as_found_value_15: Union[Unset, str] = UNSET
-    as_found_value_16: Union[Unset, str] = UNSET
-    as_found_value_17: Union[Unset, str] = UNSET
-    as_found_value_18: Union[Unset, str] = UNSET
-    as_found_value_19: Union[Unset, str] = UNSET
-    as_found_value_20: Union[Unset, str] = UNSET
-    as_found_value_21: Union[Unset, str] = UNSET
-    as_found_value_22: Union[Unset, str] = UNSET
-    as_found_value_23: Union[Unset, str] = UNSET
-    as_found_value_24: Union[Unset, str] = UNSET
-    as_found_value_25: Union[Unset, str] = UNSET
-    as_found_value_26: Union[Unset, str] = UNSET
-    as_found_value_27: Union[Unset, str] = UNSET
-    as_found_value_28: Union[Unset, str] = UNSET
-    as_found_value_29: Union[Unset, str] = UNSET
-    as_found_value_30: Union[Unset, str] = UNSET
-    as_found_value_31: Union[Unset, str] = UNSET
-    as_found_value_32: Union[Unset, str] = UNSET
-    as_found_value_33: Union[Unset, str] = UNSET
-    as_found_value_34: Union[Unset, str] = UNSET
-    as_found_value_35: Union[Unset, str] = UNSET
-    as_found_value_36: Union[Unset, str] = UNSET
-    as_found_value_37: Union[Unset, str] = UNSET
-    as_found_value_38: Union[Unset, str] = UNSET
-    as_found_value_39: Union[Unset, str] = UNSET
-    as_found_value_40: Union[Unset, str] = UNSET
-    as_found_raw_value_1: Union[Unset, str] = UNSET
-    as_found_raw_value_2: Union[Unset, str] = UNSET
-    as_found_raw_value_3: Union[Unset, str] = UNSET
-    as_found_raw_value_4: Union[Unset, str] = UNSET
-    as_found_raw_value_5: Union[Unset, str] = UNSET
-    as_found_raw_value_6: Union[Unset, str] = UNSET
-    as_found_raw_value_7: Union[Unset, str] = UNSET
-    as_found_raw_value_8: Union[Unset, str] = UNSET
-    as_found_raw_value_9: Union[Unset, str] = UNSET
-    as_found_raw_value_10: Union[Unset, str] = UNSET
-    as_found_raw_value_11: Union[Unset, str] = UNSET
-    as_found_raw_value_12: Union[Unset, str] = UNSET
-    as_found_raw_value_13: Union[Unset, str] = UNSET
-    as_found_raw_value_14: Union[Unset, str] = UNSET
-    as_found_raw_value_15: Union[Unset, str] = UNSET
-    as_found_raw_value_16: Union[Unset, str] = UNSET
-    as_found_raw_value_17: Union[Unset, str] = UNSET
-    as_found_raw_value_18: Union[Unset, str] = UNSET
-    as_found_raw_value_19: Union[Unset, str] = UNSET
-    as_found_raw_value_20: Union[Unset, str] = UNSET
-    as_found_raw_value_21: Union[Unset, str] = UNSET
-    as_found_raw_value_22: Union[Unset, str] = UNSET
-    as_found_raw_value_23: Union[Unset, str] = UNSET
-    as_found_raw_value_24: Union[Unset, str] = UNSET
-    as_found_raw_value_25: Union[Unset, str] = UNSET
-    as_found_raw_value_26: Union[Unset, str] = UNSET
-    as_found_raw_value_27: Union[Unset, str] = UNSET
-    as_found_raw_value_28: Union[Unset, str] = UNSET
-    as_found_raw_value_29: Union[Unset, str] = UNSET
-    as_found_raw_value_30: Union[Unset, str] = UNSET
-    as_found_raw_value_31: Union[Unset, str] = UNSET
-    as_found_raw_value_32: Union[Unset, str] = UNSET
-    as_found_raw_value_33: Union[Unset, str] = UNSET
-    as_found_raw_value_34: Union[Unset, str] = UNSET
-    as_found_raw_value_35: Union[Unset, str] = UNSET
-    as_found_raw_value_36: Union[Unset, str] = UNSET
-    as_found_raw_value_37: Union[Unset, str] = UNSET
-    as_found_raw_value_38: Union[Unset, str] = UNSET
-    as_found_raw_value_39: Union[Unset, str] = UNSET
-    as_found_raw_value_40: Union[Unset, str] = UNSET
-    as_found_value_subtitle_1: Union[Unset, str] = UNSET
-    as_found_value_subtitle_2: Union[Unset, str] = UNSET
-    as_found_value_subtitle_3: Union[Unset, str] = UNSET
-    as_found_value_subtitle_4: Union[Unset, str] = UNSET
-    as_found_value_subtitle_5: Union[Unset, str] = UNSET
-    as_found_value_subtitle_6: Union[Unset, str] = UNSET
-    as_found_value_subtitle_7: Union[Unset, str] = UNSET
-    as_found_value_subtitle_8: Union[Unset, str] = UNSET
-    as_found_value_subtitle_9: Union[Unset, str] = UNSET
-    as_found_value_subtitle_10: Union[Unset, str] = UNSET
-    as_found_value_subtitle_11: Union[Unset, str] = UNSET
-    as_found_value_subtitle_12: Union[Unset, str] = UNSET
-    as_found_value_subtitle_13: Union[Unset, str] = UNSET
-    as_found_value_subtitle_14: Union[Unset, str] = UNSET
-    as_found_value_subtitle_15: Union[Unset, str] = UNSET
-    as_found_value_subtitle_16: Union[Unset, str] = UNSET
-    as_found_value_subtitle_17: Union[Unset, str] = UNSET
-    as_found_value_subtitle_18: Union[Unset, str] = UNSET
-    as_found_value_subtitle_19: Union[Unset, str] = UNSET
-    as_found_value_subtitle_20: Union[Unset, str] = UNSET
-    as_found_value_subtitle_21: Union[Unset, str] = UNSET
-    as_found_value_subtitle_22: Union[Unset, str] = UNSET
-    as_found_value_subtitle_23: Union[Unset, str] = UNSET
-    as_found_value_subtitle_24: Union[Unset, str] = UNSET
-    as_found_value_subtitle_25: Union[Unset, str] = UNSET
-    as_found_value_subtitle_26: Union[Unset, str] = UNSET
-    as_found_value_subtitle_27: Union[Unset, str] = UNSET
-    as_found_value_subtitle_28: Union[Unset, str] = UNSET
-    as_found_value_subtitle_29: Union[Unset, str] = UNSET
-    as_found_value_subtitle_30: Union[Unset, str] = UNSET
-    as_found_value_subtitle_31: Union[Unset, str] = UNSET
-    as_found_value_subtitle_32: Union[Unset, str] = UNSET
-    as_found_value_subtitle_33: Union[Unset, str] = UNSET
-    as_found_value_subtitle_34: Union[Unset, str] = UNSET
-    as_found_value_subtitle_35: Union[Unset, str] = UNSET
-    as_found_value_subtitle_36: Union[Unset, str] = UNSET
-    as_found_value_subtitle_37: Union[Unset, str] = UNSET
-    as_found_value_subtitle_38: Union[Unset, str] = UNSET
-    as_found_value_subtitle_39: Union[Unset, str] = UNSET
-    as_found_value_subtitle_40: Union[Unset, str] = UNSET
-    as_found_mean: Union[Unset, float] = UNSET
-    as_found_mean_raw: Union[Unset, float] = UNSET
-    as_found_sd: Union[Unset, float] = UNSET
-    as_found_sd_raw: Union[Unset, float] = UNSET
-    as_found_delta: Union[Unset, float] = UNSET
-    as_found_range: Union[Unset, float] = UNSET
-    as_found_cv: Union[Unset, float] = UNSET
-    as_found_cv_raw: Union[Unset, float] = UNSET
+    as_found_reading_entry_math_string: Union[None, Unset, str] = UNSET
+    as_found_value_1: Union[None, Unset, str] = UNSET
+    as_found_value_2: Union[None, Unset, str] = UNSET
+    as_found_value_3: Union[None, Unset, str] = UNSET
+    as_found_value_4: Union[None, Unset, str] = UNSET
+    as_found_value_5: Union[None, Unset, str] = UNSET
+    as_found_value_6: Union[None, Unset, str] = UNSET
+    as_found_value_7: Union[None, Unset, str] = UNSET
+    as_found_value_8: Union[None, Unset, str] = UNSET
+    as_found_value_9: Union[None, Unset, str] = UNSET
+    as_found_value_10: Union[None, Unset, str] = UNSET
+    as_found_value_11: Union[None, Unset, str] = UNSET
+    as_found_value_12: Union[None, Unset, str] = UNSET
+    as_found_value_13: Union[None, Unset, str] = UNSET
+    as_found_value_14: Union[None, Unset, str] = UNSET
+    as_found_value_15: Union[None, Unset, str] = UNSET
+    as_found_value_16: Union[None, Unset, str] = UNSET
+    as_found_value_17: Union[None, Unset, str] = UNSET
+    as_found_value_18: Union[None, Unset, str] = UNSET
+    as_found_value_19: Union[None, Unset, str] = UNSET
+    as_found_value_20: Union[None, Unset, str] = UNSET
+    as_found_value_21: Union[None, Unset, str] = UNSET
+    as_found_value_22: Union[None, Unset, str] = UNSET
+    as_found_value_23: Union[None, Unset, str] = UNSET
+    as_found_value_24: Union[None, Unset, str] = UNSET
+    as_found_value_25: Union[None, Unset, str] = UNSET
+    as_found_value_26: Union[None, Unset, str] = UNSET
+    as_found_value_27: Union[None, Unset, str] = UNSET
+    as_found_value_28: Union[None, Unset, str] = UNSET
+    as_found_value_29: Union[None, Unset, str] = UNSET
+    as_found_value_30: Union[None, Unset, str] = UNSET
+    as_found_value_31: Union[None, Unset, str] = UNSET
+    as_found_value_32: Union[None, Unset, str] = UNSET
+    as_found_value_33: Union[None, Unset, str] = UNSET
+    as_found_value_34: Union[None, Unset, str] = UNSET
+    as_found_value_35: Union[None, Unset, str] = UNSET
+    as_found_value_36: Union[None, Unset, str] = UNSET
+    as_found_value_37: Union[None, Unset, str] = UNSET
+    as_found_value_38: Union[None, Unset, str] = UNSET
+    as_found_value_39: Union[None, Unset, str] = UNSET
+    as_found_value_40: Union[None, Unset, str] = UNSET
+    as_found_raw_value_1: Union[None, Unset, str] = UNSET
+    as_found_raw_value_2: Union[None, Unset, str] = UNSET
+    as_found_raw_value_3: Union[None, Unset, str] = UNSET
+    as_found_raw_value_4: Union[None, Unset, str] = UNSET
+    as_found_raw_value_5: Union[None, Unset, str] = UNSET
+    as_found_raw_value_6: Union[None, Unset, str] = UNSET
+    as_found_raw_value_7: Union[None, Unset, str] = UNSET
+    as_found_raw_value_8: Union[None, Unset, str] = UNSET
+    as_found_raw_value_9: Union[None, Unset, str] = UNSET
+    as_found_raw_value_10: Union[None, Unset, str] = UNSET
+    as_found_raw_value_11: Union[None, Unset, str] = UNSET
+    as_found_raw_value_12: Union[None, Unset, str] = UNSET
+    as_found_raw_value_13: Union[None, Unset, str] = UNSET
+    as_found_raw_value_14: Union[None, Unset, str] = UNSET
+    as_found_raw_value_15: Union[None, Unset, str] = UNSET
+    as_found_raw_value_16: Union[None, Unset, str] = UNSET
+    as_found_raw_value_17: Union[None, Unset, str] = UNSET
+    as_found_raw_value_18: Union[None, Unset, str] = UNSET
+    as_found_raw_value_19: Union[None, Unset, str] = UNSET
+    as_found_raw_value_20: Union[None, Unset, str] = UNSET
+    as_found_raw_value_21: Union[None, Unset, str] = UNSET
+    as_found_raw_value_22: Union[None, Unset, str] = UNSET
+    as_found_raw_value_23: Union[None, Unset, str] = UNSET
+    as_found_raw_value_24: Union[None, Unset, str] = UNSET
+    as_found_raw_value_25: Union[None, Unset, str] = UNSET
+    as_found_raw_value_26: Union[None, Unset, str] = UNSET
+    as_found_raw_value_27: Union[None, Unset, str] = UNSET
+    as_found_raw_value_28: Union[None, Unset, str] = UNSET
+    as_found_raw_value_29: Union[None, Unset, str] = UNSET
+    as_found_raw_value_30: Union[None, Unset, str] = UNSET
+    as_found_raw_value_31: Union[None, Unset, str] = UNSET
+    as_found_raw_value_32: Union[None, Unset, str] = UNSET
+    as_found_raw_value_33: Union[None, Unset, str] = UNSET
+    as_found_raw_value_34: Union[None, Unset, str] = UNSET
+    as_found_raw_value_35: Union[None, Unset, str] = UNSET
+    as_found_raw_value_36: Union[None, Unset, str] = UNSET
+    as_found_raw_value_37: Union[None, Unset, str] = UNSET
+    as_found_raw_value_38: Union[None, Unset, str] = UNSET
+    as_found_raw_value_39: Union[None, Unset, str] = UNSET
+    as_found_raw_value_40: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_1: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_2: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_3: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_4: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_5: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_6: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_7: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_8: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_9: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_10: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_11: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_12: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_13: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_14: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_15: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_16: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_17: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_18: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_19: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_20: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_21: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_22: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_23: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_24: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_25: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_26: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_27: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_28: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_29: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_30: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_31: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_32: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_33: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_34: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_35: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_36: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_37: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_38: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_39: Union[None, Unset, str] = UNSET
+    as_found_value_subtitle_40: Union[None, Unset, str] = UNSET
+    as_found_mean: Union[None, Unset, float] = UNSET
+    as_found_mean_raw: Union[None, Unset, float] = UNSET
+    as_found_sd: Union[None, Unset, float] = UNSET
+    as_found_sd_raw: Union[None, Unset, float] = UNSET
+    as_found_delta: Union[None, Unset, float] = UNSET
+    as_found_range: Union[None, Unset, float] = UNSET
+    as_found_cv: Union[None, Unset, float] = UNSET
+    as_found_cv_raw: Union[None, Unset, float] = UNSET
     as_found_result: Union[None, Unset, int] = UNSET
-    as_found_range_result: Union[Unset, bool] = UNSET
-    as_found_delta_result: Union[Unset, bool] = UNSET
-    as_found_min_result: Union[Unset, bool] = UNSET
-    as_found_max_result: Union[Unset, bool] = UNSET
-    as_found_tar_result: Union[Unset, bool] = UNSET
-    as_found_tur_result: Union[Unset, bool] = UNSET
-    as_found_error_result: Union[Unset, bool] = UNSET
-    as_found_sd_result: Union[Unset, bool] = UNSET
-    as_found_cv_result: Union[Unset, bool] = UNSET
-    as_found_custom_field_result: Union[Unset, int] = UNSET
-    as_found_mu: Union[Unset, float] = UNSET
-    as_found_mu_raw: Union[Unset, float] = UNSET
-    as_found_mu_effective_dof: Union[Unset, float] = UNSET
-    as_found_mu_coverage_factor: Union[Unset, float] = UNSET
-    as_found_cmc: Union[Unset, float] = UNSET
-    as_found_cmc_comments: Union[Unset, str] = UNSET
-    as_found_calculated_uncertainty: Union[Unset, float] = UNSET
-    as_found_lab_mu: Union[Unset, float] = UNSET
-    as_found_uncertainty_budget: Union[Unset, str] = UNSET
-    as_found_mu_extended: Union[Unset, str] = UNSET
-    as_found_channel: Union[Unset, int] = UNSET
-    as_found_measurement_type: Union[
-        Unset,
+    as_found_range_result: Union[None, Unset, bool] = UNSET
+    as_found_delta_result: Union[None, Unset, bool] = UNSET
+    as_found_min_result: Union[None, Unset, bool] = UNSET
+    as_found_max_result: Union[None, Unset, bool] = UNSET
+    as_found_tar_result: Union[None, Unset, bool] = UNSET
+    as_found_tur_result: Union[None, Unset, bool] = UNSET
+    as_found_error_result: Union[None, Unset, bool] = UNSET
+    as_found_sd_result: Union[None, Unset, bool] = UNSET
+    as_found_cv_result: Union[None, Unset, bool] = UNSET
+    as_found_custom_field_result: Union[None, Unset, int] = UNSET
+    as_found_mu: Union[None, Unset, float] = UNSET
+    as_found_mu_raw: Union[None, Unset, float] = UNSET
+    as_found_mu_effective_dof: Union[None, Unset, float] = UNSET
+    as_found_mu_coverage_factor: Union[None, Unset, float] = UNSET
+    as_found_cmc: Union[None, Unset, float] = UNSET
+    as_found_cmc_comments: Union[None, Unset, str] = UNSET
+    as_found_calculated_uncertainty: Union[None, Unset, float] = UNSET
+    as_found_lab_mu: Union[None, Unset, float] = UNSET
+    as_found_uncertainty_budget: Union[None, Unset, str] = UNSET
+    as_found_mu_extended: Union[None, Unset, str] = UNSET
+    as_found_channel: Union[None, Unset, int] = UNSET
+    as_found_measurement_type: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementType,
     ] = UNSET
-    as_found_updated_by: Union[Unset, str] = UNSET
-    as_found_updated_on: Union[Unset, datetime.datetime] = UNSET
-    as_left_abbreviated_uom: Union[Unset, str] = UNSET
-    as_left_unit_scale_factor: Union[Unset, float] = UNSET
-    as_found_specification_title: Union[Unset, str] = UNSET
-    as_found_specification_subtitle: Union[Unset, str] = UNSET
-    as_found_specification_group: Union[Unset, str] = UNSET
-    as_found_batch_type: Union[Unset, int] = UNSET
-    as_found_batch_result: Union[Unset, int] = UNSET
-    as_found_is_by_channel: Union[Unset, bool] = UNSET
-    as_found_channel_count: Union[Unset, int] = UNSET
-    as_found_commenced_on: Union[Unset, datetime.datetime] = UNSET
-    as_found_commenced_by: Union[Unset, str] = UNSET
-    as_found_z_factor: Union[Unset, float] = UNSET
-    as_found_air_buoyancy: Union[Unset, float] = UNSET
-    as_found_evaporation_rate: Union[Unset, float] = UNSET
-    as_found_ambient_temperature: Union[Unset, float] = UNSET
-    as_found_air_humidity: Union[Unset, float] = UNSET
-    as_found_barometric_pressure: Union[Unset, float] = UNSET
-    as_found_altitude: Union[Unset, float] = UNSET
-    as_found_wind_speed: Union[Unset, float] = UNSET
-    as_found_solar_radiation: Union[Unset, float] = UNSET
-    as_found_light_intensity: Union[Unset, float] = UNSET
-    as_found_noise_level: Union[Unset, float] = UNSET
-    as_found_ph_level: Union[Unset, float] = UNSET
-    as_found_water_conductivity: Union[Unset, float] = UNSET
-    as_found_water_temperature: Union[Unset, float] = UNSET
-    as_found_z_factor_uom: Union[Unset, str] = UNSET
-    as_found_air_buoyancy_uom: Union[Unset, str] = UNSET
-    as_found_evaporation_rate_uom: Union[Unset, str] = UNSET
-    as_found_ambient_temperature_uom: Union[Unset, str] = UNSET
-    as_found_air_humidity_uom: Union[Unset, str] = UNSET
-    as_found_barometric_pressure_uom: Union[Unset, str] = UNSET
-    as_found_altitude_uom: Union[Unset, str] = UNSET
-    as_found_wind_speed_uom: Union[Unset, str] = UNSET
-    as_found_solar_radiation_uom: Union[Unset, str] = UNSET
-    as_found_light_intensity_uom: Union[Unset, str] = UNSET
-    as_found_noise_level_uom: Union[Unset, str] = UNSET
-    as_found_ph_level_uom: Union[Unset, str] = UNSET
-    as_found_water_conductivity_uom: Union[Unset, str] = UNSET
-    as_found_water_temperature_uom: Union[Unset, str] = UNSET
-    as_found_abbreviated_uom: Union[Unset, str] = UNSET
-    as_found_unit_scale_factor: Union[Unset, float] = UNSET
-    as_found_specification_name: Union[Unset, str] = UNSET
-    as_found_parameter_name: Union[Unset, str] = UNSET
-    as_found_display_order: Union[Unset, int] = UNSET
-    as_found_unit_of_measure: Union[Unset, str] = UNSET
-    as_found_display_format: Union[Unset, str] = UNSET
-    as_found_precision: Union[Unset, float] = UNSET
-    as_found_precision_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundPrecisionType
+    as_found_updated_by: Union[None, Unset, str] = UNSET
+    as_found_updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    as_left_abbreviated_uom: Union[None, Unset, str] = UNSET
+    as_left_unit_scale_factor: Union[None, Unset, float] = UNSET
+    as_found_specification_title: Union[None, Unset, str] = UNSET
+    as_found_specification_subtitle: Union[None, Unset, str] = UNSET
+    as_found_specification_group: Union[None, Unset, str] = UNSET
+    as_found_batch_type: Union[None, Unset, int] = UNSET
+    as_found_batch_result: Union[None, Unset, int] = UNSET
+    as_found_is_by_channel: Union[None, Unset, bool] = UNSET
+    as_found_channel_count: Union[None, Unset, int] = UNSET
+    as_found_commenced_on: Union[None, Unset, datetime.datetime] = UNSET
+    as_found_commenced_by: Union[None, Unset, str] = UNSET
+    as_found_z_factor: Union[None, Unset, float] = UNSET
+    as_found_air_buoyancy: Union[None, Unset, float] = UNSET
+    as_found_evaporation_rate: Union[None, Unset, float] = UNSET
+    as_found_ambient_temperature: Union[None, Unset, float] = UNSET
+    as_found_air_humidity: Union[None, Unset, float] = UNSET
+    as_found_barometric_pressure: Union[None, Unset, float] = UNSET
+    as_found_altitude: Union[None, Unset, float] = UNSET
+    as_found_wind_speed: Union[None, Unset, float] = UNSET
+    as_found_solar_radiation: Union[None, Unset, float] = UNSET
+    as_found_light_intensity: Union[None, Unset, float] = UNSET
+    as_found_noise_level: Union[None, Unset, float] = UNSET
+    as_found_ph_level: Union[None, Unset, float] = UNSET
+    as_found_water_conductivity: Union[None, Unset, float] = UNSET
+    as_found_water_temperature: Union[None, Unset, float] = UNSET
+    as_found_z_factor_uom: Union[None, Unset, str] = UNSET
+    as_found_air_buoyancy_uom: Union[None, Unset, str] = UNSET
+    as_found_evaporation_rate_uom: Union[None, Unset, str] = UNSET
+    as_found_ambient_temperature_uom: Union[None, Unset, str] = UNSET
+    as_found_air_humidity_uom: Union[None, Unset, str] = UNSET
+    as_found_barometric_pressure_uom: Union[None, Unset, str] = UNSET
+    as_found_altitude_uom: Union[None, Unset, str] = UNSET
+    as_found_wind_speed_uom: Union[None, Unset, str] = UNSET
+    as_found_solar_radiation_uom: Union[None, Unset, str] = UNSET
+    as_found_light_intensity_uom: Union[None, Unset, str] = UNSET
+    as_found_noise_level_uom: Union[None, Unset, str] = UNSET
+    as_found_ph_level_uom: Union[None, Unset, str] = UNSET
+    as_found_water_conductivity_uom: Union[None, Unset, str] = UNSET
+    as_found_water_temperature_uom: Union[None, Unset, str] = UNSET
+    as_found_abbreviated_uom: Union[None, Unset, str] = UNSET
+    as_found_unit_scale_factor: Union[None, Unset, float] = UNSET
+    as_found_specification_name: Union[None, Unset, str] = UNSET
+    as_found_parameter_name: Union[None, Unset, str] = UNSET
+    as_found_display_order: Union[None, Unset, int] = UNSET
+    as_found_unit_of_measure: Union[None, Unset, str] = UNSET
+    as_found_display_format: Union[None, Unset, str] = UNSET
+    as_found_precision: Union[None, Unset, float] = UNSET
+    as_found_precision_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundPrecisionType
     ] = UNSET
-    as_found_minimum: Union[Unset, float] = UNSET
-    as_found_nominal: Union[Unset, float] = UNSET
-    as_found_expected_value: Union[Unset, float] = UNSET
-    as_found_expected_value_raw: Union[Unset, str] = UNSET
-    as_found_test_value: Union[Unset, float] = UNSET
-    as_found_base_value: Union[Unset, float] = UNSET
-    as_found_maxi_mum: Union[Unset, float] = UNSET
-    as_found_resolution: Union[Unset, float] = UNSET
-    as_found_resolution_count: Union[Unset, int] = UNSET
-    as_found_measurement_batch_id: Union[Unset, int] = UNSET
-    as_found_measurement_id: Union[Unset, int] = UNSET
-    as_found_standard_id: Union[Unset, int] = UNSET
-    as_found_tool_id: Union[Unset, int] = UNSET
-    as_found_measurement_condition_id: Union[Unset, int] = UNSET
-    as_found_measurement_point_id: Union[Unset, int] = UNSET
-    as_left_parameter_id: Union[Unset, int] = UNSET
-    as_left_sd_header: Union[Unset, float] = UNSET
-    as_left_cv_header: Union[Unset, float] = UNSET
-    as_left_measurement_local_time: Union[Unset, datetime.datetime] = UNSET
-    as_left_reading_entry_math: Union[
-        Unset,
+    as_found_minimum: Union[None, Unset, float] = UNSET
+    as_found_nominal: Union[None, Unset, float] = UNSET
+    as_found_expected_value: Union[None, Unset, float] = UNSET
+    as_found_expected_value_raw: Union[None, Unset, str] = UNSET
+    as_found_test_value: Union[None, Unset, float] = UNSET
+    as_found_base_value: Union[None, Unset, float] = UNSET
+    as_found_maxi_mum: Union[None, Unset, float] = UNSET
+    as_found_resolution: Union[None, Unset, float] = UNSET
+    as_found_resolution_count: Union[None, Unset, int] = UNSET
+    as_found_measurement_batch_id: Union[None, Unset, int] = UNSET
+    as_found_measurement_id: Union[None, Unset, int] = UNSET
+    as_found_standard_id: Union[None, Unset, int] = UNSET
+    as_found_tool_id: Union[None, Unset, int] = UNSET
+    as_found_measurement_condition_id: Union[None, Unset, int] = UNSET
+    as_found_measurement_point_id: Union[None, Unset, int] = UNSET
+    as_left_parameter_id: Union[None, Unset, int] = UNSET
+    as_left_sd_header: Union[None, Unset, float] = UNSET
+    as_left_cv_header: Union[None, Unset, float] = UNSET
+    as_left_measurement_local_time: Union[None, Unset, datetime.datetime] = UNSET
+    as_left_reading_entry_math: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftReadingEntryMath,
     ] = UNSET
-    as_left_reading_entry_math_string: Union[Unset, str] = UNSET
-    as_left_value_1: Union[Unset, str] = UNSET
-    as_left_value_2: Union[Unset, str] = UNSET
-    as_left_value_3: Union[Unset, str] = UNSET
-    as_left_value_4: Union[Unset, str] = UNSET
-    as_left_value_5: Union[Unset, str] = UNSET
-    as_left_value_6: Union[Unset, str] = UNSET
-    as_left_value_7: Union[Unset, str] = UNSET
-    as_left_value_8: Union[Unset, str] = UNSET
-    as_left_value_9: Union[Unset, str] = UNSET
-    as_left_value_10: Union[Unset, str] = UNSET
-    as_left_value_11: Union[Unset, str] = UNSET
-    as_left_value_12: Union[Unset, str] = UNSET
-    as_left_value_13: Union[Unset, str] = UNSET
-    as_left_value_14: Union[Unset, str] = UNSET
-    as_left_value_15: Union[Unset, str] = UNSET
-    as_left_value_16: Union[Unset, str] = UNSET
-    as_left_value_17: Union[Unset, str] = UNSET
-    as_left_value_18: Union[Unset, str] = UNSET
-    as_left_value_19: Union[Unset, str] = UNSET
-    as_left_value_20: Union[Unset, str] = UNSET
-    as_left_value_21: Union[Unset, str] = UNSET
-    as_left_value_22: Union[Unset, str] = UNSET
-    as_left_value_23: Union[Unset, str] = UNSET
-    as_left_value_24: Union[Unset, str] = UNSET
-    as_left_value_25: Union[Unset, str] = UNSET
-    as_left_value_26: Union[Unset, str] = UNSET
-    as_left_value_27: Union[Unset, str] = UNSET
-    as_left_value_28: Union[Unset, str] = UNSET
-    as_left_value_29: Union[Unset, str] = UNSET
-    as_left_value_30: Union[Unset, str] = UNSET
-    as_left_value_31: Union[Unset, str] = UNSET
-    as_left_value_32: Union[Unset, str] = UNSET
-    as_left_value_33: Union[Unset, str] = UNSET
-    as_left_value_34: Union[Unset, str] = UNSET
-    as_left_value_35: Union[Unset, str] = UNSET
-    as_left_value_36: Union[Unset, str] = UNSET
-    as_left_value_37: Union[Unset, str] = UNSET
-    as_left_value_38: Union[Unset, str] = UNSET
-    as_left_value_39: Union[Unset, str] = UNSET
-    as_left_value_40: Union[Unset, str] = UNSET
-    as_left_raw_value_1: Union[Unset, str] = UNSET
-    as_left_raw_value_2: Union[Unset, str] = UNSET
-    as_left_raw_value_3: Union[Unset, str] = UNSET
-    as_left_raw_value_4: Union[Unset, str] = UNSET
-    as_left_raw_value_5: Union[Unset, str] = UNSET
-    as_left_raw_value_6: Union[Unset, str] = UNSET
-    as_left_raw_value_7: Union[Unset, str] = UNSET
-    as_left_raw_value_8: Union[Unset, str] = UNSET
-    as_left_raw_value_9: Union[Unset, str] = UNSET
-    as_left_raw_value_10: Union[Unset, str] = UNSET
-    as_left_raw_value_11: Union[Unset, str] = UNSET
-    as_left_raw_value_12: Union[Unset, str] = UNSET
-    as_left_raw_value_13: Union[Unset, str] = UNSET
-    as_left_raw_value_14: Union[Unset, str] = UNSET
-    as_left_raw_value_15: Union[Unset, str] = UNSET
-    as_left_raw_value_16: Union[Unset, str] = UNSET
-    as_left_raw_value_17: Union[Unset, str] = UNSET
-    as_left_raw_value_18: Union[Unset, str] = UNSET
-    as_left_raw_value_19: Union[Unset, str] = UNSET
-    as_left_raw_value_20: Union[Unset, str] = UNSET
-    as_left_raw_value_21: Union[Unset, str] = UNSET
-    as_left_raw_value_22: Union[Unset, str] = UNSET
-    as_left_raw_value_23: Union[Unset, str] = UNSET
-    as_left_raw_value_24: Union[Unset, str] = UNSET
-    as_left_raw_value_25: Union[Unset, str] = UNSET
-    as_left_raw_value_26: Union[Unset, str] = UNSET
-    as_left_raw_value_27: Union[Unset, str] = UNSET
-    as_left_raw_value_28: Union[Unset, str] = UNSET
-    as_left_raw_value_29: Union[Unset, str] = UNSET
-    as_left_raw_value_30: Union[Unset, str] = UNSET
-    as_left_raw_value_31: Union[Unset, str] = UNSET
-    as_left_raw_value_32: Union[Unset, str] = UNSET
-    as_left_raw_value_33: Union[Unset, str] = UNSET
-    as_left_raw_value_34: Union[Unset, str] = UNSET
-    as_left_raw_value_35: Union[Unset, str] = UNSET
-    as_left_raw_value_36: Union[Unset, str] = UNSET
-    as_left_raw_value_37: Union[Unset, str] = UNSET
-    as_left_raw_value_38: Union[Unset, str] = UNSET
-    as_left_raw_value_39: Union[Unset, str] = UNSET
-    as_left_raw_value_40: Union[Unset, str] = UNSET
-    as_left_value_subtitle_1: Union[Unset, str] = UNSET
-    as_left_value_subtitle_2: Union[Unset, str] = UNSET
-    as_left_value_subtitle_3: Union[Unset, str] = UNSET
-    as_left_value_subtitle_4: Union[Unset, str] = UNSET
-    as_left_value_subtitle_5: Union[Unset, str] = UNSET
-    as_left_value_subtitle_6: Union[Unset, str] = UNSET
-    as_left_value_subtitle_7: Union[Unset, str] = UNSET
-    as_left_value_subtitle_8: Union[Unset, str] = UNSET
-    as_left_value_subtitle_9: Union[Unset, str] = UNSET
-    as_left_value_subtitle_10: Union[Unset, str] = UNSET
-    as_left_value_subtitle_11: Union[Unset, str] = UNSET
-    as_left_value_subtitle_12: Union[Unset, str] = UNSET
-    as_left_value_subtitle_13: Union[Unset, str] = UNSET
-    as_left_value_subtitle_14: Union[Unset, str] = UNSET
-    as_left_value_subtitle_15: Union[Unset, str] = UNSET
-    as_left_value_subtitle_16: Union[Unset, str] = UNSET
-    as_left_value_subtitle_17: Union[Unset, str] = UNSET
-    as_left_value_subtitle_18: Union[Unset, str] = UNSET
-    as_left_value_subtitle_19: Union[Unset, str] = UNSET
-    as_left_value_subtitle_20: Union[Unset, str] = UNSET
-    as_left_value_subtitle_21: Union[Unset, str] = UNSET
-    as_left_value_subtitle_22: Union[Unset, str] = UNSET
-    as_left_value_subtitle_23: Union[Unset, str] = UNSET
-    as_left_value_subtitle_24: Union[Unset, str] = UNSET
-    as_left_value_subtitle_25: Union[Unset, str] = UNSET
-    as_left_value_subtitle_26: Union[Unset, str] = UNSET
-    as_left_value_subtitle_27: Union[Unset, str] = UNSET
-    as_left_value_subtitle_28: Union[Unset, str] = UNSET
-    as_left_value_subtitle_29: Union[Unset, str] = UNSET
-    as_left_value_subtitle_30: Union[Unset, str] = UNSET
-    as_left_value_subtitle_31: Union[Unset, str] = UNSET
-    as_left_value_subtitle_32: Union[Unset, str] = UNSET
-    as_left_value_subtitle_33: Union[Unset, str] = UNSET
-    as_left_value_subtitle_34: Union[Unset, str] = UNSET
-    as_left_value_subtitle_35: Union[Unset, str] = UNSET
-    as_left_value_subtitle_36: Union[Unset, str] = UNSET
-    as_left_value_subtitle_37: Union[Unset, str] = UNSET
-    as_left_value_subtitle_38: Union[Unset, str] = UNSET
-    as_left_value_subtitle_39: Union[Unset, str] = UNSET
-    as_left_value_subtitle_40: Union[Unset, str] = UNSET
-    as_left_mean: Union[Unset, float] = UNSET
-    as_left_mean_raw: Union[Unset, float] = UNSET
-    as_left_sd: Union[Unset, float] = UNSET
-    as_left_sd_raw: Union[Unset, float] = UNSET
-    as_left_cv: Union[Unset, float] = UNSET
-    as_left_cv_raw: Union[Unset, float] = UNSET
-    as_left_delta: Union[Unset, float] = UNSET
-    as_left_range: Union[Unset, float] = UNSET
+    as_left_reading_entry_math_string: Union[None, Unset, str] = UNSET
+    as_left_value_1: Union[None, Unset, str] = UNSET
+    as_left_value_2: Union[None, Unset, str] = UNSET
+    as_left_value_3: Union[None, Unset, str] = UNSET
+    as_left_value_4: Union[None, Unset, str] = UNSET
+    as_left_value_5: Union[None, Unset, str] = UNSET
+    as_left_value_6: Union[None, Unset, str] = UNSET
+    as_left_value_7: Union[None, Unset, str] = UNSET
+    as_left_value_8: Union[None, Unset, str] = UNSET
+    as_left_value_9: Union[None, Unset, str] = UNSET
+    as_left_value_10: Union[None, Unset, str] = UNSET
+    as_left_value_11: Union[None, Unset, str] = UNSET
+    as_left_value_12: Union[None, Unset, str] = UNSET
+    as_left_value_13: Union[None, Unset, str] = UNSET
+    as_left_value_14: Union[None, Unset, str] = UNSET
+    as_left_value_15: Union[None, Unset, str] = UNSET
+    as_left_value_16: Union[None, Unset, str] = UNSET
+    as_left_value_17: Union[None, Unset, str] = UNSET
+    as_left_value_18: Union[None, Unset, str] = UNSET
+    as_left_value_19: Union[None, Unset, str] = UNSET
+    as_left_value_20: Union[None, Unset, str] = UNSET
+    as_left_value_21: Union[None, Unset, str] = UNSET
+    as_left_value_22: Union[None, Unset, str] = UNSET
+    as_left_value_23: Union[None, Unset, str] = UNSET
+    as_left_value_24: Union[None, Unset, str] = UNSET
+    as_left_value_25: Union[None, Unset, str] = UNSET
+    as_left_value_26: Union[None, Unset, str] = UNSET
+    as_left_value_27: Union[None, Unset, str] = UNSET
+    as_left_value_28: Union[None, Unset, str] = UNSET
+    as_left_value_29: Union[None, Unset, str] = UNSET
+    as_left_value_30: Union[None, Unset, str] = UNSET
+    as_left_value_31: Union[None, Unset, str] = UNSET
+    as_left_value_32: Union[None, Unset, str] = UNSET
+    as_left_value_33: Union[None, Unset, str] = UNSET
+    as_left_value_34: Union[None, Unset, str] = UNSET
+    as_left_value_35: Union[None, Unset, str] = UNSET
+    as_left_value_36: Union[None, Unset, str] = UNSET
+    as_left_value_37: Union[None, Unset, str] = UNSET
+    as_left_value_38: Union[None, Unset, str] = UNSET
+    as_left_value_39: Union[None, Unset, str] = UNSET
+    as_left_value_40: Union[None, Unset, str] = UNSET
+    as_left_raw_value_1: Union[None, Unset, str] = UNSET
+    as_left_raw_value_2: Union[None, Unset, str] = UNSET
+    as_left_raw_value_3: Union[None, Unset, str] = UNSET
+    as_left_raw_value_4: Union[None, Unset, str] = UNSET
+    as_left_raw_value_5: Union[None, Unset, str] = UNSET
+    as_left_raw_value_6: Union[None, Unset, str] = UNSET
+    as_left_raw_value_7: Union[None, Unset, str] = UNSET
+    as_left_raw_value_8: Union[None, Unset, str] = UNSET
+    as_left_raw_value_9: Union[None, Unset, str] = UNSET
+    as_left_raw_value_10: Union[None, Unset, str] = UNSET
+    as_left_raw_value_11: Union[None, Unset, str] = UNSET
+    as_left_raw_value_12: Union[None, Unset, str] = UNSET
+    as_left_raw_value_13: Union[None, Unset, str] = UNSET
+    as_left_raw_value_14: Union[None, Unset, str] = UNSET
+    as_left_raw_value_15: Union[None, Unset, str] = UNSET
+    as_left_raw_value_16: Union[None, Unset, str] = UNSET
+    as_left_raw_value_17: Union[None, Unset, str] = UNSET
+    as_left_raw_value_18: Union[None, Unset, str] = UNSET
+    as_left_raw_value_19: Union[None, Unset, str] = UNSET
+    as_left_raw_value_20: Union[None, Unset, str] = UNSET
+    as_left_raw_value_21: Union[None, Unset, str] = UNSET
+    as_left_raw_value_22: Union[None, Unset, str] = UNSET
+    as_left_raw_value_23: Union[None, Unset, str] = UNSET
+    as_left_raw_value_24: Union[None, Unset, str] = UNSET
+    as_left_raw_value_25: Union[None, Unset, str] = UNSET
+    as_left_raw_value_26: Union[None, Unset, str] = UNSET
+    as_left_raw_value_27: Union[None, Unset, str] = UNSET
+    as_left_raw_value_28: Union[None, Unset, str] = UNSET
+    as_left_raw_value_29: Union[None, Unset, str] = UNSET
+    as_left_raw_value_30: Union[None, Unset, str] = UNSET
+    as_left_raw_value_31: Union[None, Unset, str] = UNSET
+    as_left_raw_value_32: Union[None, Unset, str] = UNSET
+    as_left_raw_value_33: Union[None, Unset, str] = UNSET
+    as_left_raw_value_34: Union[None, Unset, str] = UNSET
+    as_left_raw_value_35: Union[None, Unset, str] = UNSET
+    as_left_raw_value_36: Union[None, Unset, str] = UNSET
+    as_left_raw_value_37: Union[None, Unset, str] = UNSET
+    as_left_raw_value_38: Union[None, Unset, str] = UNSET
+    as_left_raw_value_39: Union[None, Unset, str] = UNSET
+    as_left_raw_value_40: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_1: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_2: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_3: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_4: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_5: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_6: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_7: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_8: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_9: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_10: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_11: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_12: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_13: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_14: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_15: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_16: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_17: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_18: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_19: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_20: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_21: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_22: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_23: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_24: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_25: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_26: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_27: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_28: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_29: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_30: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_31: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_32: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_33: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_34: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_35: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_36: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_37: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_38: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_39: Union[None, Unset, str] = UNSET
+    as_left_value_subtitle_40: Union[None, Unset, str] = UNSET
+    as_left_mean: Union[None, Unset, float] = UNSET
+    as_left_mean_raw: Union[None, Unset, float] = UNSET
+    as_left_sd: Union[None, Unset, float] = UNSET
+    as_left_sd_raw: Union[None, Unset, float] = UNSET
+    as_left_cv: Union[None, Unset, float] = UNSET
+    as_left_cv_raw: Union[None, Unset, float] = UNSET
+    as_left_delta: Union[None, Unset, float] = UNSET
+    as_left_range: Union[None, Unset, float] = UNSET
     as_left_result: Union[None, Unset, int] = UNSET
-    as_left_range_result: Union[Unset, bool] = UNSET
-    as_left_delta_result: Union[Unset, bool] = UNSET
-    as_left_min_result: Union[Unset, bool] = UNSET
-    as_left_max_result: Union[Unset, bool] = UNSET
-    as_left_tar_result: Union[Unset, bool] = UNSET
-    as_left_tur_result: Union[Unset, bool] = UNSET
-    as_left_error_result: Union[Unset, bool] = UNSET
-    as_left_sd_result: Union[Unset, bool] = UNSET
-    as_left_cv_result: Union[Unset, bool] = UNSET
-    as_left_custom_field_result: Union[Unset, int] = UNSET
-    as_left_mu: Union[Unset, float] = UNSET
-    as_left_mu_raw: Union[Unset, float] = UNSET
-    as_left_mu_effective_dof: Union[Unset, float] = UNSET
-    as_left_mu_coverage_factor: Union[Unset, float] = UNSET
-    as_left_cmc: Union[Unset, float] = UNSET
-    as_left_cmc_comments: Union[Unset, str] = UNSET
-    as_left_calculated_uncertainty: Union[Unset, float] = UNSET
-    as_left_lab_mu: Union[Unset, float] = UNSET
-    as_left_uncertainty_budget: Union[Unset, str] = UNSET
-    as_left_mu_extended: Union[Unset, str] = UNSET
-    as_left_channel: Union[Unset, int] = UNSET
-    as_left_measurement_type: Union[
-        Unset,
+    as_left_range_result: Union[None, Unset, bool] = UNSET
+    as_left_delta_result: Union[None, Unset, bool] = UNSET
+    as_left_min_result: Union[None, Unset, bool] = UNSET
+    as_left_max_result: Union[None, Unset, bool] = UNSET
+    as_left_tar_result: Union[None, Unset, bool] = UNSET
+    as_left_tur_result: Union[None, Unset, bool] = UNSET
+    as_left_error_result: Union[None, Unset, bool] = UNSET
+    as_left_sd_result: Union[None, Unset, bool] = UNSET
+    as_left_cv_result: Union[None, Unset, bool] = UNSET
+    as_left_custom_field_result: Union[None, Unset, int] = UNSET
+    as_left_mu: Union[None, Unset, float] = UNSET
+    as_left_mu_raw: Union[None, Unset, float] = UNSET
+    as_left_mu_effective_dof: Union[None, Unset, float] = UNSET
+    as_left_mu_coverage_factor: Union[None, Unset, float] = UNSET
+    as_left_cmc: Union[None, Unset, float] = UNSET
+    as_left_cmc_comments: Union[None, Unset, str] = UNSET
+    as_left_calculated_uncertainty: Union[None, Unset, float] = UNSET
+    as_left_lab_mu: Union[None, Unset, float] = UNSET
+    as_left_uncertainty_budget: Union[None, Unset, str] = UNSET
+    as_left_mu_extended: Union[None, Unset, str] = UNSET
+    as_left_channel: Union[None, Unset, int] = UNSET
+    as_left_measurement_type: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementType,
     ] = UNSET
-    as_left_updated_by: Union[Unset, str] = UNSET
-    as_left_updated_on: Union[Unset, datetime.datetime] = UNSET
-    as_left_specification_title: Union[Unset, str] = UNSET
-    as_left_specification_subtitle: Union[Unset, str] = UNSET
-    as_left_specification_group: Union[Unset, str] = UNSET
-    as_left_batch_type: Union[Unset, int] = UNSET
-    as_left_batch_result: Union[Unset, int] = UNSET
-    as_left_is_by_channel: Union[Unset, bool] = UNSET
-    as_left_channel_count: Union[Unset, int] = UNSET
-    as_left_commenced_on: Union[Unset, datetime.datetime] = UNSET
-    as_left_commenced_by: Union[Unset, str] = UNSET
-    as_left_z_factor: Union[Unset, float] = UNSET
-    as_left_air_buoyancy: Union[Unset, float] = UNSET
-    as_left_evaporation_rate: Union[Unset, float] = UNSET
-    as_left_ambient_temperature: Union[Unset, float] = UNSET
-    as_left_air_humidity: Union[Unset, float] = UNSET
-    as_left_barometric_pressure: Union[Unset, float] = UNSET
-    as_left_altitude: Union[Unset, float] = UNSET
-    as_left_wind_speed: Union[Unset, float] = UNSET
-    as_left_solar_radiation: Union[Unset, float] = UNSET
-    as_left_light_intensity: Union[Unset, float] = UNSET
-    as_left_noise_level: Union[Unset, float] = UNSET
-    as_left_ph_level: Union[Unset, float] = UNSET
-    as_left_water_conductivity: Union[Unset, float] = UNSET
-    as_left_water_temperature: Union[Unset, float] = UNSET
-    as_left_z_factor_uom: Union[Unset, str] = UNSET
-    as_left_air_buoyancy_uom: Union[Unset, str] = UNSET
-    as_left_evaporation_rate_uom: Union[Unset, str] = UNSET
-    as_left_ambient_temperature_uom: Union[Unset, str] = UNSET
-    as_left_air_humidity_uom: Union[Unset, str] = UNSET
-    as_left_barometric_pressure_uom: Union[Unset, str] = UNSET
-    as_left_altitude_uom: Union[Unset, str] = UNSET
-    as_left_wind_speed_uom: Union[Unset, str] = UNSET
-    as_left_solar_radiation_uom: Union[Unset, str] = UNSET
-    as_left_light_intensity_uom: Union[Unset, str] = UNSET
-    as_left_noise_level_uom: Union[Unset, str] = UNSET
-    as_left_ph_level_uom: Union[Unset, str] = UNSET
-    as_left_water_conductivity_uom: Union[Unset, str] = UNSET
-    as_left_water_temperature_uom: Union[Unset, str] = UNSET
-    as_left_specification_name: Union[Unset, str] = UNSET
-    as_left_parameter_name: Union[Unset, str] = UNSET
-    as_left_display_order: Union[Unset, int] = UNSET
-    as_left_unit_of_measure: Union[Unset, str] = UNSET
-    as_left_display_format: Union[Unset, str] = UNSET
-    as_left_precision: Union[Unset, float] = UNSET
-    as_left_precision_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftPrecisionType
+    as_left_updated_by: Union[None, Unset, str] = UNSET
+    as_left_updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    as_left_specification_title: Union[None, Unset, str] = UNSET
+    as_left_specification_subtitle: Union[None, Unset, str] = UNSET
+    as_left_specification_group: Union[None, Unset, str] = UNSET
+    as_left_batch_type: Union[None, Unset, int] = UNSET
+    as_left_batch_result: Union[None, Unset, int] = UNSET
+    as_left_is_by_channel: Union[None, Unset, bool] = UNSET
+    as_left_channel_count: Union[None, Unset, int] = UNSET
+    as_left_commenced_on: Union[None, Unset, datetime.datetime] = UNSET
+    as_left_commenced_by: Union[None, Unset, str] = UNSET
+    as_left_z_factor: Union[None, Unset, float] = UNSET
+    as_left_air_buoyancy: Union[None, Unset, float] = UNSET
+    as_left_evaporation_rate: Union[None, Unset, float] = UNSET
+    as_left_ambient_temperature: Union[None, Unset, float] = UNSET
+    as_left_air_humidity: Union[None, Unset, float] = UNSET
+    as_left_barometric_pressure: Union[None, Unset, float] = UNSET
+    as_left_altitude: Union[None, Unset, float] = UNSET
+    as_left_wind_speed: Union[None, Unset, float] = UNSET
+    as_left_solar_radiation: Union[None, Unset, float] = UNSET
+    as_left_light_intensity: Union[None, Unset, float] = UNSET
+    as_left_noise_level: Union[None, Unset, float] = UNSET
+    as_left_ph_level: Union[None, Unset, float] = UNSET
+    as_left_water_conductivity: Union[None, Unset, float] = UNSET
+    as_left_water_temperature: Union[None, Unset, float] = UNSET
+    as_left_z_factor_uom: Union[None, Unset, str] = UNSET
+    as_left_air_buoyancy_uom: Union[None, Unset, str] = UNSET
+    as_left_evaporation_rate_uom: Union[None, Unset, str] = UNSET
+    as_left_ambient_temperature_uom: Union[None, Unset, str] = UNSET
+    as_left_air_humidity_uom: Union[None, Unset, str] = UNSET
+    as_left_barometric_pressure_uom: Union[None, Unset, str] = UNSET
+    as_left_altitude_uom: Union[None, Unset, str] = UNSET
+    as_left_wind_speed_uom: Union[None, Unset, str] = UNSET
+    as_left_solar_radiation_uom: Union[None, Unset, str] = UNSET
+    as_left_light_intensity_uom: Union[None, Unset, str] = UNSET
+    as_left_noise_level_uom: Union[None, Unset, str] = UNSET
+    as_left_ph_level_uom: Union[None, Unset, str] = UNSET
+    as_left_water_conductivity_uom: Union[None, Unset, str] = UNSET
+    as_left_water_temperature_uom: Union[None, Unset, str] = UNSET
+    as_left_specification_name: Union[None, Unset, str] = UNSET
+    as_left_parameter_name: Union[None, Unset, str] = UNSET
+    as_left_display_order: Union[None, Unset, int] = UNSET
+    as_left_unit_of_measure: Union[None, Unset, str] = UNSET
+    as_left_display_format: Union[None, Unset, str] = UNSET
+    as_left_precision: Union[None, Unset, float] = UNSET
+    as_left_precision_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftPrecisionType
     ] = UNSET
-    as_left_minimum: Union[Unset, float] = UNSET
-    as_left_nominal: Union[Unset, float] = UNSET
-    as_left_expected_value: Union[Unset, float] = UNSET
-    as_left_expected_value_raw: Union[Unset, str] = UNSET
-    as_left_test_value: Union[Unset, float] = UNSET
-    as_left_base_value: Union[Unset, float] = UNSET
-    as_left_maxi_mum: Union[Unset, float] = UNSET
-    as_left_resolution: Union[Unset, float] = UNSET
-    as_left_resolution_count: Union[Unset, int] = UNSET
-    as_left_measurement_not_taken_result: Union[
-        Unset,
+    as_left_minimum: Union[None, Unset, float] = UNSET
+    as_left_nominal: Union[None, Unset, float] = UNSET
+    as_left_expected_value: Union[None, Unset, float] = UNSET
+    as_left_expected_value_raw: Union[None, Unset, str] = UNSET
+    as_left_test_value: Union[None, Unset, float] = UNSET
+    as_left_base_value: Union[None, Unset, float] = UNSET
+    as_left_maxi_mum: Union[None, Unset, float] = UNSET
+    as_left_resolution: Union[None, Unset, float] = UNSET
+    as_left_resolution_count: Union[None, Unset, int] = UNSET
+    as_left_measurement_not_taken_result: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementNotTakenResult,
     ] = UNSET
-    as_left_hide_from_certificate: Union[Unset, bool] = UNSET
-    as_left_measurement_not_taken_reason: Union[Unset, str] = UNSET
-    as_left_measurement_batch_id: Union[Unset, int] = UNSET
-    as_left_measurement_id: Union[Unset, int] = UNSET
-    as_left_standard_id: Union[Unset, int] = UNSET
-    as_left_tool_id: Union[Unset, int] = UNSET
-    as_left_measurement_condition_id: Union[Unset, int] = UNSET
-    as_left_measurement_point_id: Union[Unset, int] = UNSET
+    as_left_hide_from_certificate: Union[None, Unset, bool] = UNSET
+    as_left_measurement_not_taken_reason: Union[None, Unset, str] = UNSET
+    as_left_measurement_batch_id: Union[None, Unset, int] = UNSET
+    as_left_measurement_id: Union[None, Unset, int] = UNSET
+    as_left_standard_id: Union[None, Unset, int] = UNSET
+    as_left_tool_id: Union[None, Unset, int] = UNSET
+    as_left_measurement_condition_id: Union[None, Unset, int] = UNSET
+    as_left_measurement_point_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -1339,7 +1329,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         completed_by_name = self.completed_by_name
 
-        completed_on: Union[Unset, str] = UNSET
+        completed_on: Union[None, Unset, str] = UNSET
         if self.completed_on and not isinstance(self.completed_on, Unset):
             completed_on = self.completed_on.isoformat()
 
@@ -1705,7 +1695,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
             self.as_found_secondary_tool_serial_number
         )
 
-        as_found_measurement_not_taken_result: Union[Unset, str] = UNSET
+        as_found_measurement_not_taken_result: Union[None, Unset, str] = UNSET
         if self.as_found_measurement_not_taken_result and not isinstance(
             self.as_found_measurement_not_taken_result, Unset
         ):
@@ -1737,7 +1727,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_found_cv_header = self.as_found_cv_header
 
-        as_found_measurement_local_time: Union[Unset, str] = UNSET
+        as_found_measurement_local_time: Union[None, Unset, str] = UNSET
         if self.as_found_measurement_local_time and not isinstance(
             self.as_found_measurement_local_time, Unset
         ):
@@ -1765,13 +1755,13 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_guard_band = self.as_left_guard_band
 
-        as_found_guard_band_logic: Union[Unset, str] = UNSET
+        as_found_guard_band_logic: Union[None, Unset, str] = UNSET
         if self.as_found_guard_band_logic and not isinstance(
             self.as_found_guard_band_logic, Unset
         ):
             as_found_guard_band_logic = self.as_found_guard_band_logic.value
 
-        as_left_guard_band_logic: Union[Unset, str] = UNSET
+        as_left_guard_band_logic: Union[None, Unset, str] = UNSET
         if self.as_left_guard_band_logic and not isinstance(
             self.as_left_guard_band_logic, Unset
         ):
@@ -1833,7 +1823,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_hysteresis = self.as_left_hysteresis
 
-        as_found_reading_entry_math: Union[Unset, str] = UNSET
+        as_found_reading_entry_math: Union[None, Unset, str] = UNSET
         if self.as_found_reading_entry_math and not isinstance(
             self.as_found_reading_entry_math, Unset
         ):
@@ -2148,7 +2138,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_found_channel = self.as_found_channel
 
-        as_found_measurement_type: Union[Unset, str] = UNSET
+        as_found_measurement_type: Union[None, Unset, str] = UNSET
         if self.as_found_measurement_type and not isinstance(
             self.as_found_measurement_type, Unset
         ):
@@ -2156,7 +2146,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_found_updated_by = self.as_found_updated_by
 
-        as_found_updated_on: Union[Unset, str] = UNSET
+        as_found_updated_on: Union[None, Unset, str] = UNSET
         if self.as_found_updated_on and not isinstance(self.as_found_updated_on, Unset):
             as_found_updated_on = self.as_found_updated_on.isoformat()
 
@@ -2178,7 +2168,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_found_channel_count = self.as_found_channel_count
 
-        as_found_commenced_on: Union[Unset, str] = UNSET
+        as_found_commenced_on: Union[None, Unset, str] = UNSET
         if self.as_found_commenced_on and not isinstance(
             self.as_found_commenced_on, Unset
         ):
@@ -2258,7 +2248,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_found_precision = self.as_found_precision
 
-        as_found_precision_type: Union[Unset, str] = UNSET
+        as_found_precision_type: Union[None, Unset, str] = UNSET
         if self.as_found_precision_type and not isinstance(
             self.as_found_precision_type, Unset
         ):
@@ -2300,7 +2290,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_cv_header = self.as_left_cv_header
 
-        as_left_measurement_local_time: Union[Unset, str] = UNSET
+        as_left_measurement_local_time: Union[None, Unset, str] = UNSET
         if self.as_left_measurement_local_time and not isinstance(
             self.as_left_measurement_local_time, Unset
         ):
@@ -2308,7 +2298,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
                 self.as_left_measurement_local_time.isoformat()
             )
 
-        as_left_reading_entry_math: Union[Unset, str] = UNSET
+        as_left_reading_entry_math: Union[None, Unset, str] = UNSET
         if self.as_left_reading_entry_math and not isinstance(
             self.as_left_reading_entry_math, Unset
         ):
@@ -2627,7 +2617,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_channel = self.as_left_channel
 
-        as_left_measurement_type: Union[Unset, str] = UNSET
+        as_left_measurement_type: Union[None, Unset, str] = UNSET
         if self.as_left_measurement_type and not isinstance(
             self.as_left_measurement_type, Unset
         ):
@@ -2635,7 +2625,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_updated_by = self.as_left_updated_by
 
-        as_left_updated_on: Union[Unset, str] = UNSET
+        as_left_updated_on: Union[None, Unset, str] = UNSET
         if self.as_left_updated_on and not isinstance(self.as_left_updated_on, Unset):
             as_left_updated_on = self.as_left_updated_on.isoformat()
 
@@ -2653,7 +2643,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_channel_count = self.as_left_channel_count
 
-        as_left_commenced_on: Union[Unset, str] = UNSET
+        as_left_commenced_on: Union[None, Unset, str] = UNSET
         if self.as_left_commenced_on and not isinstance(
             self.as_left_commenced_on, Unset
         ):
@@ -2729,7 +2719,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_precision = self.as_left_precision
 
-        as_left_precision_type: Union[Unset, str] = UNSET
+        as_left_precision_type: Union[None, Unset, str] = UNSET
         if self.as_left_precision_type and not isinstance(
             self.as_left_precision_type, Unset
         ):
@@ -2753,7 +2743,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
 
         as_left_resolution_count = self.as_left_resolution_count
 
-        as_left_measurement_not_taken_result: Union[Unset, str] = UNSET
+        as_left_measurement_not_taken_result: Union[None, Unset, str] = UNSET
         if self.as_left_measurement_not_taken_result and not isinstance(
             self.as_left_measurement_not_taken_result, Unset
         ):
@@ -4113,7 +4103,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         completed_by_name = d.pop("CompletedByName", UNSET)
 
         _completed_on = d.pop("CompletedOn", UNSET)
-        completed_on: Union[Unset, datetime.datetime]
+        completed_on: Union[None, Unset, datetime.datetime]
         if isinstance(_completed_on, Unset):
             completed_on = UNSET
         else:
@@ -4134,7 +4124,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         certificate_number = d.pop("CertificateNumber", UNSET)
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:
@@ -4618,8 +4608,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         _as_found_measurement_not_taken_result = d.pop(
             "AsFoundMeasurementNotTakenResult", UNSET
         )
-        as_found_measurement_not_taken_result: Union[
-            Unset,
+        as_found_measurement_not_taken_result: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementNotTakenResult,
         ]
         if isinstance(_as_found_measurement_not_taken_result, Unset):
@@ -4654,7 +4643,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_found_cv_header = d.pop("AsFoundCvHeader", UNSET)
 
         _as_found_measurement_local_time = d.pop("AsFoundMeasurementLocalTime", UNSET)
-        as_found_measurement_local_time: Union[Unset, datetime.datetime]
+        as_found_measurement_local_time: Union[None, Unset, datetime.datetime]
         if isinstance(_as_found_measurement_local_time, Unset):
             as_found_measurement_local_time = UNSET
         else:
@@ -4681,8 +4670,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_guard_band = d.pop("AsLeftGuardBand", UNSET)
 
         _as_found_guard_band_logic = d.pop("AsFoundGuardBandLogic", UNSET)
-        as_found_guard_band_logic: Union[
-            Unset,
+        as_found_guard_band_logic: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundGuardBandLogic,
         ]
         if isinstance(_as_found_guard_band_logic, Unset):
@@ -4693,8 +4681,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
             )
 
         _as_left_guard_band_logic = d.pop("AsLeftGuardBandLogic", UNSET)
-        as_left_guard_band_logic: Union[
-            Unset,
+        as_left_guard_band_logic: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftGuardBandLogic,
         ]
         if isinstance(_as_left_guard_band_logic, Unset):
@@ -4761,8 +4748,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_hysteresis = d.pop("AsLeftHysteresis", UNSET)
 
         _as_found_reading_entry_math = d.pop("AsFoundReadingEntryMath", UNSET)
-        as_found_reading_entry_math: Union[
-            Unset,
+        as_found_reading_entry_math: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundReadingEntryMath,
         ]
         if isinstance(_as_found_reading_entry_math, Unset):
@@ -5077,8 +5063,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_found_channel = d.pop("AsFoundChannel", UNSET)
 
         _as_found_measurement_type = d.pop("AsFoundMeasurementType", UNSET)
-        as_found_measurement_type: Union[
-            Unset,
+        as_found_measurement_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundMeasurementType,
         ]
         if isinstance(_as_found_measurement_type, Unset):
@@ -5091,7 +5076,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_found_updated_by = d.pop("AsFoundUpdatedBy", UNSET)
 
         _as_found_updated_on = d.pop("AsFoundUpdatedOn", UNSET)
-        as_found_updated_on: Union[Unset, datetime.datetime]
+        as_found_updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_as_found_updated_on, Unset):
             as_found_updated_on = UNSET
         else:
@@ -5116,7 +5101,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_found_channel_count = d.pop("AsFoundChannelCount", UNSET)
 
         _as_found_commenced_on = d.pop("AsFoundCommencedOn", UNSET)
-        as_found_commenced_on: Union[Unset, datetime.datetime]
+        as_found_commenced_on: Union[None, Unset, datetime.datetime]
         if isinstance(_as_found_commenced_on, Unset):
             as_found_commenced_on = UNSET
         else:
@@ -5197,8 +5182,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_found_precision = d.pop("AsFoundPrecision", UNSET)
 
         _as_found_precision_type = d.pop("AsFoundPrecisionType", UNSET)
-        as_found_precision_type: Union[
-            Unset,
+        as_found_precision_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsFoundPrecisionType,
         ]
         if isinstance(_as_found_precision_type, Unset):
@@ -5247,15 +5231,14 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_cv_header = d.pop("AsLeftCvHeader", UNSET)
 
         _as_left_measurement_local_time = d.pop("AsLeftMeasurementLocalTime", UNSET)
-        as_left_measurement_local_time: Union[Unset, datetime.datetime]
+        as_left_measurement_local_time: Union[None, Unset, datetime.datetime]
         if isinstance(_as_left_measurement_local_time, Unset):
             as_left_measurement_local_time = UNSET
         else:
             as_left_measurement_local_time = isoparse(_as_left_measurement_local_time)
 
         _as_left_reading_entry_math = d.pop("AsLeftReadingEntryMath", UNSET)
-        as_left_reading_entry_math: Union[
-            Unset,
+        as_left_reading_entry_math: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftReadingEntryMath,
         ]
         if isinstance(_as_left_reading_entry_math, Unset):
@@ -5575,8 +5558,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_channel = d.pop("AsLeftChannel", UNSET)
 
         _as_left_measurement_type = d.pop("AsLeftMeasurementType", UNSET)
-        as_left_measurement_type: Union[
-            Unset,
+        as_left_measurement_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementType,
         ]
         if isinstance(_as_left_measurement_type, Unset):
@@ -5589,7 +5571,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_updated_by = d.pop("AsLeftUpdatedBy", UNSET)
 
         _as_left_updated_on = d.pop("AsLeftUpdatedOn", UNSET)
-        as_left_updated_on: Union[Unset, datetime.datetime]
+        as_left_updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_as_left_updated_on, Unset):
             as_left_updated_on = UNSET
         else:
@@ -5610,7 +5592,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_channel_count = d.pop("AsLeftChannelCount", UNSET)
 
         _as_left_commenced_on = d.pop("AsLeftCommencedOn", UNSET)
-        as_left_commenced_on: Union[Unset, datetime.datetime]
+        as_left_commenced_on: Union[None, Unset, datetime.datetime]
         if isinstance(_as_left_commenced_on, Unset):
             as_left_commenced_on = UNSET
         else:
@@ -5687,8 +5669,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         as_left_precision = d.pop("AsLeftPrecision", UNSET)
 
         _as_left_precision_type = d.pop("AsLeftPrecisionType", UNSET)
-        as_left_precision_type: Union[
-            Unset,
+        as_left_precision_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftPrecisionType,
         ]
         if isinstance(_as_left_precision_type, Unset):
@@ -5719,8 +5700,7 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         _as_left_measurement_not_taken_result = d.pop(
             "AsLeftMeasurementNotTakenResult", UNSET
         )
-        as_left_measurement_not_taken_result: Union[
-            Unset,
+        as_left_measurement_not_taken_result: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementAllResponseAsLeftMeasurementNotTakenResult,
         ]
         if isinstance(_as_left_measurement_not_taken_result, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_result_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_result_response.py
@@ -19,40 +19,39 @@ T = TypeVar(
 class QualerApiModelsReportDatasetsToMeasurementChannelResultResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        measurement_point_id (Union[Unset, int]):
-        column_index (Union[Unset, int]):
-        batch_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementChannelResultResponseBatchType]):
-        result (Union[Unset, ServiceResultStatus]):
-        mean_result (Union[Unset, bool]):
-        range_result (Union[Unset, bool]):
-        delta_result (Union[Unset, bool]):
-        min_result (Union[Unset, bool]):
-        max_result (Union[Unset, bool]):
-        tar_result (Union[Unset, bool]):
-        tur_result (Union[Unset, bool]):
-        error_result (Union[Unset, bool]):
-        sd_result (Union[Unset, bool]):
-        cv_result (Union[Unset, bool]):
+        service_order_item_id (Union[None, Unset, int]):
+        measurement_point_id (Union[None, Unset, int]):
+        column_index (Union[None, Unset, int]):
+        batch_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementChannelResultResponseBatchType]):
+        result (Union[None, Unset, ServiceResultStatus]):
+        mean_result (Union[None, Unset, bool]):
+        range_result (Union[None, Unset, bool]):
+        delta_result (Union[None, Unset, bool]):
+        min_result (Union[None, Unset, bool]):
+        max_result (Union[None, Unset, bool]):
+        tar_result (Union[None, Unset, bool]):
+        tur_result (Union[None, Unset, bool]):
+        error_result (Union[None, Unset, bool]):
+        sd_result (Union[None, Unset, bool]):
+        cv_result (Union[None, Unset, bool]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    measurement_point_id: Union[Unset, int] = UNSET
-    column_index: Union[Unset, int] = UNSET
-    batch_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementChannelResultResponseBatchType
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    column_index: Union[None, Unset, int] = UNSET
+    batch_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementChannelResultResponseBatchType
     ] = UNSET
-    result: Union[Unset, ServiceResultStatus] = UNSET
-    mean_result: Union[Unset, bool] = UNSET
-    range_result: Union[Unset, bool] = UNSET
-    delta_result: Union[Unset, bool] = UNSET
-    min_result: Union[Unset, bool] = UNSET
-    max_result: Union[Unset, bool] = UNSET
-    tar_result: Union[Unset, bool] = UNSET
-    tur_result: Union[Unset, bool] = UNSET
-    error_result: Union[Unset, bool] = UNSET
-    sd_result: Union[Unset, bool] = UNSET
-    cv_result: Union[Unset, bool] = UNSET
+    result: Union[None, Unset, ServiceResultStatus] = UNSET
+    mean_result: Union[None, Unset, bool] = UNSET
+    range_result: Union[None, Unset, bool] = UNSET
+    delta_result: Union[None, Unset, bool] = UNSET
+    min_result: Union[None, Unset, bool] = UNSET
+    max_result: Union[None, Unset, bool] = UNSET
+    tar_result: Union[None, Unset, bool] = UNSET
+    tur_result: Union[None, Unset, bool] = UNSET
+    error_result: Union[None, Unset, bool] = UNSET
+    sd_result: Union[None, Unset, bool] = UNSET
+    cv_result: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -62,11 +61,11 @@ class QualerApiModelsReportDatasetsToMeasurementChannelResultResponse:
 
         column_index = self.column_index
 
-        batch_type: Union[Unset, int] = UNSET
+        batch_type: Union[None, Unset, int] = UNSET
         if self.batch_type and not isinstance(self.batch_type, Unset):
             batch_type = self.batch_type.value
 
-        result: Union[Unset, int] = UNSET
+        result: Union[None, Unset, int] = UNSET
         if self.result and not isinstance(self.result, Unset):
             result = self.result.value
 
@@ -136,8 +135,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelResultResponse:
         column_index = d.pop("ColumnIndex", UNSET)
 
         _batch_type = d.pop("BatchType", UNSET)
-        batch_type: Union[
-            Unset,
+        batch_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementChannelResultResponseBatchType,
         ]
         if isinstance(_batch_type, Unset):
@@ -148,7 +146,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelResultResponse:
             )
 
         _result = d.pop("Result", UNSET)
-        result: Union[Unset, ServiceResultStatus]
+        result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_result, Unset):
             result = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_uniformity_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_uniformity_response.py
@@ -19,41 +19,40 @@ T = TypeVar(
 class QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        measurement_point_id (Union[Unset, int]):
-        batch_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponseBatchType]):
-        column_index (Union[Unset, int]):
-        mean (Union[Unset, str]):
-        mean_result (Union[Unset, bool]):
-        sd (Union[Unset, str]):
-        sd_result (Union[Unset, bool]):
-        cv (Union[Unset, str]):
-        cv_result (Union[Unset, bool]):
-        range_ (Union[Unset, str]):
-        range_result (Union[Unset, bool]):
-        delta (Union[Unset, str]):
-        delta_result (Union[Unset, bool]):
-        result (Union[Unset, ServiceResultStatus]):
+        service_order_item_id (Union[None, Unset, int]):
+        measurement_point_id (Union[None, Unset, int]):
+        batch_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponseBatchType]):
+        column_index (Union[None, Unset, int]):
+        mean (Union[None, Unset, str]):
+        mean_result (Union[None, Unset, bool]):
+        sd (Union[None, Unset, str]):
+        sd_result (Union[None, Unset, bool]):
+        cv (Union[None, Unset, str]):
+        cv_result (Union[None, Unset, bool]):
+        range_ (Union[None, Unset, str]):
+        range_result (Union[None, Unset, bool]):
+        delta (Union[None, Unset, str]):
+        delta_result (Union[None, Unset, bool]):
+        result (Union[None, Unset, ServiceResultStatus]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    measurement_point_id: Union[Unset, int] = UNSET
-    batch_type: Union[
-        Unset,
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    batch_type: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponseBatchType,
     ] = UNSET
-    column_index: Union[Unset, int] = UNSET
-    mean: Union[Unset, str] = UNSET
-    mean_result: Union[Unset, bool] = UNSET
-    sd: Union[Unset, str] = UNSET
-    sd_result: Union[Unset, bool] = UNSET
-    cv: Union[Unset, str] = UNSET
-    cv_result: Union[Unset, bool] = UNSET
-    range_: Union[Unset, str] = UNSET
-    range_result: Union[Unset, bool] = UNSET
-    delta: Union[Unset, str] = UNSET
-    delta_result: Union[Unset, bool] = UNSET
-    result: Union[Unset, ServiceResultStatus] = UNSET
+    column_index: Union[None, Unset, int] = UNSET
+    mean: Union[None, Unset, str] = UNSET
+    mean_result: Union[None, Unset, bool] = UNSET
+    sd: Union[None, Unset, str] = UNSET
+    sd_result: Union[None, Unset, bool] = UNSET
+    cv: Union[None, Unset, str] = UNSET
+    cv_result: Union[None, Unset, bool] = UNSET
+    range_: Union[None, Unset, str] = UNSET
+    range_result: Union[None, Unset, bool] = UNSET
+    delta: Union[None, Unset, str] = UNSET
+    delta_result: Union[None, Unset, bool] = UNSET
+    result: Union[None, Unset, ServiceResultStatus] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -61,7 +60,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponse:
 
         measurement_point_id = self.measurement_point_id
 
-        batch_type: Union[Unset, int] = UNSET
+        batch_type: Union[None, Unset, int] = UNSET
         if self.batch_type and not isinstance(self.batch_type, Unset):
             batch_type = self.batch_type.value
 
@@ -87,7 +86,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponse:
 
         delta_result = self.delta_result
 
-        result: Union[Unset, int] = UNSET
+        result: Union[None, Unset, int] = UNSET
         if self.result and not isinstance(self.result, Unset):
             result = self.result.value
 
@@ -135,8 +134,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponse:
         measurement_point_id = d.pop("MeasurementPointId", UNSET)
 
         _batch_type = d.pop("BatchType", UNSET)
-        batch_type: Union[
-            Unset,
+        batch_type: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponseBatchType,
         ]
         if isinstance(_batch_type, Unset):
@@ -169,7 +167,7 @@ class QualerApiModelsReportDatasetsToMeasurementChannelUniformityResponse:
         delta_result = d.pop("DeltaResult", UNSET)
 
         _result = d.pop("Result", UNSET)
-        result: Union[Unset, ServiceResultStatus]
+        result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_result, Unset):
             result = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_chart_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_chart_response.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToMeasurementChartResponse"
 class QualerApiModelsReportDatasetsToMeasurementChartResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        measurement_set_id (Union[Unset, int]):
-        chart_type (Union[Unset, int]):
-        chart_image (Union[Unset, str]):
-        nominal (Union[Unset, str]):
-        title (Union[Unset, str]):
-        unit_of_measure (Union[Unset, str]):
-        abbreviated_uom (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        measurement_set_id (Union[None, Unset, int]):
+        chart_type (Union[None, Unset, int]):
+        chart_image (Union[None, Unset, str]):
+        nominal (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
+        unit_of_measure (Union[None, Unset, str]):
+        abbreviated_uom (Union[None, Unset, str]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    measurement_set_id: Union[Unset, int] = UNSET
-    chart_type: Union[Unset, int] = UNSET
-    chart_image: Union[Unset, str] = UNSET
-    nominal: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    abbreviated_uom: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    chart_type: Union[None, Unset, int] = UNSET
+    chart_image: Union[None, Unset, str] = UNSET
+    nominal: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    abbreviated_uom: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_field_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_field_response.py
@@ -16,34 +16,33 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToMeasurementFieldResponse"
 class QualerApiModelsReportDatasetsToMeasurementFieldResponse:
     """
     Attributes:
-        field_id (Union[Unset, str]):
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
-        measurement_name (Union[Unset, str]):
-        measurement_set_id (Union[Unset, int]):
-        specification_name (Union[Unset, str]):
-        measurement_point_id (Union[Unset, int]):
-        batch_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType]):
-        service_order_item_id (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        batch_field_id (Union[Unset, str]):
-        point_field_id (Union[Unset, str]):
+        field_id (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
+        measurement_name (Union[None, Unset, str]):
+        measurement_set_id (Union[None, Unset, int]):
+        specification_name (Union[None, Unset, str]):
+        measurement_point_id (Union[None, Unset, int]):
+        batch_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType]):
+        service_order_item_id (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        batch_field_id (Union[None, Unset, str]):
+        point_field_id (Union[None, Unset, str]):
     """
 
-    field_id: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
-    measurement_name: Union[Unset, str] = UNSET
-    measurement_set_id: Union[Unset, int] = UNSET
-    specification_name: Union[Unset, str] = UNSET
-    measurement_point_id: Union[Unset, int] = UNSET
-    batch_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType
+    field_id: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
+    measurement_name: Union[None, Unset, str] = UNSET
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    specification_name: Union[None, Unset, str] = UNSET
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    batch_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType
     ] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    batch_field_id: Union[Unset, str] = UNSET
-    point_field_id: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    batch_field_id: Union[None, Unset, str] = UNSET
+    point_field_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -61,7 +60,7 @@ class QualerApiModelsReportDatasetsToMeasurementFieldResponse:
 
         measurement_point_id = self.measurement_point_id
 
-        batch_type: Union[Unset, int] = UNSET
+        batch_type: Union[None, Unset, int] = UNSET
         if self.batch_type and not isinstance(self.batch_type, Unset):
             batch_type = self.batch_type.value
 
@@ -121,8 +120,7 @@ class QualerApiModelsReportDatasetsToMeasurementFieldResponse:
         measurement_point_id = d.pop("MeasurementPointId", UNSET)
 
         _batch_type = d.pop("BatchType", UNSET)
-        batch_type: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType
+        batch_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementFieldResponseBatchType
         ]
         if isinstance(_batch_type, Unset):
             batch_type = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
@@ -61,802 +61,787 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToMeasurementResponse")
 class QualerApiModelsReportDatasetsToMeasurementResponse:
     """
     Attributes:
-        is_accredited (Union[Unset, bool]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        parameter_id (Union[Unset, int]):
-        tool_range_name (Union[Unset, str]):
-        tool_range_uncertainty (Union[Unset, str]):
+        is_accredited (Union[None, Unset, bool]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        parameter_id (Union[None, Unset, int]):
+        tool_range_name (Union[None, Unset, str]):
+        tool_range_uncertainty (Union[None, Unset, str]):
         primary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         primary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        primary_tool_calibrated_by (Union[Unset, str]):
-        primary_tool_tool_name (Union[Unset, str]):
-        primary_tool_tool_description (Union[Unset, str]):
-        primary_tool_tool_type_name (Union[Unset, str]):
-        primary_tool_manufacturer (Union[Unset, str]):
-        primary_tool_manufacturer_part_number (Union[Unset, str]):
-        primary_tool_serial_number (Union[Unset, str]):
+        primary_tool_calibrated_by (Union[None, Unset, str]):
+        primary_tool_tool_name (Union[None, Unset, str]):
+        primary_tool_tool_description (Union[None, Unset, str]):
+        primary_tool_tool_type_name (Union[None, Unset, str]):
+        primary_tool_manufacturer (Union[None, Unset, str]):
+        primary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        primary_tool_serial_number (Union[None, Unset, str]):
         secondary_tool_last_service_date (Union[None, Unset, datetime.datetime]):
         secondary_tool_next_service_date (Union[None, Unset, datetime.datetime]):
-        secondary_tool_calibrated_by (Union[Unset, str]):
-        secondary_tool_tool_name (Union[Unset, str]):
-        secondary_tool_tool_description (Union[Unset, str]):
-        secondary_tool_tool_type_name (Union[Unset, str]):
-        secondary_tool_manufacturer (Union[Unset, str]):
-        secondary_tool_manufacturer_part_number (Union[Unset, str]):
-        secondary_tool_serial_number (Union[Unset, str]):
-        measurement_set_name (Union[Unset, str]):
-        decimal_places (Union[Unset, int]):
-        significant_figures (Union[Unset, int]):
-        sd_header (Union[Unset, float]):
-        cv_header (Union[Unset, float]):
-        measurement_local_time (Union[Unset, datetime.datetime]):
-        mean (Union[Unset, float]):
-        mean_raw (Union[Unset, float]):
-        mean_decimal_places (Union[Unset, int]):
-        mean_extended (Union[Unset, str]):
-        sd (Union[Unset, float]):
-        sd_raw (Union[Unset, float]):
-        sd_decimal_places (Union[Unset, int]):
-        delta (Union[Unset, float]):
-        range_ (Union[Unset, float]):
-        sd_extended (Union[Unset, str]):
-        range_extended (Union[Unset, str]):
-        delta_extended (Union[Unset, str]):
-        minimum_measured_value (Union[Unset, float]):
-        maximum_measured_value (Union[Unset, float]):
-        min_max_value_extended (Union[Unset, str]):
-        cv (Union[Unset, float]):
-        cv_raw (Union[Unset, float]):
-        cv_decimal_places (Union[Unset, int]):
-        cv_extended (Union[Unset, str]):
-        result (Union[Unset, int]):
-        range_result (Union[Unset, bool]):
-        delta_result (Union[Unset, bool]):
-        min_result (Union[Unset, bool]):
-        max_result (Union[Unset, bool]):
-        tar_result (Union[Unset, bool]):
-        tur_result (Union[Unset, bool]):
-        error_result (Union[Unset, bool]):
-        sd_result (Union[Unset, bool]):
-        cv_result (Union[Unset, bool]):
-        custom_field_result (Union[Unset, int]):
-        mu (Union[Unset, float]):
-        mu_raw (Union[Unset, float]):
-        mu_effective_dof (Union[Unset, float]):
-        mu_coverage_factor (Union[Unset, float]):
-        mu_extended (Union[Unset, str]):
-        cmc (Union[Unset, float]):
-        cmc_comments (Union[Unset, str]):
-        tur (Union[Unset, float]):
-        tur_raw (Union[Unset, float]):
-        tur_decimal_places (Union[Unset, int]):
-        tar (Union[Unset, float]):
-        tar_raw (Union[Unset, float]):
-        tar_decimal_places (Union[Unset, int]):
-        guard_band (Union[Unset, str]):
-        guard_band_logic (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic]):
-        uncertainty_budget (Union[Unset, str]):
-        calculated_uncertainty (Union[Unset, float]):
-        lock_uncertainty_budget (Union[Unset, bool]):
-        lab_mu (Union[Unset, float]):
-        channel (Union[Unset, int]):
-        measurement_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType]):
-        updated_by (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
-        error (Union[Unset, float]):
-        error_extended (Union[Unset, str]):
-        require_adjustment (Union[Unset, bool]):
-        adjustment_threshold (Union[Unset, float]):
-        percent_of_tolerance (Union[Unset, float]):
-        percent_of_tolerance_extended (Union[Unset, str]):
-        tol_decimal_places (Union[Unset, int]):
-        specification_title (Union[Unset, str]):
-        specification_subtitle (Union[Unset, str]):
-        specification_group (Union[Unset, str]):
-        batch_type (Union[Unset, int]):
-        batch_result (Union[Unset, int]):
-        is_by_channel (Union[Unset, bool]):
-        channel_count (Union[Unset, int]):
-        is_range_accredited (Union[Unset, bool]):
-        commenced_on (Union[Unset, datetime.datetime]):
-        commenced_by (Union[Unset, str]):
-        z_factor (Union[Unset, float]):
-        air_buoyancy (Union[Unset, float]):
-        evaporation_rate (Union[Unset, float]):
-        air_humidity (Union[Unset, float]):
-        altitude (Union[Unset, float]):
-        ambient_temperature (Union[Unset, float]):
-        barometric_pressure (Union[Unset, float]):
-        light_intensity (Union[Unset, float]):
-        noise_level (Union[Unset, float]):
-        ph_level (Union[Unset, float]):
-        water_conductivity (Union[Unset, float]):
-        water_temperature (Union[Unset, float]):
-        solar_radiation (Union[Unset, float]):
-        wind_speed (Union[Unset, float]):
-        z_factor_uom (Union[Unset, str]):
-        air_buoyancy_uom (Union[Unset, str]):
-        evaporation_rate_uom (Union[Unset, str]):
-        air_humidity_uom (Union[Unset, str]):
-        altitude_uom (Union[Unset, str]):
-        ambient_temperature_uom (Union[Unset, str]):
-        barometric_pressure_uom (Union[Unset, str]):
-        light_intensity_uom (Union[Unset, str]):
-        noise_level_uom (Union[Unset, str]):
-        ph_level_uom (Union[Unset, str]):
-        water_conductivity_uom (Union[Unset, str]):
-        water_temperature_uom (Union[Unset, str]):
-        solar_radiation_uom (Union[Unset, str]):
-        wind_speed_uom (Union[Unset, str]):
-        specification_name (Union[Unset, str]):
-        parameter_name (Union[Unset, str]):
-        measurement_set_display_order (Union[Unset, int]):
-        display_order (Union[Unset, int]):
-        unit_of_measure (Union[Unset, str]):
-        display_format (Union[Unset, str]):
-        precision (Union[Unset, float]):
-        minimum (Union[Unset, float]):
-        nominal (Union[Unset, float]):
-        expected_value (Union[Unset, float]):
-        expected_value_raw (Union[Unset, str]):
-        test_value (Union[Unset, float]):
-        base_value (Union[Unset, float]):
-        use_expected_value (Union[Unset, bool]):
-        reading_entry_logic (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic]):
-        reading_entry_math (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath]):
-        double_substitution_sequence (Union[Unset,
+        secondary_tool_calibrated_by (Union[None, Unset, str]):
+        secondary_tool_tool_name (Union[None, Unset, str]):
+        secondary_tool_tool_description (Union[None, Unset, str]):
+        secondary_tool_tool_type_name (Union[None, Unset, str]):
+        secondary_tool_manufacturer (Union[None, Unset, str]):
+        secondary_tool_manufacturer_part_number (Union[None, Unset, str]):
+        secondary_tool_serial_number (Union[None, Unset, str]):
+        measurement_set_name (Union[None, Unset, str]):
+        decimal_places (Union[None, Unset, int]):
+        significant_figures (Union[None, Unset, int]):
+        sd_header (Union[None, Unset, float]):
+        cv_header (Union[None, Unset, float]):
+        measurement_local_time (Union[None, Unset, datetime.datetime]):
+        mean (Union[None, Unset, float]):
+        mean_raw (Union[None, Unset, float]):
+        mean_decimal_places (Union[None, Unset, int]):
+        mean_extended (Union[None, Unset, str]):
+        sd (Union[None, Unset, float]):
+        sd_raw (Union[None, Unset, float]):
+        sd_decimal_places (Union[None, Unset, int]):
+        delta (Union[None, Unset, float]):
+        range_ (Union[None, Unset, float]):
+        sd_extended (Union[None, Unset, str]):
+        range_extended (Union[None, Unset, str]):
+        delta_extended (Union[None, Unset, str]):
+        minimum_measured_value (Union[None, Unset, float]):
+        maximum_measured_value (Union[None, Unset, float]):
+        min_max_value_extended (Union[None, Unset, str]):
+        cv (Union[None, Unset, float]):
+        cv_raw (Union[None, Unset, float]):
+        cv_decimal_places (Union[None, Unset, int]):
+        cv_extended (Union[None, Unset, str]):
+        result (Union[None, Unset, int]):
+        range_result (Union[None, Unset, bool]):
+        delta_result (Union[None, Unset, bool]):
+        min_result (Union[None, Unset, bool]):
+        max_result (Union[None, Unset, bool]):
+        tar_result (Union[None, Unset, bool]):
+        tur_result (Union[None, Unset, bool]):
+        error_result (Union[None, Unset, bool]):
+        sd_result (Union[None, Unset, bool]):
+        cv_result (Union[None, Unset, bool]):
+        custom_field_result (Union[None, Unset, int]):
+        mu (Union[None, Unset, float]):
+        mu_raw (Union[None, Unset, float]):
+        mu_effective_dof (Union[None, Unset, float]):
+        mu_coverage_factor (Union[None, Unset, float]):
+        mu_extended (Union[None, Unset, str]):
+        cmc (Union[None, Unset, float]):
+        cmc_comments (Union[None, Unset, str]):
+        tur (Union[None, Unset, float]):
+        tur_raw (Union[None, Unset, float]):
+        tur_decimal_places (Union[None, Unset, int]):
+        tar (Union[None, Unset, float]):
+        tar_raw (Union[None, Unset, float]):
+        tar_decimal_places (Union[None, Unset, int]):
+        guard_band (Union[None, Unset, str]):
+        guard_band_logic (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic]):
+        uncertainty_budget (Union[None, Unset, str]):
+        calculated_uncertainty (Union[None, Unset, float]):
+        lock_uncertainty_budget (Union[None, Unset, bool]):
+        lab_mu (Union[None, Unset, float]):
+        channel (Union[None, Unset, int]):
+        measurement_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType]):
+        updated_by (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
+        error (Union[None, Unset, float]):
+        error_extended (Union[None, Unset, str]):
+        require_adjustment (Union[None, Unset, bool]):
+        adjustment_threshold (Union[None, Unset, float]):
+        percent_of_tolerance (Union[None, Unset, float]):
+        percent_of_tolerance_extended (Union[None, Unset, str]):
+        tol_decimal_places (Union[None, Unset, int]):
+        specification_title (Union[None, Unset, str]):
+        specification_subtitle (Union[None, Unset, str]):
+        specification_group (Union[None, Unset, str]):
+        batch_type (Union[None, Unset, int]):
+        batch_result (Union[None, Unset, int]):
+        is_by_channel (Union[None, Unset, bool]):
+        channel_count (Union[None, Unset, int]):
+        is_range_accredited (Union[None, Unset, bool]):
+        commenced_on (Union[None, Unset, datetime.datetime]):
+        commenced_by (Union[None, Unset, str]):
+        z_factor (Union[None, Unset, float]):
+        air_buoyancy (Union[None, Unset, float]):
+        evaporation_rate (Union[None, Unset, float]):
+        air_humidity (Union[None, Unset, float]):
+        altitude (Union[None, Unset, float]):
+        ambient_temperature (Union[None, Unset, float]):
+        barometric_pressure (Union[None, Unset, float]):
+        light_intensity (Union[None, Unset, float]):
+        noise_level (Union[None, Unset, float]):
+        ph_level (Union[None, Unset, float]):
+        water_conductivity (Union[None, Unset, float]):
+        water_temperature (Union[None, Unset, float]):
+        solar_radiation (Union[None, Unset, float]):
+        wind_speed (Union[None, Unset, float]):
+        z_factor_uom (Union[None, Unset, str]):
+        air_buoyancy_uom (Union[None, Unset, str]):
+        evaporation_rate_uom (Union[None, Unset, str]):
+        air_humidity_uom (Union[None, Unset, str]):
+        altitude_uom (Union[None, Unset, str]):
+        ambient_temperature_uom (Union[None, Unset, str]):
+        barometric_pressure_uom (Union[None, Unset, str]):
+        light_intensity_uom (Union[None, Unset, str]):
+        noise_level_uom (Union[None, Unset, str]):
+        ph_level_uom (Union[None, Unset, str]):
+        water_conductivity_uom (Union[None, Unset, str]):
+        water_temperature_uom (Union[None, Unset, str]):
+        solar_radiation_uom (Union[None, Unset, str]):
+        wind_speed_uom (Union[None, Unset, str]):
+        specification_name (Union[None, Unset, str]):
+        parameter_name (Union[None, Unset, str]):
+        measurement_set_display_order (Union[None, Unset, int]):
+        display_order (Union[None, Unset, int]):
+        unit_of_measure (Union[None, Unset, str]):
+        display_format (Union[None, Unset, str]):
+        precision (Union[None, Unset, float]):
+        minimum (Union[None, Unset, float]):
+        nominal (Union[None, Unset, float]):
+        expected_value (Union[None, Unset, float]):
+        expected_value_raw (Union[None, Unset, str]):
+        test_value (Union[None, Unset, float]):
+        base_value (Union[None, Unset, float]):
+        use_expected_value (Union[None, Unset, bool]):
+        reading_entry_logic (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic]):
+        reading_entry_math (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath]):
+        double_substitution_sequence (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementResponseDoubleSubstitutionSequence]):
-        reading_entry_math_string (Union[Unset, str]):
-        nominal_extended (Union[Unset, str]):
-        expected_value_extended (Union[Unset, str]):
-        maximum (Union[Unset, float]):
-        tolerance_min (Union[Unset, float]):
-        tolerance_max (Union[Unset, float]):
-        resolution (Union[Unset, float]):
-        resolution_count (Union[Unset, float]):
-        min_max_header (Union[Unset, str]):
-        accuracy_class (Union[Unset, str]):
-        accuracy_class_min (Union[Unset, float]):
-        accuracy_class_max (Union[Unset, float]):
-        environment_mask (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask]):
-        display_name (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        part_number (Union[Unset, str]):
-        vendor_company_id (Union[Unset, int]):
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        completed_by_name (Union[Unset, str]):
-        completed_on (Union[Unset, datetime.datetime]):
-        is_limited (Union[Unset, bool]):
-        vendor_tag (Union[Unset, str]):
-        vendor_service_notes (Union[Unset, str]):
-        room (Union[Unset, str]):
-        segment_name (Union[Unset, str]):
-        schedule_name (Union[Unset, str]):
-        next_segment_name (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
-        work_status (Union[Unset, WorkStatus]):
-        service_type (Union[Unset, str]):
-        service_level (Union[Unset, str]):
-        barcode (Union[Unset, str]):
-        service_comments (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        asset_tag (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
-        legacy_identifier (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        station (Union[Unset, str]):
-        asset_tag_change (Union[Unset, str]):
-        asset_user_change (Union[Unset, str]):
-        serial_number_change (Union[Unset, str]):
+        reading_entry_math_string (Union[None, Unset, str]):
+        nominal_extended (Union[None, Unset, str]):
+        expected_value_extended (Union[None, Unset, str]):
+        maximum (Union[None, Unset, float]):
+        tolerance_min (Union[None, Unset, float]):
+        tolerance_max (Union[None, Unset, float]):
+        resolution (Union[None, Unset, float]):
+        resolution_count (Union[None, Unset, float]):
+        min_max_header (Union[None, Unset, str]):
+        accuracy_class (Union[None, Unset, str]):
+        accuracy_class_min (Union[None, Unset, float]):
+        accuracy_class_max (Union[None, Unset, float]):
+        environment_mask (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask]):
+        display_name (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        part_number (Union[None, Unset, str]):
+        vendor_company_id (Union[None, Unset, int]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        completed_by_name (Union[None, Unset, str]):
+        completed_on (Union[None, Unset, datetime.datetime]):
+        is_limited (Union[None, Unset, bool]):
+        vendor_tag (Union[None, Unset, str]):
+        vendor_service_notes (Union[None, Unset, str]):
+        room (Union[None, Unset, str]):
+        segment_name (Union[None, Unset, str]):
+        schedule_name (Union[None, Unset, str]):
+        next_segment_name (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        work_status (Union[None, Unset, WorkStatus]):
+        service_type (Union[None, Unset, str]):
+        service_level (Union[None, Unset, str]):
+        barcode (Union[None, Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        asset_tag (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_identifier (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        asset_tag_change (Union[None, Unset, str]):
+        asset_user_change (Union[None, Unset, str]):
+        serial_number_change (Union[None, Unset, str]):
         service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        service_order_item_id (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        measurement_batch_id (Union[Unset, int]):
-        measurement_id (Union[Unset, int]):
-        standard_id (Union[Unset, int]):
-        tool_id (Union[Unset, int]):
-        measurement_tool_id (Union[Unset, int]):
-        measurement_condition_id (Union[Unset, int]):
-        measurement_point_id (Union[Unset, int]):
-        measurement_set_id (Union[Unset, int]):
-        is_hidden (Union[Unset, bool]):
-        readings (Union[Unset, int]):
-        tolerance_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType]):
-        tolerance_type_string (Union[Unset, str]):
-        precision_type (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType]):
-        specification_mode (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode]):
-        tolerance_mode (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode]):
-        tolerance_unit (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit]):
-        tolerance_string (Union[Unset, str]):
-        po_number (Union[Unset, str]):
-        secondary_po (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        measurement_batch_id (Union[None, Unset, int]):
+        measurement_id (Union[None, Unset, int]):
+        standard_id (Union[None, Unset, int]):
+        tool_id (Union[None, Unset, int]):
+        measurement_tool_id (Union[None, Unset, int]):
+        measurement_condition_id (Union[None, Unset, int]):
+        measurement_point_id (Union[None, Unset, int]):
+        measurement_set_id (Union[None, Unset, int]):
+        is_hidden (Union[None, Unset, bool]):
+        readings (Union[None, Unset, int]):
+        tolerance_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType]):
+        tolerance_type_string (Union[None, Unset, str]):
+        precision_type (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType]):
+        specification_mode (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode]):
+        tolerance_mode (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode]):
+        tolerance_unit (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit]):
+        tolerance_string (Union[None, Unset, str]):
+        po_number (Union[None, Unset, str]):
+        secondary_po (Union[None, Unset, str]):
         shipped_date (Union[None, Unset, datetime.datetime]):
-        shipment_status (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus]):
-        shipped_on (Union[Unset, datetime.datetime]):
-        delivered_on (Union[Unset, datetime.datetime]):
-        tracking_number (Union[Unset, str]):
-        payment_terms (Union[Unset, int]):
-        shipping_method (Union[Unset, str]):
-        location (Union[Unset, str]):
-        site_access_notes (Union[Unset, str]):
-        abbreviated_uom (Union[Unset, str]):
-        unit_scale_factor (Union[Unset, float]):
-        measurement_not_taken_result (Union[Unset,
+        shipment_status (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus]):
+        shipped_on (Union[None, Unset, datetime.datetime]):
+        delivered_on (Union[None, Unset, datetime.datetime]):
+        tracking_number (Union[None, Unset, str]):
+        payment_terms (Union[None, Unset, int]):
+        shipping_method (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        site_access_notes (Union[None, Unset, str]):
+        abbreviated_uom (Union[None, Unset, str]):
+        unit_scale_factor (Union[None, Unset, float]):
+        measurement_not_taken_result (Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementResponseMeasurementNotTakenResult]):
-        hide_from_certificate (Union[Unset, bool]):
-        measurement_not_taken_reason (Union[Unset, str]):
-        environment_text_1 (Union[Unset, str]):
-        environment_text_2 (Union[Unset, str]):
-        environment_text_3 (Union[Unset, str]):
-        environment_text_4 (Union[Unset, str]):
-        environment_text_5 (Union[Unset, str]):
-        environment_text_6 (Union[Unset, str]):
-        values (Union[Unset, str]):
-        value_1 (Union[Unset, str]):
-        value_2 (Union[Unset, str]):
-        value_3 (Union[Unset, str]):
-        value_4 (Union[Unset, str]):
-        value_5 (Union[Unset, str]):
-        value_6 (Union[Unset, str]):
-        value_7 (Union[Unset, str]):
-        value_8 (Union[Unset, str]):
-        value_9 (Union[Unset, str]):
-        value_10 (Union[Unset, str]):
-        value_11 (Union[Unset, str]):
-        value_12 (Union[Unset, str]):
-        value_13 (Union[Unset, str]):
-        value_14 (Union[Unset, str]):
-        value_15 (Union[Unset, str]):
-        value_16 (Union[Unset, str]):
-        value_17 (Union[Unset, str]):
-        value_18 (Union[Unset, str]):
-        value_19 (Union[Unset, str]):
-        value_20 (Union[Unset, str]):
-        value_21 (Union[Unset, str]):
-        value_22 (Union[Unset, str]):
-        value_23 (Union[Unset, str]):
-        value_24 (Union[Unset, str]):
-        value_25 (Union[Unset, str]):
-        value_26 (Union[Unset, str]):
-        value_27 (Union[Unset, str]):
-        value_28 (Union[Unset, str]):
-        value_29 (Union[Unset, str]):
-        value_30 (Union[Unset, str]):
-        value_31 (Union[Unset, str]):
-        value_32 (Union[Unset, str]):
-        value_33 (Union[Unset, str]):
-        value_34 (Union[Unset, str]):
-        value_35 (Union[Unset, str]):
-        value_36 (Union[Unset, str]):
-        value_37 (Union[Unset, str]):
-        value_38 (Union[Unset, str]):
-        value_39 (Union[Unset, str]):
-        value_40 (Union[Unset, str]):
-        raw_value_1 (Union[Unset, str]):
-        raw_value_2 (Union[Unset, str]):
-        raw_value_3 (Union[Unset, str]):
-        raw_value_4 (Union[Unset, str]):
-        raw_value_5 (Union[Unset, str]):
-        raw_value_6 (Union[Unset, str]):
-        raw_value_7 (Union[Unset, str]):
-        raw_value_8 (Union[Unset, str]):
-        raw_value_9 (Union[Unset, str]):
-        raw_value_10 (Union[Unset, str]):
-        raw_value_11 (Union[Unset, str]):
-        raw_value_12 (Union[Unset, str]):
-        raw_value_13 (Union[Unset, str]):
-        raw_value_14 (Union[Unset, str]):
-        raw_value_15 (Union[Unset, str]):
-        raw_value_16 (Union[Unset, str]):
-        raw_value_17 (Union[Unset, str]):
-        raw_value_18 (Union[Unset, str]):
-        raw_value_19 (Union[Unset, str]):
-        raw_value_20 (Union[Unset, str]):
-        raw_value_21 (Union[Unset, str]):
-        raw_value_22 (Union[Unset, str]):
-        raw_value_23 (Union[Unset, str]):
-        raw_value_24 (Union[Unset, str]):
-        raw_value_25 (Union[Unset, str]):
-        raw_value_26 (Union[Unset, str]):
-        raw_value_27 (Union[Unset, str]):
-        raw_value_28 (Union[Unset, str]):
-        raw_value_29 (Union[Unset, str]):
-        raw_value_30 (Union[Unset, str]):
-        raw_value_31 (Union[Unset, str]):
-        raw_value_32 (Union[Unset, str]):
-        raw_value_33 (Union[Unset, str]):
-        raw_value_34 (Union[Unset, str]):
-        raw_value_35 (Union[Unset, str]):
-        raw_value_36 (Union[Unset, str]):
-        raw_value_37 (Union[Unset, str]):
-        raw_value_38 (Union[Unset, str]):
-        raw_value_39 (Union[Unset, str]):
-        raw_value_40 (Union[Unset, str]):
-        subtitles_to_readings (Union[Unset, str]):
-        value_subtitle_1 (Union[Unset, str]):
-        value_subtitle_2 (Union[Unset, str]):
-        value_subtitle_3 (Union[Unset, str]):
-        value_subtitle_4 (Union[Unset, str]):
-        value_subtitle_5 (Union[Unset, str]):
-        value_subtitle_6 (Union[Unset, str]):
-        value_subtitle_7 (Union[Unset, str]):
-        value_subtitle_8 (Union[Unset, str]):
-        value_subtitle_9 (Union[Unset, str]):
-        value_subtitle_10 (Union[Unset, str]):
-        value_subtitle_11 (Union[Unset, str]):
-        value_subtitle_12 (Union[Unset, str]):
-        value_subtitle_13 (Union[Unset, str]):
-        value_subtitle_14 (Union[Unset, str]):
-        value_subtitle_15 (Union[Unset, str]):
-        value_subtitle_16 (Union[Unset, str]):
-        value_subtitle_17 (Union[Unset, str]):
-        value_subtitle_18 (Union[Unset, str]):
-        value_subtitle_19 (Union[Unset, str]):
-        value_subtitle_20 (Union[Unset, str]):
-        value_subtitle_21 (Union[Unset, str]):
-        value_subtitle_22 (Union[Unset, str]):
-        value_subtitle_23 (Union[Unset, str]):
-        value_subtitle_24 (Union[Unset, str]):
-        value_subtitle_25 (Union[Unset, str]):
-        value_subtitle_26 (Union[Unset, str]):
-        value_subtitle_27 (Union[Unset, str]):
-        value_subtitle_28 (Union[Unset, str]):
-        value_subtitle_29 (Union[Unset, str]):
-        value_subtitle_30 (Union[Unset, str]):
-        value_subtitle_31 (Union[Unset, str]):
-        value_subtitle_32 (Union[Unset, str]):
-        value_subtitle_33 (Union[Unset, str]):
-        value_subtitle_34 (Union[Unset, str]):
-        value_subtitle_35 (Union[Unset, str]):
-        value_subtitle_36 (Union[Unset, str]):
-        value_subtitle_37 (Union[Unset, str]):
-        value_subtitle_38 (Union[Unset, str]):
-        value_subtitle_39 (Union[Unset, str]):
-        value_subtitle_40 (Union[Unset, str]):
-        values_decimal_places (Union[Unset, int]):
-        repeat_measurement_and_calculate_hysteresis (Union[Unset, bool]):
-        measurement_point_order (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementPointOrder]):
-        hysteresis_point (Union[Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint]):
-        max_hysteresis (Union[Unset, float]):
-        run (Union[Unset, int]):
-        direction (Union[Unset, int]):
-        hysteresis (Union[Unset, float]):
-        column_mean (Union[Unset, str]):
-        column_mean_result (Union[Unset, str]):
-        column_sd (Union[Unset, str]):
-        column_sd_result (Union[Unset, str]):
-        column_cv (Union[Unset, str]):
-        column_cv_result (Union[Unset, str]):
-        column_range (Union[Unset, str]):
-        column_range_result (Union[Unset, str]):
-        column_delta (Union[Unset, str]):
-        column_delta_result (Union[Unset, str]):
-        column_result (Union[Unset, str]):
+        hide_from_certificate (Union[None, Unset, bool]):
+        measurement_not_taken_reason (Union[None, Unset, str]):
+        environment_text_1 (Union[None, Unset, str]):
+        environment_text_2 (Union[None, Unset, str]):
+        environment_text_3 (Union[None, Unset, str]):
+        environment_text_4 (Union[None, Unset, str]):
+        environment_text_5 (Union[None, Unset, str]):
+        environment_text_6 (Union[None, Unset, str]):
+        values (Union[None, Unset, str]):
+        value_1 (Union[None, Unset, str]):
+        value_2 (Union[None, Unset, str]):
+        value_3 (Union[None, Unset, str]):
+        value_4 (Union[None, Unset, str]):
+        value_5 (Union[None, Unset, str]):
+        value_6 (Union[None, Unset, str]):
+        value_7 (Union[None, Unset, str]):
+        value_8 (Union[None, Unset, str]):
+        value_9 (Union[None, Unset, str]):
+        value_10 (Union[None, Unset, str]):
+        value_11 (Union[None, Unset, str]):
+        value_12 (Union[None, Unset, str]):
+        value_13 (Union[None, Unset, str]):
+        value_14 (Union[None, Unset, str]):
+        value_15 (Union[None, Unset, str]):
+        value_16 (Union[None, Unset, str]):
+        value_17 (Union[None, Unset, str]):
+        value_18 (Union[None, Unset, str]):
+        value_19 (Union[None, Unset, str]):
+        value_20 (Union[None, Unset, str]):
+        value_21 (Union[None, Unset, str]):
+        value_22 (Union[None, Unset, str]):
+        value_23 (Union[None, Unset, str]):
+        value_24 (Union[None, Unset, str]):
+        value_25 (Union[None, Unset, str]):
+        value_26 (Union[None, Unset, str]):
+        value_27 (Union[None, Unset, str]):
+        value_28 (Union[None, Unset, str]):
+        value_29 (Union[None, Unset, str]):
+        value_30 (Union[None, Unset, str]):
+        value_31 (Union[None, Unset, str]):
+        value_32 (Union[None, Unset, str]):
+        value_33 (Union[None, Unset, str]):
+        value_34 (Union[None, Unset, str]):
+        value_35 (Union[None, Unset, str]):
+        value_36 (Union[None, Unset, str]):
+        value_37 (Union[None, Unset, str]):
+        value_38 (Union[None, Unset, str]):
+        value_39 (Union[None, Unset, str]):
+        value_40 (Union[None, Unset, str]):
+        raw_value_1 (Union[None, Unset, str]):
+        raw_value_2 (Union[None, Unset, str]):
+        raw_value_3 (Union[None, Unset, str]):
+        raw_value_4 (Union[None, Unset, str]):
+        raw_value_5 (Union[None, Unset, str]):
+        raw_value_6 (Union[None, Unset, str]):
+        raw_value_7 (Union[None, Unset, str]):
+        raw_value_8 (Union[None, Unset, str]):
+        raw_value_9 (Union[None, Unset, str]):
+        raw_value_10 (Union[None, Unset, str]):
+        raw_value_11 (Union[None, Unset, str]):
+        raw_value_12 (Union[None, Unset, str]):
+        raw_value_13 (Union[None, Unset, str]):
+        raw_value_14 (Union[None, Unset, str]):
+        raw_value_15 (Union[None, Unset, str]):
+        raw_value_16 (Union[None, Unset, str]):
+        raw_value_17 (Union[None, Unset, str]):
+        raw_value_18 (Union[None, Unset, str]):
+        raw_value_19 (Union[None, Unset, str]):
+        raw_value_20 (Union[None, Unset, str]):
+        raw_value_21 (Union[None, Unset, str]):
+        raw_value_22 (Union[None, Unset, str]):
+        raw_value_23 (Union[None, Unset, str]):
+        raw_value_24 (Union[None, Unset, str]):
+        raw_value_25 (Union[None, Unset, str]):
+        raw_value_26 (Union[None, Unset, str]):
+        raw_value_27 (Union[None, Unset, str]):
+        raw_value_28 (Union[None, Unset, str]):
+        raw_value_29 (Union[None, Unset, str]):
+        raw_value_30 (Union[None, Unset, str]):
+        raw_value_31 (Union[None, Unset, str]):
+        raw_value_32 (Union[None, Unset, str]):
+        raw_value_33 (Union[None, Unset, str]):
+        raw_value_34 (Union[None, Unset, str]):
+        raw_value_35 (Union[None, Unset, str]):
+        raw_value_36 (Union[None, Unset, str]):
+        raw_value_37 (Union[None, Unset, str]):
+        raw_value_38 (Union[None, Unset, str]):
+        raw_value_39 (Union[None, Unset, str]):
+        raw_value_40 (Union[None, Unset, str]):
+        subtitles_to_readings (Union[None, Unset, str]):
+        value_subtitle_1 (Union[None, Unset, str]):
+        value_subtitle_2 (Union[None, Unset, str]):
+        value_subtitle_3 (Union[None, Unset, str]):
+        value_subtitle_4 (Union[None, Unset, str]):
+        value_subtitle_5 (Union[None, Unset, str]):
+        value_subtitle_6 (Union[None, Unset, str]):
+        value_subtitle_7 (Union[None, Unset, str]):
+        value_subtitle_8 (Union[None, Unset, str]):
+        value_subtitle_9 (Union[None, Unset, str]):
+        value_subtitle_10 (Union[None, Unset, str]):
+        value_subtitle_11 (Union[None, Unset, str]):
+        value_subtitle_12 (Union[None, Unset, str]):
+        value_subtitle_13 (Union[None, Unset, str]):
+        value_subtitle_14 (Union[None, Unset, str]):
+        value_subtitle_15 (Union[None, Unset, str]):
+        value_subtitle_16 (Union[None, Unset, str]):
+        value_subtitle_17 (Union[None, Unset, str]):
+        value_subtitle_18 (Union[None, Unset, str]):
+        value_subtitle_19 (Union[None, Unset, str]):
+        value_subtitle_20 (Union[None, Unset, str]):
+        value_subtitle_21 (Union[None, Unset, str]):
+        value_subtitle_22 (Union[None, Unset, str]):
+        value_subtitle_23 (Union[None, Unset, str]):
+        value_subtitle_24 (Union[None, Unset, str]):
+        value_subtitle_25 (Union[None, Unset, str]):
+        value_subtitle_26 (Union[None, Unset, str]):
+        value_subtitle_27 (Union[None, Unset, str]):
+        value_subtitle_28 (Union[None, Unset, str]):
+        value_subtitle_29 (Union[None, Unset, str]):
+        value_subtitle_30 (Union[None, Unset, str]):
+        value_subtitle_31 (Union[None, Unset, str]):
+        value_subtitle_32 (Union[None, Unset, str]):
+        value_subtitle_33 (Union[None, Unset, str]):
+        value_subtitle_34 (Union[None, Unset, str]):
+        value_subtitle_35 (Union[None, Unset, str]):
+        value_subtitle_36 (Union[None, Unset, str]):
+        value_subtitle_37 (Union[None, Unset, str]):
+        value_subtitle_38 (Union[None, Unset, str]):
+        value_subtitle_39 (Union[None, Unset, str]):
+        value_subtitle_40 (Union[None, Unset, str]):
+        values_decimal_places (Union[None, Unset, int]):
+        repeat_measurement_and_calculate_hysteresis (Union[None, Unset, bool]):
+        measurement_point_order (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementPointOrder]):
+        hysteresis_point (Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint]):
+        max_hysteresis (Union[None, Unset, float]):
+        run (Union[None, Unset, int]):
+        direction (Union[None, Unset, int]):
+        hysteresis (Union[None, Unset, float]):
+        column_mean (Union[None, Unset, str]):
+        column_mean_result (Union[None, Unset, str]):
+        column_sd (Union[None, Unset, str]):
+        column_sd_result (Union[None, Unset, str]):
+        column_cv (Union[None, Unset, str]):
+        column_cv_result (Union[None, Unset, str]):
+        column_range (Union[None, Unset, str]):
+        column_range_result (Union[None, Unset, str]):
+        column_delta (Union[None, Unset, str]):
+        column_delta_result (Union[None, Unset, str]):
+        column_result (Union[None, Unset, str]):
     """
 
-    is_accredited: Union[Unset, bool] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
-    parameter_id: Union[Unset, int] = UNSET
-    tool_range_name: Union[Unset, str] = UNSET
-    tool_range_uncertainty: Union[Unset, str] = UNSET
+    is_accredited: Union[None, Unset, bool] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
+    parameter_id: Union[None, Unset, int] = UNSET
+    tool_range_name: Union[None, Unset, str] = UNSET
+    tool_range_uncertainty: Union[None, Unset, str] = UNSET
     primary_tool_last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     primary_tool_next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    primary_tool_calibrated_by: Union[Unset, str] = UNSET
-    primary_tool_tool_name: Union[Unset, str] = UNSET
-    primary_tool_tool_description: Union[Unset, str] = UNSET
-    primary_tool_tool_type_name: Union[Unset, str] = UNSET
-    primary_tool_manufacturer: Union[Unset, str] = UNSET
-    primary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    primary_tool_serial_number: Union[Unset, str] = UNSET
+    primary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    primary_tool_tool_name: Union[None, Unset, str] = UNSET
+    primary_tool_tool_description: Union[None, Unset, str] = UNSET
+    primary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    primary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    primary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    primary_tool_serial_number: Union[None, Unset, str] = UNSET
     secondary_tool_last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     secondary_tool_next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    secondary_tool_calibrated_by: Union[Unset, str] = UNSET
-    secondary_tool_tool_name: Union[Unset, str] = UNSET
-    secondary_tool_tool_description: Union[Unset, str] = UNSET
-    secondary_tool_tool_type_name: Union[Unset, str] = UNSET
-    secondary_tool_manufacturer: Union[Unset, str] = UNSET
-    secondary_tool_manufacturer_part_number: Union[Unset, str] = UNSET
-    secondary_tool_serial_number: Union[Unset, str] = UNSET
-    measurement_set_name: Union[Unset, str] = UNSET
-    decimal_places: Union[Unset, int] = UNSET
-    significant_figures: Union[Unset, int] = UNSET
-    sd_header: Union[Unset, float] = UNSET
-    cv_header: Union[Unset, float] = UNSET
-    measurement_local_time: Union[Unset, datetime.datetime] = UNSET
-    mean: Union[Unset, float] = UNSET
-    mean_raw: Union[Unset, float] = UNSET
-    mean_decimal_places: Union[Unset, int] = UNSET
-    mean_extended: Union[Unset, str] = UNSET
-    sd: Union[Unset, float] = UNSET
-    sd_raw: Union[Unset, float] = UNSET
-    sd_decimal_places: Union[Unset, int] = UNSET
-    delta: Union[Unset, float] = UNSET
-    range_: Union[Unset, float] = UNSET
-    sd_extended: Union[Unset, str] = UNSET
-    range_extended: Union[Unset, str] = UNSET
-    delta_extended: Union[Unset, str] = UNSET
-    minimum_measured_value: Union[Unset, float] = UNSET
-    maximum_measured_value: Union[Unset, float] = UNSET
-    min_max_value_extended: Union[Unset, str] = UNSET
-    cv: Union[Unset, float] = UNSET
-    cv_raw: Union[Unset, float] = UNSET
-    cv_decimal_places: Union[Unset, int] = UNSET
-    cv_extended: Union[Unset, str] = UNSET
-    result: Union[Unset, int] = UNSET
-    range_result: Union[Unset, bool] = UNSET
-    delta_result: Union[Unset, bool] = UNSET
-    min_result: Union[Unset, bool] = UNSET
-    max_result: Union[Unset, bool] = UNSET
-    tar_result: Union[Unset, bool] = UNSET
-    tur_result: Union[Unset, bool] = UNSET
-    error_result: Union[Unset, bool] = UNSET
-    sd_result: Union[Unset, bool] = UNSET
-    cv_result: Union[Unset, bool] = UNSET
-    custom_field_result: Union[Unset, int] = UNSET
-    mu: Union[Unset, float] = UNSET
-    mu_raw: Union[Unset, float] = UNSET
-    mu_effective_dof: Union[Unset, float] = UNSET
-    mu_coverage_factor: Union[Unset, float] = UNSET
-    mu_extended: Union[Unset, str] = UNSET
-    cmc: Union[Unset, float] = UNSET
-    cmc_comments: Union[Unset, str] = UNSET
-    tur: Union[Unset, float] = UNSET
-    tur_raw: Union[Unset, float] = UNSET
-    tur_decimal_places: Union[Unset, int] = UNSET
-    tar: Union[Unset, float] = UNSET
-    tar_raw: Union[Unset, float] = UNSET
-    tar_decimal_places: Union[Unset, int] = UNSET
-    guard_band: Union[Unset, str] = UNSET
-    guard_band_logic: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic
+    secondary_tool_calibrated_by: Union[None, Unset, str] = UNSET
+    secondary_tool_tool_name: Union[None, Unset, str] = UNSET
+    secondary_tool_tool_description: Union[None, Unset, str] = UNSET
+    secondary_tool_tool_type_name: Union[None, Unset, str] = UNSET
+    secondary_tool_manufacturer: Union[None, Unset, str] = UNSET
+    secondary_tool_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    secondary_tool_serial_number: Union[None, Unset, str] = UNSET
+    measurement_set_name: Union[None, Unset, str] = UNSET
+    decimal_places: Union[None, Unset, int] = UNSET
+    significant_figures: Union[None, Unset, int] = UNSET
+    sd_header: Union[None, Unset, float] = UNSET
+    cv_header: Union[None, Unset, float] = UNSET
+    measurement_local_time: Union[None, Unset, datetime.datetime] = UNSET
+    mean: Union[None, Unset, float] = UNSET
+    mean_raw: Union[None, Unset, float] = UNSET
+    mean_decimal_places: Union[None, Unset, int] = UNSET
+    mean_extended: Union[None, Unset, str] = UNSET
+    sd: Union[None, Unset, float] = UNSET
+    sd_raw: Union[None, Unset, float] = UNSET
+    sd_decimal_places: Union[None, Unset, int] = UNSET
+    delta: Union[None, Unset, float] = UNSET
+    range_: Union[None, Unset, float] = UNSET
+    sd_extended: Union[None, Unset, str] = UNSET
+    range_extended: Union[None, Unset, str] = UNSET
+    delta_extended: Union[None, Unset, str] = UNSET
+    minimum_measured_value: Union[None, Unset, float] = UNSET
+    maximum_measured_value: Union[None, Unset, float] = UNSET
+    min_max_value_extended: Union[None, Unset, str] = UNSET
+    cv: Union[None, Unset, float] = UNSET
+    cv_raw: Union[None, Unset, float] = UNSET
+    cv_decimal_places: Union[None, Unset, int] = UNSET
+    cv_extended: Union[None, Unset, str] = UNSET
+    result: Union[None, Unset, int] = UNSET
+    range_result: Union[None, Unset, bool] = UNSET
+    delta_result: Union[None, Unset, bool] = UNSET
+    min_result: Union[None, Unset, bool] = UNSET
+    max_result: Union[None, Unset, bool] = UNSET
+    tar_result: Union[None, Unset, bool] = UNSET
+    tur_result: Union[None, Unset, bool] = UNSET
+    error_result: Union[None, Unset, bool] = UNSET
+    sd_result: Union[None, Unset, bool] = UNSET
+    cv_result: Union[None, Unset, bool] = UNSET
+    custom_field_result: Union[None, Unset, int] = UNSET
+    mu: Union[None, Unset, float] = UNSET
+    mu_raw: Union[None, Unset, float] = UNSET
+    mu_effective_dof: Union[None, Unset, float] = UNSET
+    mu_coverage_factor: Union[None, Unset, float] = UNSET
+    mu_extended: Union[None, Unset, str] = UNSET
+    cmc: Union[None, Unset, float] = UNSET
+    cmc_comments: Union[None, Unset, str] = UNSET
+    tur: Union[None, Unset, float] = UNSET
+    tur_raw: Union[None, Unset, float] = UNSET
+    tur_decimal_places: Union[None, Unset, int] = UNSET
+    tar: Union[None, Unset, float] = UNSET
+    tar_raw: Union[None, Unset, float] = UNSET
+    tar_decimal_places: Union[None, Unset, int] = UNSET
+    guard_band: Union[None, Unset, str] = UNSET
+    guard_band_logic: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic
     ] = UNSET
-    uncertainty_budget: Union[Unset, str] = UNSET
-    calculated_uncertainty: Union[Unset, float] = UNSET
-    lock_uncertainty_budget: Union[Unset, bool] = UNSET
-    lab_mu: Union[Unset, float] = UNSET
-    channel: Union[Unset, int] = UNSET
-    measurement_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType
+    uncertainty_budget: Union[None, Unset, str] = UNSET
+    calculated_uncertainty: Union[None, Unset, float] = UNSET
+    lock_uncertainty_budget: Union[None, Unset, bool] = UNSET
+    lab_mu: Union[None, Unset, float] = UNSET
+    channel: Union[None, Unset, int] = UNSET
+    measurement_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType
     ] = UNSET
-    updated_by: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
-    error: Union[Unset, float] = UNSET
-    error_extended: Union[Unset, str] = UNSET
-    require_adjustment: Union[Unset, bool] = UNSET
-    adjustment_threshold: Union[Unset, float] = UNSET
-    percent_of_tolerance: Union[Unset, float] = UNSET
-    percent_of_tolerance_extended: Union[Unset, str] = UNSET
-    tol_decimal_places: Union[Unset, int] = UNSET
-    specification_title: Union[Unset, str] = UNSET
-    specification_subtitle: Union[Unset, str] = UNSET
-    specification_group: Union[Unset, str] = UNSET
-    batch_type: Union[Unset, int] = UNSET
-    batch_result: Union[Unset, int] = UNSET
-    is_by_channel: Union[Unset, bool] = UNSET
-    channel_count: Union[Unset, int] = UNSET
-    is_range_accredited: Union[Unset, bool] = UNSET
-    commenced_on: Union[Unset, datetime.datetime] = UNSET
-    commenced_by: Union[Unset, str] = UNSET
-    z_factor: Union[Unset, float] = UNSET
-    air_buoyancy: Union[Unset, float] = UNSET
-    evaporation_rate: Union[Unset, float] = UNSET
-    air_humidity: Union[Unset, float] = UNSET
-    altitude: Union[Unset, float] = UNSET
-    ambient_temperature: Union[Unset, float] = UNSET
-    barometric_pressure: Union[Unset, float] = UNSET
-    light_intensity: Union[Unset, float] = UNSET
-    noise_level: Union[Unset, float] = UNSET
-    ph_level: Union[Unset, float] = UNSET
-    water_conductivity: Union[Unset, float] = UNSET
-    water_temperature: Union[Unset, float] = UNSET
-    solar_radiation: Union[Unset, float] = UNSET
-    wind_speed: Union[Unset, float] = UNSET
-    z_factor_uom: Union[Unset, str] = UNSET
-    air_buoyancy_uom: Union[Unset, str] = UNSET
-    evaporation_rate_uom: Union[Unset, str] = UNSET
-    air_humidity_uom: Union[Unset, str] = UNSET
-    altitude_uom: Union[Unset, str] = UNSET
-    ambient_temperature_uom: Union[Unset, str] = UNSET
-    barometric_pressure_uom: Union[Unset, str] = UNSET
-    light_intensity_uom: Union[Unset, str] = UNSET
-    noise_level_uom: Union[Unset, str] = UNSET
-    ph_level_uom: Union[Unset, str] = UNSET
-    water_conductivity_uom: Union[Unset, str] = UNSET
-    water_temperature_uom: Union[Unset, str] = UNSET
-    solar_radiation_uom: Union[Unset, str] = UNSET
-    wind_speed_uom: Union[Unset, str] = UNSET
-    specification_name: Union[Unset, str] = UNSET
-    parameter_name: Union[Unset, str] = UNSET
-    measurement_set_display_order: Union[Unset, int] = UNSET
-    display_order: Union[Unset, int] = UNSET
-    unit_of_measure: Union[Unset, str] = UNSET
-    display_format: Union[Unset, str] = UNSET
-    precision: Union[Unset, float] = UNSET
-    minimum: Union[Unset, float] = UNSET
-    nominal: Union[Unset, float] = UNSET
-    expected_value: Union[Unset, float] = UNSET
-    expected_value_raw: Union[Unset, str] = UNSET
-    test_value: Union[Unset, float] = UNSET
-    base_value: Union[Unset, float] = UNSET
-    use_expected_value: Union[Unset, bool] = UNSET
-    reading_entry_logic: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic
+    updated_by: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    error: Union[None, Unset, float] = UNSET
+    error_extended: Union[None, Unset, str] = UNSET
+    require_adjustment: Union[None, Unset, bool] = UNSET
+    adjustment_threshold: Union[None, Unset, float] = UNSET
+    percent_of_tolerance: Union[None, Unset, float] = UNSET
+    percent_of_tolerance_extended: Union[None, Unset, str] = UNSET
+    tol_decimal_places: Union[None, Unset, int] = UNSET
+    specification_title: Union[None, Unset, str] = UNSET
+    specification_subtitle: Union[None, Unset, str] = UNSET
+    specification_group: Union[None, Unset, str] = UNSET
+    batch_type: Union[None, Unset, int] = UNSET
+    batch_result: Union[None, Unset, int] = UNSET
+    is_by_channel: Union[None, Unset, bool] = UNSET
+    channel_count: Union[None, Unset, int] = UNSET
+    is_range_accredited: Union[None, Unset, bool] = UNSET
+    commenced_on: Union[None, Unset, datetime.datetime] = UNSET
+    commenced_by: Union[None, Unset, str] = UNSET
+    z_factor: Union[None, Unset, float] = UNSET
+    air_buoyancy: Union[None, Unset, float] = UNSET
+    evaporation_rate: Union[None, Unset, float] = UNSET
+    air_humidity: Union[None, Unset, float] = UNSET
+    altitude: Union[None, Unset, float] = UNSET
+    ambient_temperature: Union[None, Unset, float] = UNSET
+    barometric_pressure: Union[None, Unset, float] = UNSET
+    light_intensity: Union[None, Unset, float] = UNSET
+    noise_level: Union[None, Unset, float] = UNSET
+    ph_level: Union[None, Unset, float] = UNSET
+    water_conductivity: Union[None, Unset, float] = UNSET
+    water_temperature: Union[None, Unset, float] = UNSET
+    solar_radiation: Union[None, Unset, float] = UNSET
+    wind_speed: Union[None, Unset, float] = UNSET
+    z_factor_uom: Union[None, Unset, str] = UNSET
+    air_buoyancy_uom: Union[None, Unset, str] = UNSET
+    evaporation_rate_uom: Union[None, Unset, str] = UNSET
+    air_humidity_uom: Union[None, Unset, str] = UNSET
+    altitude_uom: Union[None, Unset, str] = UNSET
+    ambient_temperature_uom: Union[None, Unset, str] = UNSET
+    barometric_pressure_uom: Union[None, Unset, str] = UNSET
+    light_intensity_uom: Union[None, Unset, str] = UNSET
+    noise_level_uom: Union[None, Unset, str] = UNSET
+    ph_level_uom: Union[None, Unset, str] = UNSET
+    water_conductivity_uom: Union[None, Unset, str] = UNSET
+    water_temperature_uom: Union[None, Unset, str] = UNSET
+    solar_radiation_uom: Union[None, Unset, str] = UNSET
+    wind_speed_uom: Union[None, Unset, str] = UNSET
+    specification_name: Union[None, Unset, str] = UNSET
+    parameter_name: Union[None, Unset, str] = UNSET
+    measurement_set_display_order: Union[None, Unset, int] = UNSET
+    display_order: Union[None, Unset, int] = UNSET
+    unit_of_measure: Union[None, Unset, str] = UNSET
+    display_format: Union[None, Unset, str] = UNSET
+    precision: Union[None, Unset, float] = UNSET
+    minimum: Union[None, Unset, float] = UNSET
+    nominal: Union[None, Unset, float] = UNSET
+    expected_value: Union[None, Unset, float] = UNSET
+    expected_value_raw: Union[None, Unset, str] = UNSET
+    test_value: Union[None, Unset, float] = UNSET
+    base_value: Union[None, Unset, float] = UNSET
+    use_expected_value: Union[None, Unset, bool] = UNSET
+    reading_entry_logic: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic
     ] = UNSET
-    reading_entry_math: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath
+    reading_entry_math: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath
     ] = UNSET
-    double_substitution_sequence: Union[
-        Unset,
+    double_substitution_sequence: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementResponseDoubleSubstitutionSequence,
     ] = UNSET
-    reading_entry_math_string: Union[Unset, str] = UNSET
-    nominal_extended: Union[Unset, str] = UNSET
-    expected_value_extended: Union[Unset, str] = UNSET
-    maximum: Union[Unset, float] = UNSET
-    tolerance_min: Union[Unset, float] = UNSET
-    tolerance_max: Union[Unset, float] = UNSET
-    resolution: Union[Unset, float] = UNSET
-    resolution_count: Union[Unset, float] = UNSET
-    min_max_header: Union[Unset, str] = UNSET
-    accuracy_class: Union[Unset, str] = UNSET
-    accuracy_class_min: Union[Unset, float] = UNSET
-    accuracy_class_max: Union[Unset, float] = UNSET
-    environment_mask: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask
+    reading_entry_math_string: Union[None, Unset, str] = UNSET
+    nominal_extended: Union[None, Unset, str] = UNSET
+    expected_value_extended: Union[None, Unset, str] = UNSET
+    maximum: Union[None, Unset, float] = UNSET
+    tolerance_min: Union[None, Unset, float] = UNSET
+    tolerance_max: Union[None, Unset, float] = UNSET
+    resolution: Union[None, Unset, float] = UNSET
+    resolution_count: Union[None, Unset, float] = UNSET
+    min_max_header: Union[None, Unset, str] = UNSET
+    accuracy_class: Union[None, Unset, str] = UNSET
+    accuracy_class_min: Union[None, Unset, float] = UNSET
+    accuracy_class_max: Union[None, Unset, float] = UNSET
+    environment_mask: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask
     ] = UNSET
-    display_name: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    vendor_company_id: Union[Unset, int] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    completed_by_name: Union[Unset, str] = UNSET
-    completed_on: Union[Unset, datetime.datetime] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
-    vendor_service_notes: Union[Unset, str] = UNSET
-    room: Union[Unset, str] = UNSET
-    segment_name: Union[Unset, str] = UNSET
-    schedule_name: Union[Unset, str] = UNSET
-    next_segment_name: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    display_name: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    vendor_company_id: Union[None, Unset, int] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    completed_by_name: Union[None, Unset, str] = UNSET
+    completed_on: Union[None, Unset, datetime.datetime] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
+    vendor_service_notes: Union[None, Unset, str] = UNSET
+    room: Union[None, Unset, str] = UNSET
+    segment_name: Union[None, Unset, str] = UNSET
+    schedule_name: Union[None, Unset, str] = UNSET
+    next_segment_name: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     work_status: Union[None, Unset, WorkStatus] = UNSET
-    service_type: Union[Unset, str] = UNSET
-    service_level: Union[Unset, str] = UNSET
-    barcode: Union[Unset, str] = UNSET
-    service_comments: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_identifier: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    asset_tag_change: Union[Unset, str] = UNSET
-    asset_user_change: Union[Unset, str] = UNSET
-    serial_number_change: Union[Unset, str] = UNSET
+    service_type: Union[None, Unset, str] = UNSET
+    service_level: Union[None, Unset, str] = UNSET
+    barcode: Union[None, Unset, str] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_identifier: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    asset_tag_change: Union[None, Unset, str] = UNSET
+    asset_user_change: Union[None, Unset, str] = UNSET
+    serial_number_change: Union[None, Unset, str] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    measurement_batch_id: Union[Unset, int] = UNSET
-    measurement_id: Union[Unset, int] = UNSET
-    standard_id: Union[Unset, int] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    measurement_tool_id: Union[Unset, int] = UNSET
-    measurement_condition_id: Union[Unset, int] = UNSET
-    measurement_point_id: Union[Unset, int] = UNSET
-    measurement_set_id: Union[Unset, int] = UNSET
-    is_hidden: Union[Unset, bool] = UNSET
-    readings: Union[Unset, int] = UNSET
-    tolerance_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    measurement_batch_id: Union[None, Unset, int] = UNSET
+    measurement_id: Union[None, Unset, int] = UNSET
+    standard_id: Union[None, Unset, int] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    measurement_tool_id: Union[None, Unset, int] = UNSET
+    measurement_condition_id: Union[None, Unset, int] = UNSET
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    measurement_set_id: Union[None, Unset, int] = UNSET
+    is_hidden: Union[None, Unset, bool] = UNSET
+    readings: Union[None, Unset, int] = UNSET
+    tolerance_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType
     ] = UNSET
-    tolerance_type_string: Union[Unset, str] = UNSET
-    precision_type: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType
+    tolerance_type_string: Union[None, Unset, str] = UNSET
+    precision_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType
     ] = UNSET
-    specification_mode: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode
+    specification_mode: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode
     ] = UNSET
-    tolerance_mode: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode
+    tolerance_mode: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode
     ] = UNSET
-    tolerance_unit: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit
+    tolerance_unit: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit
     ] = UNSET
-    tolerance_string: Union[Unset, str] = UNSET
-    po_number: Union[Unset, str] = UNSET
-    secondary_po: Union[Unset, str] = UNSET
+    tolerance_string: Union[None, Unset, str] = UNSET
+    po_number: Union[None, Unset, str] = UNSET
+    secondary_po: Union[None, Unset, str] = UNSET
     shipped_date: Union[None, Unset, datetime.datetime] = UNSET
-    shipment_status: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus
+    shipment_status: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus
     ] = UNSET
-    shipped_on: Union[Unset, datetime.datetime] = UNSET
-    delivered_on: Union[Unset, datetime.datetime] = UNSET
-    tracking_number: Union[Unset, str] = UNSET
-    payment_terms: Union[Unset, int] = UNSET
-    shipping_method: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    site_access_notes: Union[Unset, str] = UNSET
-    abbreviated_uom: Union[Unset, str] = UNSET
-    unit_scale_factor: Union[Unset, float] = UNSET
-    measurement_not_taken_result: Union[
-        Unset,
+    shipped_on: Union[None, Unset, datetime.datetime] = UNSET
+    delivered_on: Union[None, Unset, datetime.datetime] = UNSET
+    tracking_number: Union[None, Unset, str] = UNSET
+    payment_terms: Union[None, Unset, int] = UNSET
+    shipping_method: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    site_access_notes: Union[None, Unset, str] = UNSET
+    abbreviated_uom: Union[None, Unset, str] = UNSET
+    unit_scale_factor: Union[None, Unset, float] = UNSET
+    measurement_not_taken_result: Union[None, Unset,
         QualerApiModelsReportDatasetsToMeasurementResponseMeasurementNotTakenResult,
     ] = UNSET
-    hide_from_certificate: Union[Unset, bool] = UNSET
-    measurement_not_taken_reason: Union[Unset, str] = UNSET
-    environment_text_1: Union[Unset, str] = UNSET
-    environment_text_2: Union[Unset, str] = UNSET
-    environment_text_3: Union[Unset, str] = UNSET
-    environment_text_4: Union[Unset, str] = UNSET
-    environment_text_5: Union[Unset, str] = UNSET
-    environment_text_6: Union[Unset, str] = UNSET
-    values: Union[Unset, str] = UNSET
-    value_1: Union[Unset, str] = UNSET
-    value_2: Union[Unset, str] = UNSET
-    value_3: Union[Unset, str] = UNSET
-    value_4: Union[Unset, str] = UNSET
-    value_5: Union[Unset, str] = UNSET
-    value_6: Union[Unset, str] = UNSET
-    value_7: Union[Unset, str] = UNSET
-    value_8: Union[Unset, str] = UNSET
-    value_9: Union[Unset, str] = UNSET
-    value_10: Union[Unset, str] = UNSET
-    value_11: Union[Unset, str] = UNSET
-    value_12: Union[Unset, str] = UNSET
-    value_13: Union[Unset, str] = UNSET
-    value_14: Union[Unset, str] = UNSET
-    value_15: Union[Unset, str] = UNSET
-    value_16: Union[Unset, str] = UNSET
-    value_17: Union[Unset, str] = UNSET
-    value_18: Union[Unset, str] = UNSET
-    value_19: Union[Unset, str] = UNSET
-    value_20: Union[Unset, str] = UNSET
-    value_21: Union[Unset, str] = UNSET
-    value_22: Union[Unset, str] = UNSET
-    value_23: Union[Unset, str] = UNSET
-    value_24: Union[Unset, str] = UNSET
-    value_25: Union[Unset, str] = UNSET
-    value_26: Union[Unset, str] = UNSET
-    value_27: Union[Unset, str] = UNSET
-    value_28: Union[Unset, str] = UNSET
-    value_29: Union[Unset, str] = UNSET
-    value_30: Union[Unset, str] = UNSET
-    value_31: Union[Unset, str] = UNSET
-    value_32: Union[Unset, str] = UNSET
-    value_33: Union[Unset, str] = UNSET
-    value_34: Union[Unset, str] = UNSET
-    value_35: Union[Unset, str] = UNSET
-    value_36: Union[Unset, str] = UNSET
-    value_37: Union[Unset, str] = UNSET
-    value_38: Union[Unset, str] = UNSET
-    value_39: Union[Unset, str] = UNSET
-    value_40: Union[Unset, str] = UNSET
-    raw_value_1: Union[Unset, str] = UNSET
-    raw_value_2: Union[Unset, str] = UNSET
-    raw_value_3: Union[Unset, str] = UNSET
-    raw_value_4: Union[Unset, str] = UNSET
-    raw_value_5: Union[Unset, str] = UNSET
-    raw_value_6: Union[Unset, str] = UNSET
-    raw_value_7: Union[Unset, str] = UNSET
-    raw_value_8: Union[Unset, str] = UNSET
-    raw_value_9: Union[Unset, str] = UNSET
-    raw_value_10: Union[Unset, str] = UNSET
-    raw_value_11: Union[Unset, str] = UNSET
-    raw_value_12: Union[Unset, str] = UNSET
-    raw_value_13: Union[Unset, str] = UNSET
-    raw_value_14: Union[Unset, str] = UNSET
-    raw_value_15: Union[Unset, str] = UNSET
-    raw_value_16: Union[Unset, str] = UNSET
-    raw_value_17: Union[Unset, str] = UNSET
-    raw_value_18: Union[Unset, str] = UNSET
-    raw_value_19: Union[Unset, str] = UNSET
-    raw_value_20: Union[Unset, str] = UNSET
-    raw_value_21: Union[Unset, str] = UNSET
-    raw_value_22: Union[Unset, str] = UNSET
-    raw_value_23: Union[Unset, str] = UNSET
-    raw_value_24: Union[Unset, str] = UNSET
-    raw_value_25: Union[Unset, str] = UNSET
-    raw_value_26: Union[Unset, str] = UNSET
-    raw_value_27: Union[Unset, str] = UNSET
-    raw_value_28: Union[Unset, str] = UNSET
-    raw_value_29: Union[Unset, str] = UNSET
-    raw_value_30: Union[Unset, str] = UNSET
-    raw_value_31: Union[Unset, str] = UNSET
-    raw_value_32: Union[Unset, str] = UNSET
-    raw_value_33: Union[Unset, str] = UNSET
-    raw_value_34: Union[Unset, str] = UNSET
-    raw_value_35: Union[Unset, str] = UNSET
-    raw_value_36: Union[Unset, str] = UNSET
-    raw_value_37: Union[Unset, str] = UNSET
-    raw_value_38: Union[Unset, str] = UNSET
-    raw_value_39: Union[Unset, str] = UNSET
-    raw_value_40: Union[Unset, str] = UNSET
-    subtitles_to_readings: Union[Unset, str] = UNSET
-    value_subtitle_1: Union[Unset, str] = UNSET
-    value_subtitle_2: Union[Unset, str] = UNSET
-    value_subtitle_3: Union[Unset, str] = UNSET
-    value_subtitle_4: Union[Unset, str] = UNSET
-    value_subtitle_5: Union[Unset, str] = UNSET
-    value_subtitle_6: Union[Unset, str] = UNSET
-    value_subtitle_7: Union[Unset, str] = UNSET
-    value_subtitle_8: Union[Unset, str] = UNSET
-    value_subtitle_9: Union[Unset, str] = UNSET
-    value_subtitle_10: Union[Unset, str] = UNSET
-    value_subtitle_11: Union[Unset, str] = UNSET
-    value_subtitle_12: Union[Unset, str] = UNSET
-    value_subtitle_13: Union[Unset, str] = UNSET
-    value_subtitle_14: Union[Unset, str] = UNSET
-    value_subtitle_15: Union[Unset, str] = UNSET
-    value_subtitle_16: Union[Unset, str] = UNSET
-    value_subtitle_17: Union[Unset, str] = UNSET
-    value_subtitle_18: Union[Unset, str] = UNSET
-    value_subtitle_19: Union[Unset, str] = UNSET
-    value_subtitle_20: Union[Unset, str] = UNSET
-    value_subtitle_21: Union[Unset, str] = UNSET
-    value_subtitle_22: Union[Unset, str] = UNSET
-    value_subtitle_23: Union[Unset, str] = UNSET
-    value_subtitle_24: Union[Unset, str] = UNSET
-    value_subtitle_25: Union[Unset, str] = UNSET
-    value_subtitle_26: Union[Unset, str] = UNSET
-    value_subtitle_27: Union[Unset, str] = UNSET
-    value_subtitle_28: Union[Unset, str] = UNSET
-    value_subtitle_29: Union[Unset, str] = UNSET
-    value_subtitle_30: Union[Unset, str] = UNSET
-    value_subtitle_31: Union[Unset, str] = UNSET
-    value_subtitle_32: Union[Unset, str] = UNSET
-    value_subtitle_33: Union[Unset, str] = UNSET
-    value_subtitle_34: Union[Unset, str] = UNSET
-    value_subtitle_35: Union[Unset, str] = UNSET
-    value_subtitle_36: Union[Unset, str] = UNSET
-    value_subtitle_37: Union[Unset, str] = UNSET
-    value_subtitle_38: Union[Unset, str] = UNSET
-    value_subtitle_39: Union[Unset, str] = UNSET
-    value_subtitle_40: Union[Unset, str] = UNSET
-    values_decimal_places: Union[Unset, int] = UNSET
-    repeat_measurement_and_calculate_hysteresis: Union[Unset, bool] = UNSET
-    measurement_point_order: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementPointOrder
+    hide_from_certificate: Union[None, Unset, bool] = UNSET
+    measurement_not_taken_reason: Union[None, Unset, str] = UNSET
+    environment_text_1: Union[None, Unset, str] = UNSET
+    environment_text_2: Union[None, Unset, str] = UNSET
+    environment_text_3: Union[None, Unset, str] = UNSET
+    environment_text_4: Union[None, Unset, str] = UNSET
+    environment_text_5: Union[None, Unset, str] = UNSET
+    environment_text_6: Union[None, Unset, str] = UNSET
+    values: Union[None, Unset, str] = UNSET
+    value_1: Union[None, Unset, str] = UNSET
+    value_2: Union[None, Unset, str] = UNSET
+    value_3: Union[None, Unset, str] = UNSET
+    value_4: Union[None, Unset, str] = UNSET
+    value_5: Union[None, Unset, str] = UNSET
+    value_6: Union[None, Unset, str] = UNSET
+    value_7: Union[None, Unset, str] = UNSET
+    value_8: Union[None, Unset, str] = UNSET
+    value_9: Union[None, Unset, str] = UNSET
+    value_10: Union[None, Unset, str] = UNSET
+    value_11: Union[None, Unset, str] = UNSET
+    value_12: Union[None, Unset, str] = UNSET
+    value_13: Union[None, Unset, str] = UNSET
+    value_14: Union[None, Unset, str] = UNSET
+    value_15: Union[None, Unset, str] = UNSET
+    value_16: Union[None, Unset, str] = UNSET
+    value_17: Union[None, Unset, str] = UNSET
+    value_18: Union[None, Unset, str] = UNSET
+    value_19: Union[None, Unset, str] = UNSET
+    value_20: Union[None, Unset, str] = UNSET
+    value_21: Union[None, Unset, str] = UNSET
+    value_22: Union[None, Unset, str] = UNSET
+    value_23: Union[None, Unset, str] = UNSET
+    value_24: Union[None, Unset, str] = UNSET
+    value_25: Union[None, Unset, str] = UNSET
+    value_26: Union[None, Unset, str] = UNSET
+    value_27: Union[None, Unset, str] = UNSET
+    value_28: Union[None, Unset, str] = UNSET
+    value_29: Union[None, Unset, str] = UNSET
+    value_30: Union[None, Unset, str] = UNSET
+    value_31: Union[None, Unset, str] = UNSET
+    value_32: Union[None, Unset, str] = UNSET
+    value_33: Union[None, Unset, str] = UNSET
+    value_34: Union[None, Unset, str] = UNSET
+    value_35: Union[None, Unset, str] = UNSET
+    value_36: Union[None, Unset, str] = UNSET
+    value_37: Union[None, Unset, str] = UNSET
+    value_38: Union[None, Unset, str] = UNSET
+    value_39: Union[None, Unset, str] = UNSET
+    value_40: Union[None, Unset, str] = UNSET
+    raw_value_1: Union[None, Unset, str] = UNSET
+    raw_value_2: Union[None, Unset, str] = UNSET
+    raw_value_3: Union[None, Unset, str] = UNSET
+    raw_value_4: Union[None, Unset, str] = UNSET
+    raw_value_5: Union[None, Unset, str] = UNSET
+    raw_value_6: Union[None, Unset, str] = UNSET
+    raw_value_7: Union[None, Unset, str] = UNSET
+    raw_value_8: Union[None, Unset, str] = UNSET
+    raw_value_9: Union[None, Unset, str] = UNSET
+    raw_value_10: Union[None, Unset, str] = UNSET
+    raw_value_11: Union[None, Unset, str] = UNSET
+    raw_value_12: Union[None, Unset, str] = UNSET
+    raw_value_13: Union[None, Unset, str] = UNSET
+    raw_value_14: Union[None, Unset, str] = UNSET
+    raw_value_15: Union[None, Unset, str] = UNSET
+    raw_value_16: Union[None, Unset, str] = UNSET
+    raw_value_17: Union[None, Unset, str] = UNSET
+    raw_value_18: Union[None, Unset, str] = UNSET
+    raw_value_19: Union[None, Unset, str] = UNSET
+    raw_value_20: Union[None, Unset, str] = UNSET
+    raw_value_21: Union[None, Unset, str] = UNSET
+    raw_value_22: Union[None, Unset, str] = UNSET
+    raw_value_23: Union[None, Unset, str] = UNSET
+    raw_value_24: Union[None, Unset, str] = UNSET
+    raw_value_25: Union[None, Unset, str] = UNSET
+    raw_value_26: Union[None, Unset, str] = UNSET
+    raw_value_27: Union[None, Unset, str] = UNSET
+    raw_value_28: Union[None, Unset, str] = UNSET
+    raw_value_29: Union[None, Unset, str] = UNSET
+    raw_value_30: Union[None, Unset, str] = UNSET
+    raw_value_31: Union[None, Unset, str] = UNSET
+    raw_value_32: Union[None, Unset, str] = UNSET
+    raw_value_33: Union[None, Unset, str] = UNSET
+    raw_value_34: Union[None, Unset, str] = UNSET
+    raw_value_35: Union[None, Unset, str] = UNSET
+    raw_value_36: Union[None, Unset, str] = UNSET
+    raw_value_37: Union[None, Unset, str] = UNSET
+    raw_value_38: Union[None, Unset, str] = UNSET
+    raw_value_39: Union[None, Unset, str] = UNSET
+    raw_value_40: Union[None, Unset, str] = UNSET
+    subtitles_to_readings: Union[None, Unset, str] = UNSET
+    value_subtitle_1: Union[None, Unset, str] = UNSET
+    value_subtitle_2: Union[None, Unset, str] = UNSET
+    value_subtitle_3: Union[None, Unset, str] = UNSET
+    value_subtitle_4: Union[None, Unset, str] = UNSET
+    value_subtitle_5: Union[None, Unset, str] = UNSET
+    value_subtitle_6: Union[None, Unset, str] = UNSET
+    value_subtitle_7: Union[None, Unset, str] = UNSET
+    value_subtitle_8: Union[None, Unset, str] = UNSET
+    value_subtitle_9: Union[None, Unset, str] = UNSET
+    value_subtitle_10: Union[None, Unset, str] = UNSET
+    value_subtitle_11: Union[None, Unset, str] = UNSET
+    value_subtitle_12: Union[None, Unset, str] = UNSET
+    value_subtitle_13: Union[None, Unset, str] = UNSET
+    value_subtitle_14: Union[None, Unset, str] = UNSET
+    value_subtitle_15: Union[None, Unset, str] = UNSET
+    value_subtitle_16: Union[None, Unset, str] = UNSET
+    value_subtitle_17: Union[None, Unset, str] = UNSET
+    value_subtitle_18: Union[None, Unset, str] = UNSET
+    value_subtitle_19: Union[None, Unset, str] = UNSET
+    value_subtitle_20: Union[None, Unset, str] = UNSET
+    value_subtitle_21: Union[None, Unset, str] = UNSET
+    value_subtitle_22: Union[None, Unset, str] = UNSET
+    value_subtitle_23: Union[None, Unset, str] = UNSET
+    value_subtitle_24: Union[None, Unset, str] = UNSET
+    value_subtitle_25: Union[None, Unset, str] = UNSET
+    value_subtitle_26: Union[None, Unset, str] = UNSET
+    value_subtitle_27: Union[None, Unset, str] = UNSET
+    value_subtitle_28: Union[None, Unset, str] = UNSET
+    value_subtitle_29: Union[None, Unset, str] = UNSET
+    value_subtitle_30: Union[None, Unset, str] = UNSET
+    value_subtitle_31: Union[None, Unset, str] = UNSET
+    value_subtitle_32: Union[None, Unset, str] = UNSET
+    value_subtitle_33: Union[None, Unset, str] = UNSET
+    value_subtitle_34: Union[None, Unset, str] = UNSET
+    value_subtitle_35: Union[None, Unset, str] = UNSET
+    value_subtitle_36: Union[None, Unset, str] = UNSET
+    value_subtitle_37: Union[None, Unset, str] = UNSET
+    value_subtitle_38: Union[None, Unset, str] = UNSET
+    value_subtitle_39: Union[None, Unset, str] = UNSET
+    value_subtitle_40: Union[None, Unset, str] = UNSET
+    values_decimal_places: Union[None, Unset, int] = UNSET
+    repeat_measurement_and_calculate_hysteresis: Union[None, Unset, bool] = UNSET
+    measurement_point_order: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementPointOrder
     ] = UNSET
-    hysteresis_point: Union[
-        Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint
+    hysteresis_point: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint
     ] = UNSET
-    max_hysteresis: Union[Unset, float] = UNSET
-    run: Union[Unset, int] = UNSET
-    direction: Union[Unset, int] = UNSET
-    hysteresis: Union[Unset, float] = UNSET
-    column_mean: Union[Unset, str] = UNSET
-    column_mean_result: Union[Unset, str] = UNSET
-    column_sd: Union[Unset, str] = UNSET
-    column_sd_result: Union[Unset, str] = UNSET
-    column_cv: Union[Unset, str] = UNSET
-    column_cv_result: Union[Unset, str] = UNSET
-    column_range: Union[Unset, str] = UNSET
-    column_range_result: Union[Unset, str] = UNSET
-    column_delta: Union[Unset, str] = UNSET
-    column_delta_result: Union[Unset, str] = UNSET
-    column_result: Union[Unset, str] = UNSET
+    max_hysteresis: Union[None, Unset, float] = UNSET
+    run: Union[None, Unset, int] = UNSET
+    direction: Union[None, Unset, int] = UNSET
+    hysteresis: Union[None, Unset, float] = UNSET
+    column_mean: Union[None, Unset, str] = UNSET
+    column_mean_result: Union[None, Unset, str] = UNSET
+    column_sd: Union[None, Unset, str] = UNSET
+    column_sd_result: Union[None, Unset, str] = UNSET
+    column_cv: Union[None, Unset, str] = UNSET
+    column_cv_result: Union[None, Unset, str] = UNSET
+    column_range: Union[None, Unset, str] = UNSET
+    column_range_result: Union[None, Unset, str] = UNSET
+    column_delta: Union[None, Unset, str] = UNSET
+    column_delta_result: Union[None, Unset, str] = UNSET
+    column_result: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -956,7 +941,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         cv_header = self.cv_header
 
-        measurement_local_time: Union[Unset, str] = UNSET
+        measurement_local_time: Union[None, Unset, str] = UNSET
         if self.measurement_local_time and not isinstance(
             self.measurement_local_time, Unset
         ):
@@ -1050,7 +1035,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         guard_band = self.guard_band
 
-        guard_band_logic: Union[Unset, str] = UNSET
+        guard_band_logic: Union[None, Unset, str] = UNSET
         if self.guard_band_logic and not isinstance(self.guard_band_logic, Unset):
             guard_band_logic = self.guard_band_logic.value
 
@@ -1064,13 +1049,13 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         channel = self.channel
 
-        measurement_type: Union[Unset, str] = UNSET
+        measurement_type: Union[None, Unset, str] = UNSET
         if self.measurement_type and not isinstance(self.measurement_type, Unset):
             measurement_type = self.measurement_type.value
 
         updated_by = self.updated_by
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -1104,7 +1089,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         is_range_accredited = self.is_range_accredited
 
-        commenced_on: Union[Unset, str] = UNSET
+        commenced_on: Union[None, Unset, str] = UNSET
         if self.commenced_on and not isinstance(self.commenced_on, Unset):
             commenced_on = self.commenced_on.isoformat()
 
@@ -1194,15 +1179,15 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         use_expected_value = self.use_expected_value
 
-        reading_entry_logic: Union[Unset, str] = UNSET
+        reading_entry_logic: Union[None, Unset, str] = UNSET
         if self.reading_entry_logic and not isinstance(self.reading_entry_logic, Unset):
             reading_entry_logic = self.reading_entry_logic.value
 
-        reading_entry_math: Union[Unset, str] = UNSET
+        reading_entry_math: Union[None, Unset, str] = UNSET
         if self.reading_entry_math and not isinstance(self.reading_entry_math, Unset):
             reading_entry_math = self.reading_entry_math.value
 
-        double_substitution_sequence: Union[Unset, str] = UNSET
+        double_substitution_sequence: Union[None, Unset, str] = UNSET
         if self.double_substitution_sequence and not isinstance(
             self.double_substitution_sequence, Unset
         ):
@@ -1232,7 +1217,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         accuracy_class_max = self.accuracy_class_max
 
-        environment_mask: Union[Unset, str] = UNSET
+        environment_mask: Union[None, Unset, str] = UNSET
         if self.environment_mask and not isinstance(self.environment_mask, Unset):
             environment_mask = self.environment_mask.value
 
@@ -1250,7 +1235,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         completed_by_name = self.completed_by_name
 
-        completed_on: Union[Unset, str] = UNSET
+        completed_on: Union[None, Unset, str] = UNSET
         if self.completed_on and not isinstance(self.completed_on, Unset):
             completed_on = self.completed_on.isoformat()
 
@@ -1354,25 +1339,25 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         readings = self.readings
 
-        tolerance_type: Union[Unset, str] = UNSET
+        tolerance_type: Union[None, Unset, str] = UNSET
         if self.tolerance_type and not isinstance(self.tolerance_type, Unset):
             tolerance_type = self.tolerance_type.value
 
         tolerance_type_string = self.tolerance_type_string
 
-        precision_type: Union[Unset, str] = UNSET
+        precision_type: Union[None, Unset, str] = UNSET
         if self.precision_type and not isinstance(self.precision_type, Unset):
             precision_type = self.precision_type.value
 
-        specification_mode: Union[Unset, int] = UNSET
+        specification_mode: Union[None, Unset, int] = UNSET
         if self.specification_mode and not isinstance(self.specification_mode, Unset):
             specification_mode = self.specification_mode.value
 
-        tolerance_mode: Union[Unset, int] = UNSET
+        tolerance_mode: Union[None, Unset, int] = UNSET
         if self.tolerance_mode and not isinstance(self.tolerance_mode, Unset):
             tolerance_mode = self.tolerance_mode.value
 
-        tolerance_unit: Union[Unset, int] = UNSET
+        tolerance_unit: Union[None, Unset, int] = UNSET
         if self.tolerance_unit and not isinstance(self.tolerance_unit, Unset):
             tolerance_unit = self.tolerance_unit.value
 
@@ -1390,15 +1375,15 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         else:
             shipped_date = self.shipped_date
 
-        shipment_status: Union[Unset, str] = UNSET
+        shipment_status: Union[None, Unset, str] = UNSET
         if self.shipment_status and not isinstance(self.shipment_status, Unset):
             shipment_status = self.shipment_status.value
 
-        shipped_on: Union[Unset, str] = UNSET
+        shipped_on: Union[None, Unset, str] = UNSET
         if self.shipped_on and not isinstance(self.shipped_on, Unset):
             shipped_on = self.shipped_on.isoformat()
 
-        delivered_on: Union[Unset, str] = UNSET
+        delivered_on: Union[None, Unset, str] = UNSET
         if self.delivered_on and not isinstance(self.delivered_on, Unset):
             delivered_on = self.delivered_on.isoformat()
 
@@ -1416,7 +1401,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
 
         unit_scale_factor = self.unit_scale_factor
 
-        measurement_not_taken_result: Union[Unset, str] = UNSET
+        measurement_not_taken_result: Union[None, Unset, str] = UNSET
         if self.measurement_not_taken_result and not isinstance(
             self.measurement_not_taken_result, Unset
         ):
@@ -1688,13 +1673,13 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             self.repeat_measurement_and_calculate_hysteresis
         )
 
-        measurement_point_order: Union[Unset, str] = UNSET
+        measurement_point_order: Union[None, Unset, str] = UNSET
         if self.measurement_point_order and not isinstance(
             self.measurement_point_order, Unset
         ):
             measurement_point_order = self.measurement_point_order.value
 
-        hysteresis_point: Union[Unset, str] = UNSET
+        hysteresis_point: Union[None, Unset, str] = UNSET
         if self.hysteresis_point and not isinstance(self.hysteresis_point, Unset):
             hysteresis_point = self.hysteresis_point.value
 
@@ -2648,7 +2633,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         cv_header = d.pop("CvHeader", UNSET)
 
         _measurement_local_time = d.pop("MeasurementLocalTime", UNSET)
-        measurement_local_time: Union[Unset, datetime.datetime]
+        measurement_local_time: Union[None, Unset, datetime.datetime]
         if isinstance(_measurement_local_time, Unset):
             measurement_local_time = UNSET
         else:
@@ -2743,8 +2728,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         guard_band = d.pop("GuardBand", UNSET)
 
         _guard_band_logic = d.pop("GuardBandLogic", UNSET)
-        guard_band_logic: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic
+        guard_band_logic: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseGuardBandLogic
         ]
         if isinstance(_guard_band_logic, Unset):
             guard_band_logic = UNSET
@@ -2766,8 +2750,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         channel = d.pop("Channel", UNSET)
 
         _measurement_type = d.pop("MeasurementType", UNSET)
-        measurement_type: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType
+        measurement_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseMeasurementType
         ]
         if isinstance(_measurement_type, Unset):
             measurement_type = UNSET
@@ -2781,7 +2764,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         updated_by = d.pop("UpdatedBy", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:
@@ -2818,7 +2801,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         is_range_accredited = d.pop("IsRangeAccredited", UNSET)
 
         _commenced_on = d.pop("CommencedOn", UNSET)
-        commenced_on: Union[Unset, datetime.datetime]
+        commenced_on: Union[None, Unset, datetime.datetime]
         if isinstance(_commenced_on, Unset):
             commenced_on = UNSET
         else:
@@ -2911,8 +2894,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         use_expected_value = d.pop("UseExpectedValue", UNSET)
 
         _reading_entry_logic = d.pop("ReadingEntryLogic", UNSET)
-        reading_entry_logic: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic
+        reading_entry_logic: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryLogic
         ]
         if isinstance(_reading_entry_logic, Unset):
             reading_entry_logic = UNSET
@@ -2924,8 +2906,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _reading_entry_math = d.pop("ReadingEntryMath", UNSET)
-        reading_entry_math: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath
+        reading_entry_math: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseReadingEntryMath
         ]
         if isinstance(_reading_entry_math, Unset):
             reading_entry_math = UNSET
@@ -2937,8 +2918,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _double_substitution_sequence = d.pop("DoubleSubstitutionSequence", UNSET)
-        double_substitution_sequence: Union[
-            Unset,
+        double_substitution_sequence: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementResponseDoubleSubstitutionSequence,
         ]
         if isinstance(_double_substitution_sequence, Unset):
@@ -2973,8 +2953,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         accuracy_class_max = d.pop("AccuracyClassMax", UNSET)
 
         _environment_mask = d.pop("EnvironmentMask", UNSET)
-        environment_mask: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask
+        environment_mask: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseEnvironmentMask
         ]
         if isinstance(_environment_mask, Unset):
             environment_mask = UNSET
@@ -3000,7 +2979,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         completed_by_name = d.pop("CompletedByName", UNSET)
 
         _completed_on = d.pop("CompletedOn", UNSET)
-        completed_on: Union[Unset, datetime.datetime]
+        completed_on: Union[None, Unset, datetime.datetime]
         if isinstance(_completed_on, Unset):
             completed_on = UNSET
         else:
@@ -3023,7 +3002,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         certificate_number = d.pop("CertificateNumber", UNSET)
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:
@@ -3132,8 +3111,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         readings = d.pop("Readings", UNSET)
 
         _tolerance_type = d.pop("ToleranceType", UNSET)
-        tolerance_type: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType
+        tolerance_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceType
         ]
         if isinstance(_tolerance_type, Unset):
             tolerance_type = UNSET
@@ -3147,8 +3125,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         tolerance_type_string = d.pop("ToleranceTypeString", UNSET)
 
         _precision_type = d.pop("PrecisionType", UNSET)
-        precision_type: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType
+        precision_type: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponsePrecisionType
         ]
         if isinstance(_precision_type, Unset):
             precision_type = UNSET
@@ -3160,8 +3137,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _specification_mode = d.pop("SpecificationMode", UNSET)
-        specification_mode: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode
+        specification_mode: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseSpecificationMode
         ]
         if isinstance(_specification_mode, Unset):
             specification_mode = UNSET
@@ -3173,8 +3149,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _tolerance_mode = d.pop("ToleranceMode", UNSET)
-        tolerance_mode: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode
+        tolerance_mode: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceMode
         ]
         if isinstance(_tolerance_mode, Unset):
             tolerance_mode = UNSET
@@ -3186,8 +3161,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _tolerance_unit = d.pop("ToleranceUnit", UNSET)
-        tolerance_unit: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit
+        tolerance_unit: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseToleranceUnit
         ]
         if isinstance(_tolerance_unit, Unset):
             tolerance_unit = UNSET
@@ -3222,8 +3196,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         shipped_date = _parse_shipped_date(d.pop("ShippedDate", UNSET))
 
         _shipment_status = d.pop("ShipmentStatus", UNSET)
-        shipment_status: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus
+        shipment_status: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseShipmentStatus
         ]
         if isinstance(_shipment_status, Unset):
             shipment_status = UNSET
@@ -3235,14 +3208,14 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _shipped_on = d.pop("ShippedOn", UNSET)
-        shipped_on: Union[Unset, datetime.datetime]
+        shipped_on: Union[None, Unset, datetime.datetime]
         if isinstance(_shipped_on, Unset):
             shipped_on = UNSET
         else:
             shipped_on = isoparse(_shipped_on)
 
         _delivered_on = d.pop("DeliveredOn", UNSET)
-        delivered_on: Union[Unset, datetime.datetime]
+        delivered_on: Union[None, Unset, datetime.datetime]
         if isinstance(_delivered_on, Unset):
             delivered_on = UNSET
         else:
@@ -3263,8 +3236,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         unit_scale_factor = d.pop("UnitScaleFactor", UNSET)
 
         _measurement_not_taken_result = d.pop("MeasurementNotTakenResult", UNSET)
-        measurement_not_taken_result: Union[
-            Unset,
+        measurement_not_taken_result: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementResponseMeasurementNotTakenResult,
         ]
         if isinstance(_measurement_not_taken_result, Unset):
@@ -3541,8 +3513,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         )
 
         _measurement_point_order = d.pop("MeasurementPointOrder", UNSET)
-        measurement_point_order: Union[
-            Unset,
+        measurement_point_order: Union[None, Unset,
             QualerApiModelsReportDatasetsToMeasurementResponseMeasurementPointOrder,
         ]
         if isinstance(_measurement_point_order, Unset):
@@ -3555,8 +3526,7 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
             )
 
         _hysteresis_point = d.pop("HysteresisPoint", UNSET)
-        hysteresis_point: Union[
-            Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint
+        hysteresis_point: Union[None, Unset, QualerApiModelsReportDatasetsToMeasurementResponseHysteresisPoint
         ]
         if isinstance(_hysteresis_point, Unset):
             hysteresis_point = UNSET

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_order_item_image_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_order_item_image_response.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToOrderItemImageResponse")
 class QualerApiModelsReportDatasetsToOrderItemImageResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        image (Union[Unset, str]):
-        image_url (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        image (Union[None, Unset, str]):
+        image_url (Union[None, Unset, str]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    image: Union[Unset, str] = UNSET
-    image_url: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    image: Union[None, Unset, str] = UNSET
+    image_url: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_reference_standard_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_reference_standard_response.py
@@ -15,52 +15,52 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToReferenceStandardResponse
 class QualerApiModelsReportDatasetsToReferenceStandardResponse:
     """
     Attributes:
-        is_auxiliary (Union[Unset, bool]):
+        is_auxiliary (Union[None, Unset, bool]):
         last_service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
         certificate_number (Union[None, Unset, str]):
         calibrated_by (Union[None, Unset, str]):
-        tool_name (Union[Unset, str]):
-        tool_site (Union[Unset, str]):
-        tool_room (Union[Unset, str]):
-        tool_station (Union[Unset, str]):
-        tool_location (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        lot_number (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        tool_type_name (Union[Unset, str]):
-        tool_description (Union[Unset, str]):
-        tool_id (Union[Unset, int]):
-        manufacturer (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        area (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
-        manufacturer_part_number (Union[Unset, str]):
-        equipment_id (Union[Unset, str]):
+        tool_name (Union[None, Unset, str]):
+        tool_site (Union[None, Unset, str]):
+        tool_room (Union[None, Unset, str]):
+        tool_station (Union[None, Unset, str]):
+        tool_location (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        lot_number (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        tool_type_name (Union[None, Unset, str]):
+        tool_description (Union[None, Unset, str]):
+        tool_id (Union[None, Unset, int]):
+        manufacturer (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        area (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        equipment_id (Union[None, Unset, str]):
     """
 
-    is_auxiliary: Union[Unset, bool] = UNSET
+    is_auxiliary: Union[None, Unset, bool] = UNSET
     last_service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
     certificate_number: Union[None, Unset, str] = UNSET
     calibrated_by: Union[None, Unset, str] = UNSET
-    tool_name: Union[Unset, str] = UNSET
-    tool_site: Union[Unset, str] = UNSET
-    tool_room: Union[Unset, str] = UNSET
-    tool_station: Union[Unset, str] = UNSET
-    tool_location: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    lot_number: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    tool_type_name: Union[Unset, str] = UNSET
-    tool_description: Union[Unset, str] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    manufacturer: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    area: Union[Unset, str] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
+    tool_name: Union[None, Unset, str] = UNSET
+    tool_site: Union[None, Unset, str] = UNSET
+    tool_room: Union[None, Unset, str] = UNSET
+    tool_station: Union[None, Unset, str] = UNSET
+    tool_location: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    lot_number: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    tool_type_name: Union[None, Unset, str] = UNSET
+    tool_description: Union[None, Unset, str] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    manufacturer: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    area: Union[None, Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_assignee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_assignee_response.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderAssigneeRespo
 class QualerApiModelsReportDatasetsToServiceOrderAssigneeResponse:
     """
     Attributes:
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        alias (Union[Unset, str]):
-        email (Union[Unset, str]):
-        title (Union[Unset, str]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
+        email (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
     """
 
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
-    email: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
+    email: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_charge_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_charge_response.py
@@ -15,35 +15,35 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderChargeRespons
 class QualerApiModelsReportDatasetsToServiceOrderChargeResponse:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        description (Union[Unset, str]):
-        name (Union[Unset, str]):
-        unit_name (Union[Unset, str]):
-        quantity (Union[Unset, float]):
-        discount (Union[Unset, float]):
-        fixed_charge (Union[Unset, float]):
-        price (Union[Unset, float]):
-        subtotal (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
-        time_spent_in_minutes (Union[Unset, float]):
-        is_hourly_pricing (Union[Unset, bool]):
-        created_by (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        description (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        unit_name (Union[None, Unset, str]):
+        quantity (Union[None, Unset, float]):
+        discount (Union[None, Unset, float]):
+        fixed_charge (Union[None, Unset, float]):
+        price (Union[None, Unset, float]):
+        subtotal (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        created_by (Union[None, Unset, str]):
         charge_date (Union[None, Unset, datetime.datetime]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    description: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    discount: Union[Unset, float] = UNSET
-    fixed_charge: Union[Unset, float] = UNSET
-    price: Union[Unset, float] = UNSET
-    subtotal: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    created_by: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    discount: Union[None, Unset, float] = UNSET
+    fixed_charge: Union[None, Unset, float] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    subtotal: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    created_by: Union[None, Unset, str] = UNSET
     charge_date: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_component_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_component_response.py
@@ -15,34 +15,34 @@ T = TypeVar(
 class QualerApiModelsReportDatasetsToServiceOrderItemComponentResponse:
     """
     Attributes:
-        order_item_id (Union[Unset, int]):
-        component_asset_id (Union[Unset, int]):
-        component_serial_number (Union[Unset, str]):
-        component_asset_tag (Union[Unset, str]):
-        component_asset_user (Union[Unset, str]):
-        component_equipment_id (Union[Unset, str]):
-        component_manufacturer_part_number (Union[Unset, str]):
-        component_manufacturer (Union[Unset, str]):
-        component_root_category (Union[Unset, str]):
-        component_sub_category (Union[Unset, str]):
-        component_location (Union[Unset, str]):
-        component_display_name (Union[Unset, str]):
-        component_display_part_number (Union[Unset, str]):
+        order_item_id (Union[None, Unset, int]):
+        component_asset_id (Union[None, Unset, int]):
+        component_serial_number (Union[None, Unset, str]):
+        component_asset_tag (Union[None, Unset, str]):
+        component_asset_user (Union[None, Unset, str]):
+        component_equipment_id (Union[None, Unset, str]):
+        component_manufacturer_part_number (Union[None, Unset, str]):
+        component_manufacturer (Union[None, Unset, str]):
+        component_root_category (Union[None, Unset, str]):
+        component_sub_category (Union[None, Unset, str]):
+        component_location (Union[None, Unset, str]):
+        component_display_name (Union[None, Unset, str]):
+        component_display_part_number (Union[None, Unset, str]):
     """
 
-    order_item_id: Union[Unset, int] = UNSET
-    component_asset_id: Union[Unset, int] = UNSET
-    component_serial_number: Union[Unset, str] = UNSET
-    component_asset_tag: Union[Unset, str] = UNSET
-    component_asset_user: Union[Unset, str] = UNSET
-    component_equipment_id: Union[Unset, str] = UNSET
-    component_manufacturer_part_number: Union[Unset, str] = UNSET
-    component_manufacturer: Union[Unset, str] = UNSET
-    component_root_category: Union[Unset, str] = UNSET
-    component_sub_category: Union[Unset, str] = UNSET
-    component_location: Union[Unset, str] = UNSET
-    component_display_name: Union[Unset, str] = UNSET
-    component_display_part_number: Union[Unset, str] = UNSET
+    order_item_id: Union[None, Unset, int] = UNSET
+    component_asset_id: Union[None, Unset, int] = UNSET
+    component_serial_number: Union[None, Unset, str] = UNSET
+    component_asset_tag: Union[None, Unset, str] = UNSET
+    component_asset_user: Union[None, Unset, str] = UNSET
+    component_equipment_id: Union[None, Unset, str] = UNSET
+    component_manufacturer_part_number: Union[None, Unset, str] = UNSET
+    component_manufacturer: Union[None, Unset, str] = UNSET
+    component_root_category: Union[None, Unset, str] = UNSET
+    component_sub_category: Union[None, Unset, str] = UNSET
+    component_location: Union[None, Unset, str] = UNSET
+    component_display_name: Union[None, Unset, str] = UNSET
+    component_display_part_number: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_field_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_field_response.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderItemFieldResp
 class QualerApiModelsReportDatasetsToServiceOrderItemFieldResponse:
     """
     Attributes:
-        field_id (Union[Unset, str]):
-        type_ (Union[Unset, int]):
-        value (Union[Unset, str]):
-        service_order_item_id (Union[Unset, int]):
-        service_order_item_task_id (Union[Unset, int]):
+        field_id (Union[None, Unset, str]):
+        type_ (Union[None, Unset, int]):
+        value (Union[None, Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        service_order_item_task_id (Union[None, Unset, int]):
     """
 
-    field_id: Union[Unset, str] = UNSET
-    type_: Union[Unset, int] = UNSET
-    value: Union[Unset, str] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    service_order_item_task_id: Union[Unset, int] = UNSET
+    field_id: Union[None, Unset, str] = UNSET
+    type_: Union[None, Unset, int] = UNSET
+    value: Union[None, Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    service_order_item_task_id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_option_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_option_response.py
@@ -13,20 +13,20 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderItemOptionRes
 class QualerApiModelsReportDatasetsToServiceOrderItemOptionResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        service_charge (Union[Unset, float]):
-        time_spent (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
-        price (Union[Unset, float]):
-        task_name (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        service_charge (Union[None, Unset, float]):
+        time_spent (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
+        price (Union[None, Unset, float]):
+        task_name (Union[None, Unset, str]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    service_charge: Union[Unset, float] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
-    price: Union[Unset, float] = UNSET
-    task_name: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    service_charge: Union[None, Unset, float] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_response.py
@@ -16,58 +16,58 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderItemResponse"
 class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
     """
     Attributes:
-        certificate_number (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        revision (Union[Unset, str]):
+        certificate_number (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        revision (Union[None, Unset, str]):
         effective_date (Union[None, Unset, datetime.datetime]):
-        document_section (Union[Unset, str]):
-        service_level (Union[Unset, str]):
-        service_level_code (Union[Unset, str]):
-        service_type (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        service_charge (Union[Unset, float]):
-        updated_by (Union[Unset, str]):
-        updated_on (Union[Unset, datetime.datetime]):
-        work_status (Union[Unset, WorkStatus]):
-        custom_work_status (Union[Unset, str]):
-        service_comments (Union[Unset, str]):
-        client_notes (Union[Unset, str]):
-        vendor_service_notes (Union[Unset, str]):
-        display_name (Union[Unset, str]):
-        display_part_number (Union[Unset, str]):
-        part_number (Union[Unset, str]):
-        schedule_name (Union[Unset, str]):
-        segment_name (Union[Unset, str]):
-        next_segment_name (Union[Unset, str]):
-        interval_length (Union[Unset, int]):
-        interval_cycle (Union[Unset, str]):
-        service_options (Union[Unset, str]):
-        service_options_price (Union[Unset, str]):
-        service_options_document_numbers (Union[Unset, str]):
-        location (Union[Unset, str]):
-        station (Union[Unset, str]):
-        room (Union[Unset, str]):
-        site (Union[Unset, str]):
-        vendor_id (Union[Unset, int]):
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
-        linked_order_number (Union[Unset, str]):
-        asset_id (Union[Unset, int]):
-        asset_class (Union[Unset, str]):
-        asset_condition (Union[Unset, str]):
-        asset_criticality (Union[Unset, str]):
-        asset_pool (Union[Unset, str]):
-        asset_name (Union[Unset, str]):
-        asset_description (Union[Unset, str]):
-        asset_document_number (Union[Unset, str]):
-        asset_document_section (Union[Unset, str]):
-        document_number_values (Union[Unset, str]):
-        product_name (Union[Unset, str]):
-        product_description (Union[Unset, str]):
-        asset_maker (Union[Unset, str]):
-        category_name (Union[Unset, str]):
-        root_category_name (Union[Unset, str]):
-        vendor_tag (Union[Unset, str]):
+        document_section (Union[None, Unset, str]):
+        service_level (Union[None, Unset, str]):
+        service_level_code (Union[None, Unset, str]):
+        service_type (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        service_charge (Union[None, Unset, float]):
+        updated_by (Union[None, Unset, str]):
+        updated_on (Union[None, Unset, datetime.datetime]):
+        work_status (Union[None, Unset, WorkStatus]):
+        custom_work_status (Union[None, Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        client_notes (Union[None, Unset, str]):
+        vendor_service_notes (Union[None, Unset, str]):
+        display_name (Union[None, Unset, str]):
+        display_part_number (Union[None, Unset, str]):
+        part_number (Union[None, Unset, str]):
+        schedule_name (Union[None, Unset, str]):
+        segment_name (Union[None, Unset, str]):
+        next_segment_name (Union[None, Unset, str]):
+        interval_length (Union[None, Unset, int]):
+        interval_cycle (Union[None, Unset, str]):
+        service_options (Union[None, Unset, str]):
+        service_options_price (Union[None, Unset, str]):
+        service_options_document_numbers (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
+        station (Union[None, Unset, str]):
+        room (Union[None, Unset, str]):
+        site (Union[None, Unset, str]):
+        vendor_id (Union[None, Unset, int]):
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
+        linked_order_number (Union[None, Unset, str]):
+        asset_id (Union[None, Unset, int]):
+        asset_class (Union[None, Unset, str]):
+        asset_condition (Union[None, Unset, str]):
+        asset_criticality (Union[None, Unset, str]):
+        asset_pool (Union[None, Unset, str]):
+        asset_name (Union[None, Unset, str]):
+        asset_description (Union[None, Unset, str]):
+        asset_document_number (Union[None, Unset, str]):
+        asset_document_section (Union[None, Unset, str]):
+        document_number_values (Union[None, Unset, str]):
+        product_name (Union[None, Unset, str]):
+        product_description (Union[None, Unset, str]):
+        asset_maker (Union[None, Unset, str]):
+        category_name (Union[None, Unset, str]):
+        root_category_name (Union[None, Unset, str]):
+        vendor_tag (Union[None, Unset, str]):
         result_status (Union[None, Unset, int]):
         service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
@@ -81,19 +81,19 @@ class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
         purchase_date (Union[None, Unset, datetime.datetime]):
         part_name (Union[None, Unset, str]):
         part_description (Union[None, Unset, str]):
-        is_taxable (Union[Unset, bool]):
-        is_limited (Union[Unset, bool]):
+        is_taxable (Union[None, Unset, bool]):
+        is_limited (Union[None, Unset, bool]):
         quantity (Union[None, Unset, float]):
         discount (Union[None, Unset, float]):
         price (Union[None, Unset, float]):
         time_spent_in_minutes (Union[None, Unset, float]):
         is_hourly_pricing (Union[None, Unset, bool]):
         delivery_charge (Union[None, Unset, float]):
-        serial_number (Union[Unset, str]):
+        serial_number (Union[None, Unset, str]):
         part_repair_charges (Union[None, Unset, float]):
         part_repair_price (Union[None, Unset, float]):
-        override_parts_total (Union[Unset, bool]):
-        override_repairs_total (Union[Unset, bool]):
+        override_parts_total (Union[None, Unset, bool]):
+        override_repairs_total (Union[None, Unset, bool]):
         asset_custodian_name (Union[None, Unset, str]):
         as_found_specification_group_name (Union[None, Unset, str]):
         as_found_specification_company_name (Union[None, Unset, str]):
@@ -157,58 +157,58 @@ class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
         service_option_service_code (Union[None, Unset, str]):
     """
 
-    certificate_number: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    revision: Union[Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    revision: Union[None, Unset, str] = UNSET
     effective_date: Union[None, Unset, datetime.datetime] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    service_level: Union[Unset, str] = UNSET
-    service_level_code: Union[Unset, str] = UNSET
-    service_type: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    service_charge: Union[Unset, float] = UNSET
-    updated_by: Union[Unset, str] = UNSET
-    updated_on: Union[Unset, datetime.datetime] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    service_level: Union[None, Unset, str] = UNSET
+    service_level_code: Union[None, Unset, str] = UNSET
+    service_type: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    service_charge: Union[None, Unset, float] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
+    updated_on: Union[None, Unset, datetime.datetime] = UNSET
     work_status: Union[None, Unset, WorkStatus] = UNSET
-    custom_work_status: Union[Unset, str] = UNSET
-    service_comments: Union[Unset, str] = UNSET
-    client_notes: Union[Unset, str] = UNSET
-    vendor_service_notes: Union[Unset, str] = UNSET
-    display_name: Union[Unset, str] = UNSET
-    display_part_number: Union[Unset, str] = UNSET
-    part_number: Union[Unset, str] = UNSET
-    schedule_name: Union[Unset, str] = UNSET
-    segment_name: Union[Unset, str] = UNSET
-    next_segment_name: Union[Unset, str] = UNSET
-    interval_length: Union[Unset, int] = UNSET
-    interval_cycle: Union[Unset, str] = UNSET
-    service_options: Union[Unset, str] = UNSET
-    service_options_price: Union[Unset, str] = UNSET
-    service_options_document_numbers: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
-    station: Union[Unset, str] = UNSET
-    room: Union[Unset, str] = UNSET
-    site: Union[Unset, str] = UNSET
-    vendor_id: Union[Unset, int] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    linked_order_number: Union[Unset, str] = UNSET
-    asset_id: Union[Unset, int] = UNSET
-    asset_class: Union[Unset, str] = UNSET
-    asset_condition: Union[Unset, str] = UNSET
-    asset_criticality: Union[Unset, str] = UNSET
-    asset_pool: Union[Unset, str] = UNSET
-    asset_name: Union[Unset, str] = UNSET
-    asset_description: Union[Unset, str] = UNSET
-    asset_document_number: Union[Unset, str] = UNSET
-    asset_document_section: Union[Unset, str] = UNSET
-    document_number_values: Union[Unset, str] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    product_description: Union[Unset, str] = UNSET
-    asset_maker: Union[Unset, str] = UNSET
-    category_name: Union[Unset, str] = UNSET
-    root_category_name: Union[Unset, str] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
+    custom_work_status: Union[None, Unset, str] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    client_notes: Union[None, Unset, str] = UNSET
+    vendor_service_notes: Union[None, Unset, str] = UNSET
+    display_name: Union[None, Unset, str] = UNSET
+    display_part_number: Union[None, Unset, str] = UNSET
+    part_number: Union[None, Unset, str] = UNSET
+    schedule_name: Union[None, Unset, str] = UNSET
+    segment_name: Union[None, Unset, str] = UNSET
+    next_segment_name: Union[None, Unset, str] = UNSET
+    interval_length: Union[None, Unset, int] = UNSET
+    interval_cycle: Union[None, Unset, str] = UNSET
+    service_options: Union[None, Unset, str] = UNSET
+    service_options_price: Union[None, Unset, str] = UNSET
+    service_options_document_numbers: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
+    station: Union[None, Unset, str] = UNSET
+    room: Union[None, Unset, str] = UNSET
+    site: Union[None, Unset, str] = UNSET
+    vendor_id: Union[None, Unset, int] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    linked_order_number: Union[None, Unset, str] = UNSET
+    asset_id: Union[None, Unset, int] = UNSET
+    asset_class: Union[None, Unset, str] = UNSET
+    asset_condition: Union[None, Unset, str] = UNSET
+    asset_criticality: Union[None, Unset, str] = UNSET
+    asset_pool: Union[None, Unset, str] = UNSET
+    asset_name: Union[None, Unset, str] = UNSET
+    asset_description: Union[None, Unset, str] = UNSET
+    asset_document_number: Union[None, Unset, str] = UNSET
+    asset_document_section: Union[None, Unset, str] = UNSET
+    document_number_values: Union[None, Unset, str] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    asset_maker: Union[None, Unset, str] = UNSET
+    category_name: Union[None, Unset, str] = UNSET
+    root_category_name: Union[None, Unset, str] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
     result_status: Union[None, Unset, int] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
@@ -222,19 +222,19 @@ class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
     purchase_date: Union[None, Unset, datetime.datetime] = UNSET
     part_name: Union[None, Unset, str] = UNSET
     part_description: Union[None, Unset, str] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
     quantity: Union[None, Unset, float] = UNSET
     discount: Union[None, Unset, float] = UNSET
     price: Union[None, Unset, float] = UNSET
     time_spent_in_minutes: Union[None, Unset, float] = UNSET
     is_hourly_pricing: Union[None, Unset, bool] = UNSET
     delivery_charge: Union[None, Unset, float] = UNSET
-    serial_number: Union[Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
     part_repair_charges: Union[None, Unset, float] = UNSET
     part_repair_price: Union[None, Unset, float] = UNSET
-    override_parts_total: Union[Unset, bool] = UNSET
-    override_repairs_total: Union[Unset, bool] = UNSET
+    override_parts_total: Union[None, Unset, bool] = UNSET
+    override_repairs_total: Union[None, Unset, bool] = UNSET
     asset_custodian_name: Union[None, Unset, str] = UNSET
     as_found_specification_group_name: Union[None, Unset, str] = UNSET
     as_found_specification_company_name: Union[None, Unset, str] = UNSET
@@ -327,7 +327,7 @@ class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
 
         updated_by = self.updated_by
 
-        updated_on: Union[Unset, str] = UNSET
+        updated_on: Union[None, Unset, str] = UNSET
         if self.updated_on and not isinstance(self.updated_on, Unset):
             updated_on = self.updated_on.isoformat()
 
@@ -1289,14 +1289,14 @@ class QualerApiModelsReportDatasetsToServiceOrderItemResponse:
         updated_by = d.pop("UpdatedBy", UNSET)
 
         _updated_on = d.pop("UpdatedOn", UNSET)
-        updated_on: Union[Unset, datetime.datetime]
+        updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on, Unset):
             updated_on = UNSET
         else:
             updated_on = isoparse(_updated_on)
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_status_history_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_status_history_response.py
@@ -17,30 +17,30 @@ T = TypeVar(
 class QualerApiModelsReportDatasetsToServiceOrderItemStatusHistoryResponse:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        previous_status_name (Union[Unset, str]):
-        selected_status_name (Union[Unset, str]):
-        explanation (Union[Unset, str]):
-        is_password_reentered (Union[Unset, bool]):
-        created_on (Union[Unset, datetime.datetime]):
-        created_on_utc (Union[Unset, datetime.datetime]):
-        employee_id (Union[Unset, int]):
-        first_name (Union[Unset, str]):
-        last_name (Union[Unset, str]):
-        alias (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        previous_status_name (Union[None, Unset, str]):
+        selected_status_name (Union[None, Unset, str]):
+        explanation (Union[None, Unset, str]):
+        is_password_reentered (Union[None, Unset, bool]):
+        created_on (Union[None, Unset, datetime.datetime]):
+        created_on_utc (Union[None, Unset, datetime.datetime]):
+        employee_id (Union[None, Unset, int]):
+        first_name (Union[None, Unset, str]):
+        last_name (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    previous_status_name: Union[Unset, str] = UNSET
-    selected_status_name: Union[Unset, str] = UNSET
-    explanation: Union[Unset, str] = UNSET
-    is_password_reentered: Union[Unset, bool] = UNSET
-    created_on: Union[Unset, datetime.datetime] = UNSET
-    created_on_utc: Union[Unset, datetime.datetime] = UNSET
-    employee_id: Union[Unset, int] = UNSET
-    first_name: Union[Unset, str] = UNSET
-    last_name: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    previous_status_name: Union[None, Unset, str] = UNSET
+    selected_status_name: Union[None, Unset, str] = UNSET
+    explanation: Union[None, Unset, str] = UNSET
+    is_password_reentered: Union[None, Unset, bool] = UNSET
+    created_on: Union[None, Unset, datetime.datetime] = UNSET
+    created_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    employee_id: Union[None, Unset, int] = UNSET
+    first_name: Union[None, Unset, str] = UNSET
+    last_name: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -54,11 +54,11 @@ class QualerApiModelsReportDatasetsToServiceOrderItemStatusHistoryResponse:
 
         is_password_reentered = self.is_password_reentered
 
-        created_on: Union[Unset, str] = UNSET
+        created_on: Union[None, Unset, str] = UNSET
         if self.created_on and not isinstance(self.created_on, Unset):
             created_on = self.created_on.isoformat()
 
-        created_on_utc: Union[Unset, str] = UNSET
+        created_on_utc: Union[None, Unset, str] = UNSET
         if self.created_on_utc and not isinstance(self.created_on_utc, Unset):
             created_on_utc = self.created_on_utc.isoformat()
 
@@ -112,14 +112,14 @@ class QualerApiModelsReportDatasetsToServiceOrderItemStatusHistoryResponse:
         is_password_reentered = d.pop("IsPasswordReentered", UNSET)
 
         _created_on = d.pop("CreatedOn", UNSET)
-        created_on: Union[Unset, datetime.datetime]
+        created_on: Union[None, Unset, datetime.datetime]
         if isinstance(_created_on, Unset):
             created_on = UNSET
         else:
             created_on = isoparse(_created_on)
 
         _created_on_utc = d.pop("CreatedOnUtc", UNSET)
-        created_on_utc: Union[Unset, datetime.datetime]
+        created_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_created_on_utc, Unset):
             created_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_task_response.py
@@ -13,32 +13,32 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderItemTaskRespo
 class QualerApiModelsReportDatasetsToServiceOrderItemTaskResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        service_charge (Union[Unset, float]):
-        time_spent (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
-        as_found_details (Union[Unset, str]):
-        as_left_details (Union[Unset, str]):
-        price (Union[Unset, float]):
-        task_name (Union[Unset, str]):
-        task_description (Union[Unset, str]):
-        level_description (Union[Unset, str]):
-        custom_text_value (Union[Unset, str]):
+        id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        service_charge (Union[None, Unset, float]):
+        time_spent (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
+        as_found_details (Union[None, Unset, str]):
+        as_left_details (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
+        task_name (Union[None, Unset, str]):
+        task_description (Union[None, Unset, str]):
+        level_description (Union[None, Unset, str]):
+        custom_text_value (Union[None, Unset, str]):
     """
 
-    id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    service_charge: Union[Unset, float] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
-    as_found_details: Union[Unset, str] = UNSET
-    as_left_details: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
-    task_name: Union[Unset, str] = UNSET
-    task_description: Union[Unset, str] = UNSET
-    level_description: Union[Unset, str] = UNSET
-    custom_text_value: Union[Unset, str] = UNSET
+    id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    service_charge: Union[None, Unset, float] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
+    as_found_details: Union[None, Unset, str] = UNSET
+    as_left_details: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_description: Union[None, Unset, str] = UNSET
+    level_description: Union[None, Unset, str] = UNSET
+    custom_text_value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
@@ -15,125 +15,125 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderResponse")
 class QualerApiModelsReportDatasetsToServiceOrderResponse:
     """
     Attributes:
-        guid (Union[Unset, str]):
-        account_number (Union[Unset, str]):
-        service_order_number (Union[Unset, int]):
-        service_order_number_text (Union[Unset, str]):
-        number_of_instruments (Union[Unset, int]):
-        parts_discount_total (Union[Unset, float]):
-        po_number (Union[Unset, str]):
-        secondary_po (Union[Unset, str]):
-        location (Union[Unset, str]):
+        guid (Union[None, Unset, str]):
+        account_number (Union[None, Unset, str]):
+        service_order_number (Union[None, Unset, int]):
+        service_order_number_text (Union[None, Unset, str]):
+        number_of_instruments (Union[None, Unset, int]):
+        parts_discount_total (Union[None, Unset, float]):
+        po_number (Union[None, Unset, str]):
+        secondary_po (Union[None, Unset, str]):
+        location (Union[None, Unset, str]):
         shipped_date (Union[None, Unset, datetime.datetime]):
-        payment_terms (Union[Unset, int]):
-        site_access_notes (Union[Unset, str]):
-        grace_period (Union[Unset, int]):
-        trade_in_credit (Union[Unset, float]):
-        prepaid_credit (Union[Unset, float]):
-        interest_rate (Union[Unset, float]):
-        service_taxation (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        federal_number (Union[Unset, str]):
-        vendor_site_id (Union[Unset, int]):
-        vendor_site (Union[Unset, str]):
-        site_name (Union[Unset, str]):
-        site_code (Union[Unset, str]):
-        vendor_name (Union[Unset, str]):
-        domain_name (Union[Unset, str]):
-        client_company_domain (Union[Unset, str]):
-        provider_logo (Union[Unset, str]):
-        client_signature (Union[Unset, str]):
-        vendor_signature (Union[Unset, str]):
-        qr_code (Union[Unset, str]):
-        bar_code (Union[Unset, str]):
-        bar_code_string (Union[Unset, str]):
-        po_balance (Union[Unset, float]):
-        service_terms (Union[Unset, str]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        parts_total_before_discount (Union[Unset, float]):
-        effective_tax_rate (Union[Unset, float]):
-        tax_amount (Union[Unset, float]):
-        shipping_fee (Union[Unset, float]):
-        late_fee (Union[Unset, float]):
-        grand_total (Union[Unset, float]):
-        amount_paid (Union[Unset, float]):
-        balance_total (Union[Unset, float]):
-        travel_charge (Union[Unset, float]):
-        private_notes (Union[Unset, str]):
-        service_notes (Union[Unset, str]):
-        display_service_comments (Union[Unset, bool]):
-        display_part_repairs (Union[Unset, bool]):
-        print_separate_measurement (Union[Unset, bool]):
-        billing_address_1 (Union[Unset, str]):
-        billing_address_2 (Union[Unset, str]):
-        billing_first_name (Union[Unset, str]):
-        billing_last_name (Union[Unset, str]):
-        billing_company (Union[Unset, str]):
-        billing_country (Union[Unset, str]):
-        billing_city (Union[Unset, str]):
-        billing_state (Union[Unset, str]):
-        billing_zip (Union[Unset, str]):
-        billing_phone_number (Union[Unset, str]):
-        billing_fax_number (Union[Unset, str]):
-        billing_email (Union[Unset, str]):
-        shipping_address_1 (Union[Unset, str]):
-        shipping_address_2 (Union[Unset, str]):
-        shipping_first_name (Union[Unset, str]):
-        shipping_last_name (Union[Unset, str]):
-        shipping_email (Union[Unset, str]):
-        shipping_company (Union[Unset, str]):
-        shipping_city (Union[Unset, str]):
-        shipping_zip (Union[Unset, str]):
-        shipping_phone_number (Union[Unset, str]):
-        shipping_fax_number (Union[Unset, str]):
-        shipping_country (Union[Unset, str]):
-        shipping_state (Union[Unset, str]):
-        shipping_method (Union[Unset, str]):
-        return_shipping_method (Union[Unset, str]):
-        tracking_number (Union[Unset, str]):
-        provider_billing_address_1 (Union[Unset, str]):
-        provider_billing_address_2 (Union[Unset, str]):
-        provider_billing_first_name (Union[Unset, str]):
-        provider_billing_last_name (Union[Unset, str]):
-        provider_billing_email (Union[Unset, str]):
-        provider_billing_company (Union[Unset, str]):
-        provider_billing_city (Union[Unset, str]):
-        provider_billing_zip (Union[Unset, str]):
-        provider_billing_phone_number (Union[Unset, str]):
-        provider_billing_country (Union[Unset, str]):
-        provider_billing_state (Union[Unset, str]):
-        provider_billing_fax_number (Union[Unset, str]):
-        provider_shipping_address_1 (Union[Unset, str]):
-        provider_shipping_address_2 (Union[Unset, str]):
-        provider_shipping_first_name (Union[Unset, str]):
-        provider_shipping_last_name (Union[Unset, str]):
-        provider_shipping_email (Union[Unset, str]):
-        provider_shipping_company (Union[Unset, str]):
-        provider_shipping_city (Union[Unset, str]):
-        provider_shipping_zip (Union[Unset, str]):
-        provider_shipping_phone_number (Union[Unset, str]):
-        provider_shipping_country (Union[Unset, str]):
-        provider_shipping_state (Union[Unset, str]):
-        provider_shipping_fax_number (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        vendor_company_id (Union[Unset, int]):
-        client_vendor_id (Union[Unset, int]):
+        payment_terms (Union[None, Unset, int]):
+        site_access_notes (Union[None, Unset, str]):
+        grace_period (Union[None, Unset, int]):
+        trade_in_credit (Union[None, Unset, float]):
+        prepaid_credit (Union[None, Unset, float]):
+        interest_rate (Union[None, Unset, float]):
+        service_taxation (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        federal_number (Union[None, Unset, str]):
+        vendor_site_id (Union[None, Unset, int]):
+        vendor_site (Union[None, Unset, str]):
+        site_name (Union[None, Unset, str]):
+        site_code (Union[None, Unset, str]):
+        vendor_name (Union[None, Unset, str]):
+        domain_name (Union[None, Unset, str]):
+        client_company_domain (Union[None, Unset, str]):
+        provider_logo (Union[None, Unset, str]):
+        client_signature (Union[None, Unset, str]):
+        vendor_signature (Union[None, Unset, str]):
+        qr_code (Union[None, Unset, str]):
+        bar_code (Union[None, Unset, str]):
+        bar_code_string (Union[None, Unset, str]):
+        po_balance (Union[None, Unset, float]):
+        service_terms (Union[None, Unset, str]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        parts_total_before_discount (Union[None, Unset, float]):
+        effective_tax_rate (Union[None, Unset, float]):
+        tax_amount (Union[None, Unset, float]):
+        shipping_fee (Union[None, Unset, float]):
+        late_fee (Union[None, Unset, float]):
+        grand_total (Union[None, Unset, float]):
+        amount_paid (Union[None, Unset, float]):
+        balance_total (Union[None, Unset, float]):
+        travel_charge (Union[None, Unset, float]):
+        private_notes (Union[None, Unset, str]):
+        service_notes (Union[None, Unset, str]):
+        display_service_comments (Union[None, Unset, bool]):
+        display_part_repairs (Union[None, Unset, bool]):
+        print_separate_measurement (Union[None, Unset, bool]):
+        billing_address_1 (Union[None, Unset, str]):
+        billing_address_2 (Union[None, Unset, str]):
+        billing_first_name (Union[None, Unset, str]):
+        billing_last_name (Union[None, Unset, str]):
+        billing_company (Union[None, Unset, str]):
+        billing_country (Union[None, Unset, str]):
+        billing_city (Union[None, Unset, str]):
+        billing_state (Union[None, Unset, str]):
+        billing_zip (Union[None, Unset, str]):
+        billing_phone_number (Union[None, Unset, str]):
+        billing_fax_number (Union[None, Unset, str]):
+        billing_email (Union[None, Unset, str]):
+        shipping_address_1 (Union[None, Unset, str]):
+        shipping_address_2 (Union[None, Unset, str]):
+        shipping_first_name (Union[None, Unset, str]):
+        shipping_last_name (Union[None, Unset, str]):
+        shipping_email (Union[None, Unset, str]):
+        shipping_company (Union[None, Unset, str]):
+        shipping_city (Union[None, Unset, str]):
+        shipping_zip (Union[None, Unset, str]):
+        shipping_phone_number (Union[None, Unset, str]):
+        shipping_fax_number (Union[None, Unset, str]):
+        shipping_country (Union[None, Unset, str]):
+        shipping_state (Union[None, Unset, str]):
+        shipping_method (Union[None, Unset, str]):
+        return_shipping_method (Union[None, Unset, str]):
+        tracking_number (Union[None, Unset, str]):
+        provider_billing_address_1 (Union[None, Unset, str]):
+        provider_billing_address_2 (Union[None, Unset, str]):
+        provider_billing_first_name (Union[None, Unset, str]):
+        provider_billing_last_name (Union[None, Unset, str]):
+        provider_billing_email (Union[None, Unset, str]):
+        provider_billing_company (Union[None, Unset, str]):
+        provider_billing_city (Union[None, Unset, str]):
+        provider_billing_zip (Union[None, Unset, str]):
+        provider_billing_phone_number (Union[None, Unset, str]):
+        provider_billing_country (Union[None, Unset, str]):
+        provider_billing_state (Union[None, Unset, str]):
+        provider_billing_fax_number (Union[None, Unset, str]):
+        provider_shipping_address_1 (Union[None, Unset, str]):
+        provider_shipping_address_2 (Union[None, Unset, str]):
+        provider_shipping_first_name (Union[None, Unset, str]):
+        provider_shipping_last_name (Union[None, Unset, str]):
+        provider_shipping_email (Union[None, Unset, str]):
+        provider_shipping_company (Union[None, Unset, str]):
+        provider_shipping_city (Union[None, Unset, str]):
+        provider_shipping_zip (Union[None, Unset, str]):
+        provider_shipping_phone_number (Union[None, Unset, str]):
+        provider_shipping_country (Union[None, Unset, str]):
+        provider_shipping_state (Union[None, Unset, str]):
+        provider_shipping_fax_number (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        vendor_company_id (Union[None, Unset, int]):
+        client_vendor_id (Union[None, Unset, int]):
         sign_off_date (Union[None, Unset, datetime.datetime]):
-        quality_control_date (Union[Unset, datetime.datetime]):
+        quality_control_date (Union[None, Unset, datetime.datetime]):
         client_sign_off_on (Union[None, Unset, datetime.datetime]):
-        client_sign_off_by_name (Union[Unset, str]):
+        client_sign_off_by_name (Union[None, Unset, str]):
         client_signed_on (Union[None, Unset, datetime.datetime]):
-        client_sticker_notes (Union[Unset, str]):
-        asset_sticker_notes (Union[Unset, str]):
-        order_sticker_notes (Union[Unset, str]):
-        quality_control_name (Union[Unset, str]):
-        fulfilled_by_name (Union[Unset, str]):
-        sign_off_name (Union[Unset, str]):
-        display_as_found (Union[Unset, bool]):
-        display_as_left (Union[Unset, bool]):
-        created_on (Union[Unset, datetime.datetime]):
+        client_sticker_notes (Union[None, Unset, str]):
+        asset_sticker_notes (Union[None, Unset, str]):
+        order_sticker_notes (Union[None, Unset, str]):
+        quality_control_name (Union[None, Unset, str]):
+        fulfilled_by_name (Union[None, Unset, str]):
+        sign_off_name (Union[None, Unset, str]):
+        display_as_found (Union[None, Unset, bool]):
+        display_as_left (Union[None, Unset, bool]):
+        created_on (Union[None, Unset, datetime.datetime]):
         invoiced_on (Union[None, Unset, datetime.datetime]):
         submitted_on (Union[None, Unset, datetime.datetime]):
         shipped_on (Union[None, Unset, datetime.datetime]):
@@ -147,12 +147,12 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         sign_off_on (Union[None, Unset, datetime.datetime]):
         vendor_signed_on (Union[None, Unset, datetime.datetime]):
         client_notes (Union[None, Unset, str]):
-        order_shipping_option (Union[Unset, int]):
-        shipment_status (Union[Unset, int]):
-        payment_status (Union[Unset, int]):
-        payment_option (Union[Unset, str]):
-        order_status (Union[Unset, int]):
-        created_by_name (Union[Unset, str]):
+        order_shipping_option (Union[None, Unset, int]):
+        shipment_status (Union[None, Unset, int]):
+        payment_status (Union[None, Unset, int]):
+        payment_option (Union[None, Unset, str]):
+        order_status (Union[None, Unset, int]):
+        created_by_name (Union[None, Unset, str]):
         completed_by_name (Union[None, Unset, str]):
         shipped_by_name (Union[None, Unset, str]):
         accepted_by_name (Union[None, Unset, str]):
@@ -166,147 +166,147 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         owner_department (Union[None, Unset, str]):
         assignee_name (Union[None, Unset, str]):
         payment_due_on (Union[None, Unset, datetime.datetime]):
-        process_date_option (Union[Unset, int]):
+        process_date_option (Union[None, Unset, int]):
         desired_date (Union[None, Unset, datetime.datetime]):
         deadline_date (Union[None, Unset, datetime.datetime]):
-        vendor_sign_off_on (Union[Unset, datetime.datetime]):
-        vendor_sign_off_by_name (Union[Unset, str]):
-        service_discount (Union[Unset, float]):
-        return_account (Union[Unset, str]):
+        vendor_sign_off_on (Union[None, Unset, datetime.datetime]):
+        vendor_sign_off_by_name (Union[None, Unset, str]):
+        service_discount (Union[None, Unset, float]):
+        return_account (Union[None, Unset, str]):
         business_hours_from (Union[None, Unset, datetime.datetime]):
         business_hours_to (Union[None, Unset, datetime.datetime]):
-        client_company_alternative_names (Union[Unset, str]):
-        client_id (Union[Unset, int]):
-        client_class (Union[Unset, str]):
-        client_status (Union[Unset, str]):
-        client_invoicing (Union[Unset, str]):
-        client_standing (Union[Unset, str]):
-        client_category (Union[Unset, str]):
-        master_template_name (Union[Unset, str]):
-        client_site_code (Union[Unset, str]):
-        order_workflow_name (Union[Unset, str]):
-        request_workflow_name (Union[Unset, str]):
+        client_company_alternative_names (Union[None, Unset, str]):
+        client_id (Union[None, Unset, int]):
+        client_class (Union[None, Unset, str]):
+        client_status (Union[None, Unset, str]):
+        client_invoicing (Union[None, Unset, str]):
+        client_standing (Union[None, Unset, str]):
+        client_category (Union[None, Unset, str]):
+        master_template_name (Union[None, Unset, str]):
+        client_site_code (Union[None, Unset, str]):
+        order_workflow_name (Union[None, Unset, str]):
+        request_workflow_name (Union[None, Unset, str]):
     """
 
-    guid: Union[Unset, str] = UNSET
-    account_number: Union[Unset, str] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    service_order_number_text: Union[Unset, str] = UNSET
-    number_of_instruments: Union[Unset, int] = UNSET
-    parts_discount_total: Union[Unset, float] = UNSET
-    po_number: Union[Unset, str] = UNSET
-    secondary_po: Union[Unset, str] = UNSET
-    location: Union[Unset, str] = UNSET
+    guid: Union[None, Unset, str] = UNSET
+    account_number: Union[None, Unset, str] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    service_order_number_text: Union[None, Unset, str] = UNSET
+    number_of_instruments: Union[None, Unset, int] = UNSET
+    parts_discount_total: Union[None, Unset, float] = UNSET
+    po_number: Union[None, Unset, str] = UNSET
+    secondary_po: Union[None, Unset, str] = UNSET
+    location: Union[None, Unset, str] = UNSET
     shipped_date: Union[None, Unset, datetime.datetime] = UNSET
-    payment_terms: Union[Unset, int] = UNSET
-    site_access_notes: Union[Unset, str] = UNSET
-    grace_period: Union[Unset, int] = UNSET
-    trade_in_credit: Union[Unset, float] = UNSET
-    prepaid_credit: Union[Unset, float] = UNSET
-    interest_rate: Union[Unset, float] = UNSET
-    service_taxation: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    federal_number: Union[Unset, str] = UNSET
-    vendor_site_id: Union[Unset, int] = UNSET
-    vendor_site: Union[Unset, str] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_code: Union[Unset, str] = UNSET
-    vendor_name: Union[Unset, str] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    client_company_domain: Union[Unset, str] = UNSET
-    provider_logo: Union[Unset, str] = UNSET
-    client_signature: Union[Unset, str] = UNSET
-    vendor_signature: Union[Unset, str] = UNSET
-    qr_code: Union[Unset, str] = UNSET
-    bar_code: Union[Unset, str] = UNSET
-    bar_code_string: Union[Unset, str] = UNSET
-    po_balance: Union[Unset, float] = UNSET
-    service_terms: Union[Unset, str] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
-    parts_total_before_discount: Union[Unset, float] = UNSET
-    effective_tax_rate: Union[Unset, float] = UNSET
-    tax_amount: Union[Unset, float] = UNSET
-    shipping_fee: Union[Unset, float] = UNSET
-    late_fee: Union[Unset, float] = UNSET
-    grand_total: Union[Unset, float] = UNSET
-    amount_paid: Union[Unset, float] = UNSET
-    balance_total: Union[Unset, float] = UNSET
-    travel_charge: Union[Unset, float] = UNSET
-    private_notes: Union[Unset, str] = UNSET
-    service_notes: Union[Unset, str] = UNSET
-    display_service_comments: Union[Unset, bool] = UNSET
-    display_part_repairs: Union[Unset, bool] = UNSET
-    print_separate_measurement: Union[Unset, bool] = UNSET
-    billing_address_1: Union[Unset, str] = UNSET
-    billing_address_2: Union[Unset, str] = UNSET
-    billing_first_name: Union[Unset, str] = UNSET
-    billing_last_name: Union[Unset, str] = UNSET
-    billing_company: Union[Unset, str] = UNSET
-    billing_country: Union[Unset, str] = UNSET
-    billing_city: Union[Unset, str] = UNSET
-    billing_state: Union[Unset, str] = UNSET
-    billing_zip: Union[Unset, str] = UNSET
-    billing_phone_number: Union[Unset, str] = UNSET
-    billing_fax_number: Union[Unset, str] = UNSET
-    billing_email: Union[Unset, str] = UNSET
-    shipping_address_1: Union[Unset, str] = UNSET
-    shipping_address_2: Union[Unset, str] = UNSET
-    shipping_first_name: Union[Unset, str] = UNSET
-    shipping_last_name: Union[Unset, str] = UNSET
-    shipping_email: Union[Unset, str] = UNSET
-    shipping_company: Union[Unset, str] = UNSET
-    shipping_city: Union[Unset, str] = UNSET
-    shipping_zip: Union[Unset, str] = UNSET
-    shipping_phone_number: Union[Unset, str] = UNSET
-    shipping_fax_number: Union[Unset, str] = UNSET
-    shipping_country: Union[Unset, str] = UNSET
-    shipping_state: Union[Unset, str] = UNSET
-    shipping_method: Union[Unset, str] = UNSET
-    return_shipping_method: Union[Unset, str] = UNSET
-    tracking_number: Union[Unset, str] = UNSET
-    provider_billing_address_1: Union[Unset, str] = UNSET
-    provider_billing_address_2: Union[Unset, str] = UNSET
-    provider_billing_first_name: Union[Unset, str] = UNSET
-    provider_billing_last_name: Union[Unset, str] = UNSET
-    provider_billing_email: Union[Unset, str] = UNSET
-    provider_billing_company: Union[Unset, str] = UNSET
-    provider_billing_city: Union[Unset, str] = UNSET
-    provider_billing_zip: Union[Unset, str] = UNSET
-    provider_billing_phone_number: Union[Unset, str] = UNSET
-    provider_billing_country: Union[Unset, str] = UNSET
-    provider_billing_state: Union[Unset, str] = UNSET
-    provider_billing_fax_number: Union[Unset, str] = UNSET
-    provider_shipping_address_1: Union[Unset, str] = UNSET
-    provider_shipping_address_2: Union[Unset, str] = UNSET
-    provider_shipping_first_name: Union[Unset, str] = UNSET
-    provider_shipping_last_name: Union[Unset, str] = UNSET
-    provider_shipping_email: Union[Unset, str] = UNSET
-    provider_shipping_company: Union[Unset, str] = UNSET
-    provider_shipping_city: Union[Unset, str] = UNSET
-    provider_shipping_zip: Union[Unset, str] = UNSET
-    provider_shipping_phone_number: Union[Unset, str] = UNSET
-    provider_shipping_country: Union[Unset, str] = UNSET
-    provider_shipping_state: Union[Unset, str] = UNSET
-    provider_shipping_fax_number: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    vendor_company_id: Union[Unset, int] = UNSET
-    client_vendor_id: Union[Unset, int] = UNSET
+    payment_terms: Union[None, Unset, int] = UNSET
+    site_access_notes: Union[None, Unset, str] = UNSET
+    grace_period: Union[None, Unset, int] = UNSET
+    trade_in_credit: Union[None, Unset, float] = UNSET
+    prepaid_credit: Union[None, Unset, float] = UNSET
+    interest_rate: Union[None, Unset, float] = UNSET
+    service_taxation: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    federal_number: Union[None, Unset, str] = UNSET
+    vendor_site_id: Union[None, Unset, int] = UNSET
+    vendor_site: Union[None, Unset, str] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_code: Union[None, Unset, str] = UNSET
+    vendor_name: Union[None, Unset, str] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    client_company_domain: Union[None, Unset, str] = UNSET
+    provider_logo: Union[None, Unset, str] = UNSET
+    client_signature: Union[None, Unset, str] = UNSET
+    vendor_signature: Union[None, Unset, str] = UNSET
+    qr_code: Union[None, Unset, str] = UNSET
+    bar_code: Union[None, Unset, str] = UNSET
+    bar_code_string: Union[None, Unset, str] = UNSET
+    po_balance: Union[None, Unset, float] = UNSET
+    service_terms: Union[None, Unset, str] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
+    parts_total_before_discount: Union[None, Unset, float] = UNSET
+    effective_tax_rate: Union[None, Unset, float] = UNSET
+    tax_amount: Union[None, Unset, float] = UNSET
+    shipping_fee: Union[None, Unset, float] = UNSET
+    late_fee: Union[None, Unset, float] = UNSET
+    grand_total: Union[None, Unset, float] = UNSET
+    amount_paid: Union[None, Unset, float] = UNSET
+    balance_total: Union[None, Unset, float] = UNSET
+    travel_charge: Union[None, Unset, float] = UNSET
+    private_notes: Union[None, Unset, str] = UNSET
+    service_notes: Union[None, Unset, str] = UNSET
+    display_service_comments: Union[None, Unset, bool] = UNSET
+    display_part_repairs: Union[None, Unset, bool] = UNSET
+    print_separate_measurement: Union[None, Unset, bool] = UNSET
+    billing_address_1: Union[None, Unset, str] = UNSET
+    billing_address_2: Union[None, Unset, str] = UNSET
+    billing_first_name: Union[None, Unset, str] = UNSET
+    billing_last_name: Union[None, Unset, str] = UNSET
+    billing_company: Union[None, Unset, str] = UNSET
+    billing_country: Union[None, Unset, str] = UNSET
+    billing_city: Union[None, Unset, str] = UNSET
+    billing_state: Union[None, Unset, str] = UNSET
+    billing_zip: Union[None, Unset, str] = UNSET
+    billing_phone_number: Union[None, Unset, str] = UNSET
+    billing_fax_number: Union[None, Unset, str] = UNSET
+    billing_email: Union[None, Unset, str] = UNSET
+    shipping_address_1: Union[None, Unset, str] = UNSET
+    shipping_address_2: Union[None, Unset, str] = UNSET
+    shipping_first_name: Union[None, Unset, str] = UNSET
+    shipping_last_name: Union[None, Unset, str] = UNSET
+    shipping_email: Union[None, Unset, str] = UNSET
+    shipping_company: Union[None, Unset, str] = UNSET
+    shipping_city: Union[None, Unset, str] = UNSET
+    shipping_zip: Union[None, Unset, str] = UNSET
+    shipping_phone_number: Union[None, Unset, str] = UNSET
+    shipping_fax_number: Union[None, Unset, str] = UNSET
+    shipping_country: Union[None, Unset, str] = UNSET
+    shipping_state: Union[None, Unset, str] = UNSET
+    shipping_method: Union[None, Unset, str] = UNSET
+    return_shipping_method: Union[None, Unset, str] = UNSET
+    tracking_number: Union[None, Unset, str] = UNSET
+    provider_billing_address_1: Union[None, Unset, str] = UNSET
+    provider_billing_address_2: Union[None, Unset, str] = UNSET
+    provider_billing_first_name: Union[None, Unset, str] = UNSET
+    provider_billing_last_name: Union[None, Unset, str] = UNSET
+    provider_billing_email: Union[None, Unset, str] = UNSET
+    provider_billing_company: Union[None, Unset, str] = UNSET
+    provider_billing_city: Union[None, Unset, str] = UNSET
+    provider_billing_zip: Union[None, Unset, str] = UNSET
+    provider_billing_phone_number: Union[None, Unset, str] = UNSET
+    provider_billing_country: Union[None, Unset, str] = UNSET
+    provider_billing_state: Union[None, Unset, str] = UNSET
+    provider_billing_fax_number: Union[None, Unset, str] = UNSET
+    provider_shipping_address_1: Union[None, Unset, str] = UNSET
+    provider_shipping_address_2: Union[None, Unset, str] = UNSET
+    provider_shipping_first_name: Union[None, Unset, str] = UNSET
+    provider_shipping_last_name: Union[None, Unset, str] = UNSET
+    provider_shipping_email: Union[None, Unset, str] = UNSET
+    provider_shipping_company: Union[None, Unset, str] = UNSET
+    provider_shipping_city: Union[None, Unset, str] = UNSET
+    provider_shipping_zip: Union[None, Unset, str] = UNSET
+    provider_shipping_phone_number: Union[None, Unset, str] = UNSET
+    provider_shipping_country: Union[None, Unset, str] = UNSET
+    provider_shipping_state: Union[None, Unset, str] = UNSET
+    provider_shipping_fax_number: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    vendor_company_id: Union[None, Unset, int] = UNSET
+    client_vendor_id: Union[None, Unset, int] = UNSET
     sign_off_date: Union[None, Unset, datetime.datetime] = UNSET
-    quality_control_date: Union[Unset, datetime.datetime] = UNSET
+    quality_control_date: Union[None, Unset, datetime.datetime] = UNSET
     client_sign_off_on: Union[None, Unset, datetime.datetime] = UNSET
-    client_sign_off_by_name: Union[Unset, str] = UNSET
+    client_sign_off_by_name: Union[None, Unset, str] = UNSET
     client_signed_on: Union[None, Unset, datetime.datetime] = UNSET
-    client_sticker_notes: Union[Unset, str] = UNSET
-    asset_sticker_notes: Union[Unset, str] = UNSET
-    order_sticker_notes: Union[Unset, str] = UNSET
-    quality_control_name: Union[Unset, str] = UNSET
-    fulfilled_by_name: Union[Unset, str] = UNSET
-    sign_off_name: Union[Unset, str] = UNSET
-    display_as_found: Union[Unset, bool] = UNSET
-    display_as_left: Union[Unset, bool] = UNSET
-    created_on: Union[Unset, datetime.datetime] = UNSET
+    client_sticker_notes: Union[None, Unset, str] = UNSET
+    asset_sticker_notes: Union[None, Unset, str] = UNSET
+    order_sticker_notes: Union[None, Unset, str] = UNSET
+    quality_control_name: Union[None, Unset, str] = UNSET
+    fulfilled_by_name: Union[None, Unset, str] = UNSET
+    sign_off_name: Union[None, Unset, str] = UNSET
+    display_as_found: Union[None, Unset, bool] = UNSET
+    display_as_left: Union[None, Unset, bool] = UNSET
+    created_on: Union[None, Unset, datetime.datetime] = UNSET
     invoiced_on: Union[None, Unset, datetime.datetime] = UNSET
     submitted_on: Union[None, Unset, datetime.datetime] = UNSET
     shipped_on: Union[None, Unset, datetime.datetime] = UNSET
@@ -320,12 +320,12 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
     sign_off_on: Union[None, Unset, datetime.datetime] = UNSET
     vendor_signed_on: Union[None, Unset, datetime.datetime] = UNSET
     client_notes: Union[None, Unset, str] = UNSET
-    order_shipping_option: Union[Unset, int] = UNSET
-    shipment_status: Union[Unset, int] = UNSET
-    payment_status: Union[Unset, int] = UNSET
-    payment_option: Union[Unset, str] = UNSET
-    order_status: Union[Unset, int] = UNSET
-    created_by_name: Union[Unset, str] = UNSET
+    order_shipping_option: Union[None, Unset, int] = UNSET
+    shipment_status: Union[None, Unset, int] = UNSET
+    payment_status: Union[None, Unset, int] = UNSET
+    payment_option: Union[None, Unset, str] = UNSET
+    order_status: Union[None, Unset, int] = UNSET
+    created_by_name: Union[None, Unset, str] = UNSET
     completed_by_name: Union[None, Unset, str] = UNSET
     shipped_by_name: Union[None, Unset, str] = UNSET
     accepted_by_name: Union[None, Unset, str] = UNSET
@@ -339,26 +339,26 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
     owner_department: Union[None, Unset, str] = UNSET
     assignee_name: Union[None, Unset, str] = UNSET
     payment_due_on: Union[None, Unset, datetime.datetime] = UNSET
-    process_date_option: Union[Unset, int] = UNSET
+    process_date_option: Union[None, Unset, int] = UNSET
     desired_date: Union[None, Unset, datetime.datetime] = UNSET
     deadline_date: Union[None, Unset, datetime.datetime] = UNSET
-    vendor_sign_off_on: Union[Unset, datetime.datetime] = UNSET
-    vendor_sign_off_by_name: Union[Unset, str] = UNSET
-    service_discount: Union[Unset, float] = UNSET
-    return_account: Union[Unset, str] = UNSET
+    vendor_sign_off_on: Union[None, Unset, datetime.datetime] = UNSET
+    vendor_sign_off_by_name: Union[None, Unset, str] = UNSET
+    service_discount: Union[None, Unset, float] = UNSET
+    return_account: Union[None, Unset, str] = UNSET
     business_hours_from: Union[None, Unset, datetime.datetime] = UNSET
     business_hours_to: Union[None, Unset, datetime.datetime] = UNSET
-    client_company_alternative_names: Union[Unset, str] = UNSET
-    client_id: Union[Unset, int] = UNSET
-    client_class: Union[Unset, str] = UNSET
-    client_status: Union[Unset, str] = UNSET
-    client_invoicing: Union[Unset, str] = UNSET
-    client_standing: Union[Unset, str] = UNSET
-    client_category: Union[Unset, str] = UNSET
-    master_template_name: Union[Unset, str] = UNSET
-    client_site_code: Union[Unset, str] = UNSET
-    order_workflow_name: Union[Unset, str] = UNSET
-    request_workflow_name: Union[Unset, str] = UNSET
+    client_company_alternative_names: Union[None, Unset, str] = UNSET
+    client_id: Union[None, Unset, int] = UNSET
+    client_class: Union[None, Unset, str] = UNSET
+    client_status: Union[None, Unset, str] = UNSET
+    client_invoicing: Union[None, Unset, str] = UNSET
+    client_standing: Union[None, Unset, str] = UNSET
+    client_category: Union[None, Unset, str] = UNSET
+    master_template_name: Union[None, Unset, str] = UNSET
+    client_site_code: Union[None, Unset, str] = UNSET
+    order_workflow_name: Union[None, Unset, str] = UNSET
+    request_workflow_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -586,7 +586,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         else:
             sign_off_date = self.sign_off_date
 
-        quality_control_date: Union[Unset, str] = UNSET
+        quality_control_date: Union[None, Unset, str] = UNSET
         if self.quality_control_date and not isinstance(
             self.quality_control_date, Unset
         ):
@@ -626,7 +626,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
 
         display_as_left = self.display_as_left
 
-        created_on: Union[Unset, str] = UNSET
+        created_on: Union[None, Unset, str] = UNSET
         if self.created_on and not isinstance(self.created_on, Unset):
             created_on = self.created_on.isoformat()
 
@@ -842,7 +842,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         else:
             deadline_date = self.deadline_date
 
-        vendor_sign_off_on: Union[Unset, str] = UNSET
+        vendor_sign_off_on: Union[None, Unset, str] = UNSET
         if self.vendor_sign_off_on and not isinstance(self.vendor_sign_off_on, Unset):
             vendor_sign_off_on = self.vendor_sign_off_on.isoformat()
 
@@ -1486,7 +1486,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         sign_off_date = _parse_sign_off_date(d.pop("SignOffDate", UNSET))
 
         _quality_control_date = d.pop("QualityControlDate", UNSET)
-        quality_control_date: Union[Unset, datetime.datetime]
+        quality_control_date: Union[None, Unset, datetime.datetime]
         if isinstance(_quality_control_date, Unset):
             quality_control_date = UNSET
         else:
@@ -1549,7 +1549,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         display_as_left = d.pop("DisplayAsLeft", UNSET)
 
         _created_on = d.pop("CreatedOn", UNSET)
-        created_on: Union[Unset, datetime.datetime]
+        created_on: Union[None, Unset, datetime.datetime]
         if isinstance(_created_on, Unset):
             created_on = UNSET
         else:
@@ -1946,7 +1946,7 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         deadline_date = _parse_deadline_date(d.pop("DeadlineDate", UNSET))
 
         _vendor_sign_off_on = d.pop("VendorSignOffOn", UNSET)
-        vendor_sign_off_on: Union[Unset, datetime.datetime]
+        vendor_sign_off_on: Union[None, Unset, datetime.datetime]
         if isinstance(_vendor_sign_off_on, Unset):
             vendor_sign_off_on = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_task_response.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToServiceOrderTaskResponse"
 class QualerApiModelsReportDatasetsToServiceOrderTaskResponse:
     """
     Attributes:
-        task_name (Union[Unset, str]):
-        task_order (Union[Unset, int]):
-        task_details (Union[Unset, str]):
-        time_spent (Union[Unset, float]):
-        time_spent_hours (Union[Unset, float]):
-        time_spent_minutes (Union[Unset, float]):
-        price (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
+        task_name (Union[None, Unset, str]):
+        task_order (Union[None, Unset, int]):
+        task_details (Union[None, Unset, str]):
+        time_spent (Union[None, Unset, float]):
+        time_spent_hours (Union[None, Unset, float]):
+        time_spent_minutes (Union[None, Unset, float]):
+        price (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
     """
 
-    task_name: Union[Unset, str] = UNSET
-    task_order: Union[Unset, int] = UNSET
-    task_details: Union[Unset, str] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    time_spent_hours: Union[Unset, float] = UNSET
-    time_spent_minutes: Union[Unset, float] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_order: Union[None, Unset, int] = UNSET
+    task_details: Union[None, Unset, str] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    time_spent_hours: Union[None, Unset, float] = UNSET
+    time_spent_minutes: Union[None, Unset, float] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_attribute_response.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToToolAttributeResponse")
 class QualerApiModelsReportDatasetsToToolAttributeResponse:
     """
     Attributes:
-        tool_id (Union[Unset, int]):
-        attribute_name (Union[Unset, str]):
-        attribute_value (Union[Unset, str]):
+        tool_id (Union[None, Unset, int]):
+        attribute_name (Union[None, Unset, str]):
+        attribute_value (Union[None, Unset, str]):
     """
 
-    tool_id: Union[Unset, int] = UNSET
-    attribute_name: Union[Unset, str] = UNSET
-    attribute_value: Union[Unset, str] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    attribute_name: Union[None, Unset, str] = UNSET
+    attribute_value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_range_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_range_attribute_response.py
@@ -13,22 +13,22 @@ T = TypeVar("T", bound="QualerApiModelsReportDatasetsToToolRangeAttributeRespons
 class QualerApiModelsReportDatasetsToToolRangeAttributeResponse:
     """
     Attributes:
-        measurement_point_id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        tool_id (Union[Unset, int]):
-        range_title (Union[Unset, str]):
-        range_subtitle (Union[Unset, str]):
-        attribute_name (Union[Unset, str]):
-        attribute_value (Union[Unset, str]):
+        measurement_point_id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        tool_id (Union[None, Unset, int]):
+        range_title (Union[None, Unset, str]):
+        range_subtitle (Union[None, Unset, str]):
+        attribute_name (Union[None, Unset, str]):
+        attribute_value (Union[None, Unset, str]):
     """
 
-    measurement_point_id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    tool_id: Union[Unset, int] = UNSET
-    range_title: Union[Unset, str] = UNSET
-    range_subtitle: Union[Unset, str] = UNSET
-    attribute_name: Union[Unset, str] = UNSET
-    attribute_value: Union[Unset, str] = UNSET
+    measurement_point_id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    tool_id: Union[None, Unset, int] = UNSET
+    range_title: Union[None, Unset, str] = UNSET
+    range_subtitle: Union[None, Unset, str] = UNSET
+    attribute_name: Union[None, Unset, str] = UNSET
+    attribute_value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_options_to_service_option_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_options_to_service_option_response_model.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsServiceOptionsToServiceOptionResponseMode
 class QualerApiModelsServiceOptionsToServiceOptionResponseModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
-        service_charge (Union[Unset, float]):
-        time_spent (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        service_code (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
+        service_charge (Union[None, Unset, float]):
+        time_spent (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        service_code (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
-    service_charge: Union[Unset, float] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    service_code: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    service_charge: Union[None, Unset, float] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    service_code: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_documents_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_documents_list_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrderDocumentsFromDocumentsListMod
 class QualerApiModelsServiceOrderDocumentsFromDocumentsListModel:
     """
     Attributes:
-        report_type (Union[Unset, str]):
+        report_type (Union[None, Unset, str]):
     """
 
-    report_type: Union[Unset, str] = UNSET
+    report_type: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_get_documents_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_get_documents_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrderDocumentsFromGetDocumentsMode
 class QualerApiModelsServiceOrderDocumentsFromGetDocumentsModel:
     """
     Attributes:
-        file_name (Union[Unset, str]):
+        file_name (Union[None, Unset, str]):
     """
 
-    file_name: Union[Unset, str] = UNSET
+    file_name: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_upload_documents_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_upload_documents_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrderDocumentsFromUploadDocumentsM
 class QualerApiModelsServiceOrderDocumentsFromUploadDocumentsModel:
     """
     Attributes:
-        report_type (Union[Unset, str]):
-        is_private (Union[Unset, bool]):
+        report_type (Union[None, Unset, str]):
+        is_private (Union[None, Unset, bool]):
     """
 
-    report_type: Union[Unset, str] = UNSET
-    is_private: Union[Unset, bool] = UNSET
+    report_type: Union[None, Unset, str] = UNSET
+    is_private: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
@@ -21,34 +21,33 @@ T = TypeVar(
 class QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        guid (Union[Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
-        document_name (Union[Unset, str]):
-        file_name (Union[Unset, str]):
-        document_type (Union[Unset,
+        service_order_id (Union[None, Unset, int]):
+        guid (Union[None, Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
+        document_name (Union[None, Unset, str]):
+        file_name (Union[None, Unset, str]):
+        document_type (Union[None, Unset,
             QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType]):
-        revision_number (Union[Unset, int]):
-        report_type (Union[Unset, ReportType]):
-        download_url (Union[Unset, str]):
+        revision_number (Union[None, Unset, int]):
+        report_type (Union[None, Unset, ReportType]):
+        download_url (Union[None, Unset, str]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    guid: Union[Unset, UUID] = UNSET
-    document_name: Union[Unset, str] = UNSET
-    file_name: Union[Unset, str] = UNSET
-    document_type: Union[
-        Unset,
+    service_order_id: Union[None, Unset, int] = UNSET
+    guid: Union[None, Unset, UUID] = UNSET
+    document_name: Union[None, Unset, str] = UNSET
+    file_name: Union[None, Unset, str] = UNSET
+    document_type: Union[None, Unset,
         QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType,
     ] = UNSET
-    revision_number: Union[Unset, int] = UNSET
-    report_type: Union[Unset, ReportType] = UNSET
-    download_url: Union[Unset, str] = UNSET
+    revision_number: Union[None, Unset, int] = UNSET
+    report_type: Union[None, Unset, ReportType] = UNSET
+    download_url: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         service_order_id = self.service_order_id
 
-        guid: Union[Unset, str] = UNSET
+        guid: Union[None, Unset, str] = UNSET
         if self.guid and not isinstance(self.guid, Unset):
             guid = str(self.guid)
 
@@ -56,13 +55,13 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentRespon
 
         file_name = self.file_name
 
-        document_type: Union[Unset, int] = UNSET
+        document_type: Union[None, Unset, int] = UNSET
         if self.document_type and not isinstance(self.document_type, Unset):
             document_type = self.document_type.value
 
         revision_number = self.revision_number
 
-        report_type: Union[Unset, int] = UNSET
+        report_type: Union[None, Unset, int] = UNSET
         if self.report_type and not isinstance(self.report_type, Unset):
             report_type = self.report_type.value
 
@@ -96,7 +95,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentRespon
         service_order_id = d.pop("ServiceOrderId", UNSET)
 
         _guid = d.pop("Guid", UNSET)
-        guid: Union[Unset, UUID]
+        guid: Union[None, Unset, UUID]
         if isinstance(_guid, Unset):
             guid = UNSET
         else:
@@ -107,8 +106,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentRespon
         file_name = d.pop("FileName", UNSET)
 
         _document_type = d.pop("DocumentType", UNSET)
-        document_type: Union[
-            Unset,
+        document_type: Union[None, Unset,
             QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType,
         ]
         if isinstance(_document_type, Unset):
@@ -121,7 +119,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderControlledDocumentRespon
         revision_number = d.pop("RevisionNumber", UNSET)
 
         _report_type = d.pop("ReportType", UNSET)
-        report_type: Union[Unset, ReportType]
+        report_type: Union[None, Unset, ReportType]
         if isinstance(_report_type, Unset):
             report_type = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
@@ -18,26 +18,26 @@ T = TypeVar(
 class QualerApiModelsServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        guid (Union[Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
-        document_name (Union[Unset, str]):
-        file_name (Union[Unset, str]):
-        document_type (Union[Unset, int]):
-        revision_number (Union[Unset, int]):
-        report_type (Union[Unset, ReportType]):
-        download_url (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        guid (Union[None, Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
+        document_name (Union[None, Unset, str]):
+        file_name (Union[None, Unset, str]):
+        document_type (Union[None, Unset, int]):
+        revision_number (Union[None, Unset, int]):
+        report_type (Union[None, Unset, ReportType]):
+        download_url (Union[None, Unset, str]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    guid: Union[Unset, UUID] = UNSET
-    document_name: Union[Unset, str] = UNSET
-    file_name: Union[Unset, str] = UNSET
-    document_type: Union[Unset, int] = UNSET
-    revision_number: Union[Unset, int] = UNSET
-    report_type: Union[Unset, ReportType] = UNSET
-    download_url: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    guid: Union[None, Unset, UUID] = UNSET
+    document_name: Union[None, Unset, str] = UNSET
+    file_name: Union[None, Unset, str] = UNSET
+    document_type: Union[None, Unset, int] = UNSET
+    revision_number: Union[None, Unset, int] = UNSET
+    report_type: Union[None, Unset, ReportType] = UNSET
+    download_url: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -45,7 +45,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderItemControlledDocumentRe
 
         service_order_item_id = self.service_order_item_id
 
-        guid: Union[Unset, str] = UNSET
+        guid: Union[None, Unset, str] = UNSET
         if self.guid and not isinstance(self.guid, Unset):
             guid = str(self.guid)
 
@@ -57,7 +57,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderItemControlledDocumentRe
 
         revision_number = self.revision_number
 
-        report_type: Union[Unset, int] = UNSET
+        report_type: Union[None, Unset, int] = UNSET
         if self.report_type and not isinstance(self.report_type, Unset):
             report_type = self.report_type.value
 
@@ -95,7 +95,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderItemControlledDocumentRe
         service_order_item_id = d.pop("ServiceOrderItemId", UNSET)
 
         _guid = d.pop("Guid", UNSET)
-        guid: Union[Unset, UUID]
+        guid: Union[None, Unset, UUID]
         if isinstance(_guid, Unset):
             guid = UNSET
         else:
@@ -110,7 +110,7 @@ class QualerApiModelsServiceOrderDocumentsToCompanyOrderItemControlledDocumentRe
         revision_number = d.pop("RevisionNumber", UNSET)
 
         _report_type = d.pop("ReportType", UNSET)
-        report_type: Union[Unset, ReportType]
+        report_type: Union[None, Unset, ReportType]
         if isinstance(_report_type, Unset):
             report_type = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_item_parts_to_order_item_part_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_item_parts_to_order_item_part_response_model.py
@@ -18,38 +18,37 @@ T = TypeVar(
 class QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModel:
     """
     Attributes:
-        service_order_item_part_id (Union[Unset, int]):
-        service_order_item_id (Union[Unset, int]):
-        name (Union[Unset, str]):
-        description (Union[Unset, str]):
-        discount (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
-        is_hourly_pricing (Union[Unset, bool]):
-        price (Union[Unset, float]):
-        unit_name (Union[Unset, str]):
-        quantity (Union[Unset, float]):
-        delivery_charge (Union[Unset, float]):
-        time_spent_in_minutes (Union[Unset, float]):
-        free_quantity (Union[Unset, int]):
-        service_order_charge_type (Union[Unset,
+        service_order_item_part_id (Union[None, Unset, int]):
+        service_order_item_id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
+        discount (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        price (Union[None, Unset, float]):
+        unit_name (Union[None, Unset, str]):
+        quantity (Union[None, Unset, float]):
+        delivery_charge (Union[None, Unset, float]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        free_quantity (Union[None, Unset, int]):
+        service_order_charge_type (Union[None, Unset,
             QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModelServiceOrderChargeType]):
     """
 
-    service_order_item_part_id: Union[Unset, int] = UNSET
-    service_order_item_id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
-    discount: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    price: Union[Unset, float] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    delivery_charge: Union[Unset, float] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    free_quantity: Union[Unset, int] = UNSET
-    service_order_charge_type: Union[
-        Unset,
+    service_order_item_part_id: Union[None, Unset, int] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    discount: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    free_quantity: Union[None, Unset, int] = UNSET
+    service_order_charge_type: Union[None, Unset,
         QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModelServiceOrderChargeType,
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -81,7 +80,7 @@ class QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModel:
 
         free_quantity = self.free_quantity
 
-        service_order_charge_type: Union[Unset, str] = UNSET
+        service_order_charge_type: Union[None, Unset, str] = UNSET
         if self.service_order_charge_type and not isinstance(
             self.service_order_charge_type, Unset
         ):
@@ -151,8 +150,7 @@ class QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModel:
         free_quantity = d.pop("FreeQuantity", UNSET)
 
         _service_order_charge_type = d.pop("ServiceOrderChargeType", UNSET)
-        service_order_charge_type: Union[
-            Unset,
+        service_order_charge_type: Union[None, Unset,
             QualerApiModelsServiceOrderItemPartsToOrderItemPartResponseModelServiceOrderChargeType,
         ]
         if isinstance(_service_order_charge_type, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model.py
@@ -15,18 +15,18 @@ T = TypeVar(
 class QualerApiModelsServiceOrderItemTasksFromServiceOrderItemTaskCreateModel:
     """
     Attributes:
-        service_order_item_id (Union[Unset, int]):
-        task_name (Union[Unset, str]):
-        task_description (Union[Unset, str]):
-        as_found_details (Union[Unset, str]):
-        as_left_details (Union[Unset, str]):
+        service_order_item_id (Union[None, Unset, int]):
+        task_name (Union[None, Unset, str]):
+        task_description (Union[None, Unset, str]):
+        as_found_details (Union[None, Unset, str]):
+        as_left_details (Union[None, Unset, str]):
     """
 
-    service_order_item_id: Union[Unset, int] = UNSET
-    task_name: Union[Unset, str] = UNSET
-    task_description: Union[Unset, str] = UNSET
-    as_found_details: Union[Unset, str] = UNSET
-    as_left_details: Union[Unset, str] = UNSET
+    service_order_item_id: Union[None, Unset, int] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_description: Union[None, Unset, str] = UNSET
+    as_found_details: Union[None, Unset, str] = UNSET
+    as_left_details: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_payment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_payment_model.py
@@ -13,14 +13,14 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromAddPaymentModel")
 class QualerApiModelsServiceOrdersFromAddPaymentModel:
     """
     Attributes:
-        payment_type (Union[Unset, str]):
-        payment_amount (Union[Unset, float]):
-        details (Union[Unset, str]):
+        payment_type (Union[None, Unset, str]):
+        payment_amount (Union[None, Unset, float]):
+        details (Union[None, Unset, str]):
     """
 
-    payment_type: Union[Unset, str] = UNSET
-    payment_amount: Union[Unset, float] = UNSET
-    details: Union[Unset, str] = UNSET
+    payment_type: Union[None, Unset, str] = UNSET
+    payment_amount: Union[None, Unset, float] = UNSET
+    details: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_work_items_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_work_items_model.py
@@ -13,20 +13,20 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromAddWorkItemsModel")
 class QualerApiModelsServiceOrdersFromAddWorkItemsModel:
     """
     Attributes:
-        asset_ids (Union[Unset, list[int]]):
-        schedule_segment_ids (Union[Unset, list[int]]):
+        asset_ids (Union[None, Unset, list[int]]):
+        schedule_segment_ids (Union[None, Unset, list[int]]):
     """
 
-    asset_ids: Union[Unset, list[int]] = UNSET
-    schedule_segment_ids: Union[Unset, list[int]] = UNSET
+    asset_ids: Union[None, Unset, list[int]] = UNSET
+    schedule_segment_ids: Union[None, Unset, list[int]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        asset_ids: Union[Unset, list[int]] = UNSET
+        asset_ids: Union[None, Unset, list[int]] = UNSET
         if self.asset_ids and not isinstance(self.asset_ids, Unset):
             asset_ids = self.asset_ids
 
-        schedule_segment_ids: Union[Unset, list[int]] = UNSET
+        schedule_segment_ids: Union[None, Unset, list[int]] = UNSET
         if self.schedule_segment_ids and not isinstance(
             self.schedule_segment_ids, Unset
         ):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_append_tracking_number_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_append_tracking_number_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromAppendTrackingNumberMode
 class QualerApiModelsServiceOrdersFromAppendTrackingNumberModel:
     """
     Attributes:
-        tracking_number (Union[Unset, str]):
+        tracking_number (Union[None, Unset, str]):
     """
 
-    tracking_number: Union[Unset, str] = UNSET
+    tracking_number: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_change_service_order_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_change_service_order_status_model.py
@@ -16,20 +16,19 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromChangeServiceOrderStatus
 class QualerApiModelsServiceOrdersFromChangeServiceOrderStatusModel:
     """
     Attributes:
-        service_order_status (Union[Unset,
+        service_order_status (Union[None, Unset,
             QualerApiModelsServiceOrdersFromChangeServiceOrderStatusModelServiceOrderStatus]):
-        reset_status (Union[Unset, bool]):
-        email (Union[Unset, str]):
-        password (Union[Unset, str]):
+        reset_status (Union[None, Unset, bool]):
+        email (Union[None, Unset, str]):
+        password (Union[None, Unset, str]):
     """
 
-    service_order_status: Union[
-        Unset,
+    service_order_status: Union[None, Unset,
         QualerApiModelsServiceOrdersFromChangeServiceOrderStatusModelServiceOrderStatus,
     ] = UNSET
-    reset_status: Union[Unset, bool] = UNSET
-    email: Union[Unset, str] = UNSET
-    password: Union[Unset, str] = UNSET
+    reset_status: Union[None, Unset, bool] = UNSET
+    email: Union[None, Unset, str] = UNSET
+    password: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -63,8 +62,7 @@ class QualerApiModelsServiceOrdersFromChangeServiceOrderStatusModel:
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         _service_order_status = d.pop("ServiceOrderStatus", UNSET)
-        service_order_status: Union[
-            Unset,
+        service_order_status: Union[None, Unset,
             QualerApiModelsServiceOrdersFromChangeServiceOrderStatusModelServiceOrderStatus,
         ]
         if isinstance(_service_order_status, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model.py
@@ -19,16 +19,15 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromChargeUpdateModel")
 class QualerApiModelsServiceOrdersFromChargeUpdateModel:
     """
     Attributes:
-        charges (Union[Unset, list['QualerApiModelsServiceOrdersFromChargeUpdateModelPriceModel']]):
+        charges (Union[None, Unset, list['QualerApiModelsServiceOrdersFromChargeUpdateModelPriceModel']]):
     """
 
-    charges: Union[
-        Unset, list["QualerApiModelsServiceOrdersFromChargeUpdateModelPriceModel"]
+    charges: Union[None, Unset, list["QualerApiModelsServiceOrdersFromChargeUpdateModelPriceModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        charges: Union[Unset, list[dict[str, Any]]] = UNSET
+        charges: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.charges and not isinstance(self.charges, Unset):
             charges = []
             for charges_item_data in self.charges:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model_price_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromChargeUpdateModelPriceMo
 class QualerApiModelsServiceOrdersFromChargeUpdateModelPriceModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
     """
 
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_create_order_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_create_order_model.py
@@ -13,22 +13,22 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromCreateOrderModel")
 class QualerApiModelsServiceOrdersFromCreateOrderModel:
     """
     Attributes:
-        client_company_id (Union[Unset, int]):
-        vendor_site_id (Union[Unset, int]):
-        asset_ids (Union[Unset, list[int]]):
-        schedule_segment_ids (Union[Unset, list[int]]):
-        service_level_ids (Union[Unset, list[int]]):
-        use_due_segments (Union[Unset, bool]):
-        order_notes (Union[Unset, str]):
+        client_company_id (Union[None, Unset, int]):
+        vendor_site_id (Union[None, Unset, int]):
+        asset_ids (Union[None, Unset, list[int]]):
+        schedule_segment_ids (Union[None, Unset, list[int]]):
+        service_level_ids (Union[None, Unset, list[int]]):
+        use_due_segments (Union[None, Unset, bool]):
+        order_notes (Union[None, Unset, str]):
     """
 
-    client_company_id: Union[Unset, int] = UNSET
-    vendor_site_id: Union[Unset, int] = UNSET
-    asset_ids: Union[Unset, list[int]] = UNSET
-    schedule_segment_ids: Union[Unset, list[int]] = UNSET
-    service_level_ids: Union[Unset, list[int]] = UNSET
-    use_due_segments: Union[Unset, bool] = UNSET
-    order_notes: Union[Unset, str] = UNSET
+    client_company_id: Union[None, Unset, int] = UNSET
+    vendor_site_id: Union[None, Unset, int] = UNSET
+    asset_ids: Union[None, Unset, list[int]] = UNSET
+    schedule_segment_ids: Union[None, Unset, list[int]] = UNSET
+    service_level_ids: Union[None, Unset, list[int]] = UNSET
+    use_due_segments: Union[None, Unset, bool] = UNSET
+    order_notes: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -36,17 +36,17 @@ class QualerApiModelsServiceOrdersFromCreateOrderModel:
 
         vendor_site_id = self.vendor_site_id
 
-        asset_ids: Union[Unset, list[int]] = UNSET
+        asset_ids: Union[None, Unset, list[int]] = UNSET
         if self.asset_ids and not isinstance(self.asset_ids, Unset):
             asset_ids = self.asset_ids
 
-        schedule_segment_ids: Union[Unset, list[int]] = UNSET
+        schedule_segment_ids: Union[None, Unset, list[int]] = UNSET
         if self.schedule_segment_ids and not isinstance(
             self.schedule_segment_ids, Unset
         ):
             schedule_segment_ids = self.schedule_segment_ids
 
-        service_level_ids: Union[Unset, list[int]] = UNSET
+        service_level_ids: Union[None, Unset, list[int]] = UNSET
         if self.service_level_ids and not isinstance(self.service_level_ids, Unset):
             service_level_ids = self.service_level_ids
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model.py
@@ -19,17 +19,16 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromItemChargeUpdateModel")
 class QualerApiModelsServiceOrdersFromItemChargeUpdateModel:
     """
     Attributes:
-        charges (Union[Unset, list['QualerApiModelsServiceOrdersFromItemChargeUpdateModelItemPriceModel']]):
+        charges (Union[None, Unset, list['QualerApiModelsServiceOrdersFromItemChargeUpdateModelItemPriceModel']]):
     """
 
-    charges: Union[
-        Unset,
+    charges: Union[None, Unset,
         list["QualerApiModelsServiceOrdersFromItemChargeUpdateModelItemPriceModel"],
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        charges: Union[Unset, list[dict[str, Any]]] = UNSET
+        charges: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.charges and not isinstance(self.charges, Unset):
             charges = []
             for charges_item_data in self.charges:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model_item_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model_item_price_model.py
@@ -15,12 +15,12 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersFromItemChargeUpdateModelItemPriceModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
     """
 
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_order_item_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_order_item_update_model.py
@@ -23,78 +23,76 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromOrderItemUpdateModel")
 class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
     """
     Attributes:
-        service_comments (Union[Unset, str]):
-        private_comments (Union[Unset, str]):
-        service_notes (Union[Unset, str]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        work_status (Union[Unset, WorkStatus]):
-        custom_work_status (Union[Unset, str]):
-        is_limited (Union[Unset, bool]):
-        checked_on (Union[Unset, datetime.datetime]):
-        checked_by_name (Union[Unset, str]):
-        completed_on (Union[Unset, datetime.datetime]):
-        completed_by_name (Union[Unset, str]):
-        as_found_check (Union[Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck]):
-        as_left_check (Union[Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck]):
-        result_status (Union[Unset, ServiceResultStatus]):
-        as_found_result (Union[Unset, ServiceResultStatus]):
-        as_left_result (Union[Unset, ServiceResultStatus]):
-        equipment_id (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
-        serial_number (Union[Unset, str]):
-        serial_number_change (Union[Unset, str]):
-        asset_tag (Union[Unset, str]):
-        asset_tag_change (Union[Unset, str]):
-        asset_user (Union[Unset, str]):
-        asset_user_change (Union[Unset, str]):
-        provider_technician (Union[Unset, str]):
-        provider_phone (Union[Unset, str]):
-        provider_company (Union[Unset, str]):
-        certificate_number (Union[Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        private_comments (Union[None, Unset, str]):
+        service_notes (Union[None, Unset, str]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        work_status (Union[None, Unset, WorkStatus]):
+        custom_work_status (Union[None, Unset, str]):
+        is_limited (Union[None, Unset, bool]):
+        checked_on (Union[None, Unset, datetime.datetime]):
+        checked_by_name (Union[None, Unset, str]):
+        completed_on (Union[None, Unset, datetime.datetime]):
+        completed_by_name (Union[None, Unset, str]):
+        as_found_check (Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck]):
+        as_left_check (Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck]):
+        result_status (Union[None, Unset, ServiceResultStatus]):
+        as_found_result (Union[None, Unset, ServiceResultStatus]):
+        as_left_result (Union[None, Unset, ServiceResultStatus]):
+        equipment_id (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
+        serial_number (Union[None, Unset, str]):
+        serial_number_change (Union[None, Unset, str]):
+        asset_tag (Union[None, Unset, str]):
+        asset_tag_change (Union[None, Unset, str]):
+        asset_user (Union[None, Unset, str]):
+        asset_user_change (Union[None, Unset, str]):
+        provider_technician (Union[None, Unset, str]):
+        provider_phone (Union[None, Unset, str]):
+        provider_company (Union[None, Unset, str]):
+        certificate_number (Union[None, Unset, str]):
         service_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        vendor_tag (Union[Unset, str]):
+        vendor_tag (Union[None, Unset, str]):
     """
 
-    service_comments: Union[Unset, str] = UNSET
-    private_comments: Union[Unset, str] = UNSET
-    service_notes: Union[Unset, str] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    private_comments: Union[None, Unset, str] = UNSET
+    service_notes: Union[None, Unset, str] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
     work_status: Union[None, Unset, WorkStatus] = UNSET
-    custom_work_status: Union[Unset, str] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
-    checked_on: Union[Unset, datetime.datetime] = UNSET
-    checked_by_name: Union[Unset, str] = UNSET
-    completed_on: Union[Unset, datetime.datetime] = UNSET
-    completed_by_name: Union[Unset, str] = UNSET
-    as_found_check: Union[
-        Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck
+    custom_work_status: Union[None, Unset, str] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
+    checked_on: Union[None, Unset, datetime.datetime] = UNSET
+    checked_by_name: Union[None, Unset, str] = UNSET
+    completed_on: Union[None, Unset, datetime.datetime] = UNSET
+    completed_by_name: Union[None, Unset, str] = UNSET
+    as_found_check: Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck
     ] = UNSET
-    as_left_check: Union[
-        Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck
+    as_left_check: Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck
     ] = UNSET
     result_status: Union[None, Unset, ServiceResultStatus] = UNSET
     as_found_result: Union[None, Unset, ServiceResultStatus] = UNSET
     as_left_result: Union[None, Unset, ServiceResultStatus] = UNSET
-    equipment_id: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
-    serial_number: Union[Unset, str] = UNSET
-    serial_number_change: Union[Unset, str] = UNSET
-    asset_tag: Union[Unset, str] = UNSET
-    asset_tag_change: Union[Unset, str] = UNSET
-    asset_user: Union[Unset, str] = UNSET
-    asset_user_change: Union[Unset, str] = UNSET
-    provider_technician: Union[Unset, str] = UNSET
-    provider_phone: Union[Unset, str] = UNSET
-    provider_company: Union[Unset, str] = UNSET
-    certificate_number: Union[Unset, str] = UNSET
+    equipment_id: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    serial_number: Union[None, Unset, str] = UNSET
+    serial_number_change: Union[None, Unset, str] = UNSET
+    asset_tag: Union[None, Unset, str] = UNSET
+    asset_tag_change: Union[None, Unset, str] = UNSET
+    asset_user: Union[None, Unset, str] = UNSET
+    asset_user_change: Union[None, Unset, str] = UNSET
+    provider_technician: Union[None, Unset, str] = UNSET
+    provider_phone: Union[None, Unset, str] = UNSET
+    provider_company: Union[None, Unset, str] = UNSET
+    certificate_number: Union[None, Unset, str] = UNSET
     service_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -118,23 +116,23 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
 
         is_limited = self.is_limited
 
-        checked_on: Union[Unset, str] = UNSET
+        checked_on: Union[None, Unset, str] = UNSET
         if self.checked_on and not isinstance(self.checked_on, Unset):
             checked_on = self.checked_on.isoformat()
 
         checked_by_name = self.checked_by_name
 
-        completed_on: Union[Unset, str] = UNSET
+        completed_on: Union[None, Unset, str] = UNSET
         if self.completed_on and not isinstance(self.completed_on, Unset):
             completed_on = self.completed_on.isoformat()
 
         completed_by_name = self.completed_by_name
 
-        as_found_check: Union[Unset, str] = UNSET
+        as_found_check: Union[None, Unset, str] = UNSET
         if self.as_found_check and not isinstance(self.as_found_check, Unset):
             as_found_check = self.as_found_check.value
 
-        as_left_check: Union[Unset, str] = UNSET
+        as_left_check: Union[None, Unset, str] = UNSET
         if self.as_left_check and not isinstance(self.as_left_check, Unset):
             as_left_check = self.as_left_check.value
 
@@ -280,7 +278,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
         parts_total = d.pop("PartsTotal", UNSET)
 
         _work_status = d.pop("WorkStatus", UNSET)
-        work_status: Union[Unset, WorkStatus]
+        work_status: Union[None, Unset, WorkStatus]
         if isinstance(_work_status, Unset):
             work_status = UNSET
         elif _work_status is None:
@@ -293,7 +291,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
         is_limited = d.pop("IsLimited", UNSET)
 
         _checked_on = d.pop("CheckedOn", UNSET)
-        checked_on: Union[Unset, datetime.datetime]
+        checked_on: Union[None, Unset, datetime.datetime]
         if isinstance(_checked_on, Unset):
             checked_on = UNSET
         else:
@@ -302,7 +300,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
         checked_by_name = d.pop("CheckedByName", UNSET)
 
         _completed_on = d.pop("CompletedOn", UNSET)
-        completed_on: Union[Unset, datetime.datetime]
+        completed_on: Union[None, Unset, datetime.datetime]
         if isinstance(_completed_on, Unset):
             completed_on = UNSET
         else:
@@ -311,8 +309,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
         completed_by_name = d.pop("CompletedByName", UNSET)
 
         _as_found_check = d.pop("AsFoundCheck", UNSET)
-        as_found_check: Union[
-            Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck
+        as_found_check: Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsFoundCheck
         ]
         if isinstance(_as_found_check, Unset):
             as_found_check = UNSET
@@ -324,8 +321,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
             )
 
         _as_left_check = d.pop("AsLeftCheck", UNSET)
-        as_left_check: Union[
-            Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck
+        as_left_check: Union[None, Unset, QualerApiModelsServiceOrdersFromOrderItemUpdateModelAsLeftCheck
         ]
         if isinstance(_as_left_check, Unset):
             as_left_check = UNSET
@@ -337,7 +333,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
             )
 
         _result_status = d.pop("ResultStatus", UNSET)
-        result_status: Union[Unset, ServiceResultStatus]
+        result_status: Union[None, Unset, ServiceResultStatus]
         if isinstance(_result_status, Unset):
             result_status = UNSET
         elif _result_status is None:
@@ -346,7 +342,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
             result_status = ServiceResultStatus(_result_status)
 
         _as_found_result = d.pop("AsFoundResult", UNSET)
-        as_found_result: Union[Unset, ServiceResultStatus]
+        as_found_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_found_result, Unset):
             as_found_result = UNSET
         elif _as_found_result is None:
@@ -355,7 +351,7 @@ class QualerApiModelsServiceOrdersFromOrderItemUpdateModel:
             as_found_result = ServiceResultStatus(_as_found_result)
 
         _as_left_result = d.pop("AsLeftResult", UNSET)
-        as_left_result: Union[Unset, ServiceResultStatus]
+        as_left_result: Union[None, Unset, ServiceResultStatus]
         if isinstance(_as_left_result, Unset):
             as_left_result = UNSET
         elif _as_left_result is None:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_create_model.py
@@ -21,20 +21,19 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersFromServiceOrderMetadataCreateModel:
     """
     Attributes:
-        metadata (Union[Unset, str]):
-        exhibits (Union[Unset, QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]):
+        metadata (Union[None, Unset, str]):
+        exhibits (Union[None, Unset, QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]):
     """
 
-    metadata: Union[Unset, str] = UNSET
-    exhibits: Union[
-        Unset, "QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits"
+    metadata: Union[None, Unset, str] = UNSET
+    exhibits: Union[None, Unset, "QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits"
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         metadata = self.metadata
 
-        exhibits: Union[Unset, dict[str, Any]] = UNSET
+        exhibits: Union[None, Unset, dict[str, Any]] = UNSET
         if self.exhibits and not isinstance(self.exhibits, Unset):
             exhibits = self.exhibits.to_dict()
 
@@ -58,8 +57,7 @@ class QualerApiModelsServiceOrdersFromServiceOrderMetadataCreateModel:
         metadata = d.pop("Metadata", UNSET)
 
         _exhibits = d.pop("Exhibits", UNSET)
-        exhibits: Union[
-            Unset,
+        exhibits: Union[None, Unset,
             QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits,
         ]
         if isinstance(_exhibits, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_update_model.py
@@ -21,15 +21,14 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersFromServiceOrderMetadataUpdateModel:
     """
     Attributes:
-        service_order_metadata_id (Union[Unset, int]):
-        metadata (Union[Unset, str]):
-        exhibits (Union[Unset, QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]):
+        service_order_metadata_id (Union[None, Unset, int]):
+        metadata (Union[None, Unset, str]):
+        exhibits (Union[None, Unset, QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]):
     """
 
-    service_order_metadata_id: Union[Unset, int] = UNSET
-    metadata: Union[Unset, str] = UNSET
-    exhibits: Union[
-        Unset, "QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits"
+    service_order_metadata_id: Union[None, Unset, int] = UNSET
+    metadata: Union[None, Unset, str] = UNSET
+    exhibits: Union[None, Unset, "QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits"
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -38,7 +37,7 @@ class QualerApiModelsServiceOrdersFromServiceOrderMetadataUpdateModel:
 
         metadata = self.metadata
 
-        exhibits: Union[Unset, dict[str, Any]] = UNSET
+        exhibits: Union[None, Unset, dict[str, Any]] = UNSET
         if self.exhibits and not isinstance(self.exhibits, Unset):
             exhibits = self.exhibits.to_dict()
 
@@ -66,8 +65,7 @@ class QualerApiModelsServiceOrdersFromServiceOrderMetadataUpdateModel:
         metadata = d.pop("Metadata", UNSET)
 
         _exhibits = d.pop("Exhibits", UNSET)
-        exhibits: Union[
-            Unset,
+        exhibits: Union[None, Unset,
             QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits,
         ]
         if isinstance(_exhibits, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_create_model.py
@@ -15,22 +15,22 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromServiceOrderTaskCreateMo
 class QualerApiModelsServiceOrdersFromServiceOrderTaskCreateModel:
     """
     Attributes:
-        task_name (Union[Unset, str]):
-        task_details (Union[Unset, str]):
-        start_time (Union[Unset, datetime.datetime]):
-        finish_time (Union[Unset, datetime.datetime]):
-        time_spent_minutes (Union[Unset, int]):
-        price (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
+        task_name (Union[None, Unset, str]):
+        task_details (Union[None, Unset, str]):
+        start_time (Union[None, Unset, datetime.datetime]):
+        finish_time (Union[None, Unset, datetime.datetime]):
+        time_spent_minutes (Union[None, Unset, int]):
+        price (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
     """
 
-    task_name: Union[Unset, str] = UNSET
-    task_details: Union[Unset, str] = UNSET
-    start_time: Union[Unset, datetime.datetime] = UNSET
-    finish_time: Union[Unset, datetime.datetime] = UNSET
-    time_spent_minutes: Union[Unset, int] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_details: Union[None, Unset, str] = UNSET
+    start_time: Union[None, Unset, datetime.datetime] = UNSET
+    finish_time: Union[None, Unset, datetime.datetime] = UNSET
+    time_spent_minutes: Union[None, Unset, int] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -38,11 +38,11 @@ class QualerApiModelsServiceOrdersFromServiceOrderTaskCreateModel:
 
         task_details = self.task_details
 
-        start_time: Union[Unset, str] = UNSET
+        start_time: Union[None, Unset, str] = UNSET
         if self.start_time and not isinstance(self.start_time, Unset):
             start_time = self.start_time.isoformat()
 
-        finish_time: Union[Unset, str] = UNSET
+        finish_time: Union[None, Unset, str] = UNSET
         if self.finish_time and not isinstance(self.finish_time, Unset):
             finish_time = self.finish_time.isoformat()
 
@@ -80,14 +80,14 @@ class QualerApiModelsServiceOrdersFromServiceOrderTaskCreateModel:
         task_details = d.pop("TaskDetails", UNSET)
 
         _start_time = d.pop("StartTime", UNSET)
-        start_time: Union[Unset, datetime.datetime]
+        start_time: Union[None, Unset, datetime.datetime]
         if isinstance(_start_time, Unset):
             start_time = UNSET
         else:
             start_time = isoparse(_start_time)
 
         _finish_time = d.pop("FinishTime", UNSET)
-        finish_time: Union[Unset, datetime.datetime]
+        finish_time: Union[None, Unset, datetime.datetime]
         if isinstance(_finish_time, Unset):
             finish_time = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_update_model.py
@@ -15,24 +15,24 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromServiceOrderTaskUpdateMo
 class QualerApiModelsServiceOrdersFromServiceOrderTaskUpdateModel:
     """
     Attributes:
-        service_order_task_id (Union[Unset, int]):
-        task_name (Union[Unset, str]):
-        task_details (Union[Unset, str]):
-        start_time (Union[Unset, datetime.datetime]):
-        finish_time (Union[Unset, datetime.datetime]):
-        time_spent_minutes (Union[Unset, int]):
-        price (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
+        service_order_task_id (Union[None, Unset, int]):
+        task_name (Union[None, Unset, str]):
+        task_details (Union[None, Unset, str]):
+        start_time (Union[None, Unset, datetime.datetime]):
+        finish_time (Union[None, Unset, datetime.datetime]):
+        time_spent_minutes (Union[None, Unset, int]):
+        price (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
     """
 
-    service_order_task_id: Union[Unset, int] = UNSET
-    task_name: Union[Unset, str] = UNSET
-    task_details: Union[Unset, str] = UNSET
-    start_time: Union[Unset, datetime.datetime] = UNSET
-    finish_time: Union[Unset, datetime.datetime] = UNSET
-    time_spent_minutes: Union[Unset, int] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
+    service_order_task_id: Union[None, Unset, int] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_details: Union[None, Unset, str] = UNSET
+    start_time: Union[None, Unset, datetime.datetime] = UNSET
+    finish_time: Union[None, Unset, datetime.datetime] = UNSET
+    time_spent_minutes: Union[None, Unset, int] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -42,11 +42,11 @@ class QualerApiModelsServiceOrdersFromServiceOrderTaskUpdateModel:
 
         task_details = self.task_details
 
-        start_time: Union[Unset, str] = UNSET
+        start_time: Union[None, Unset, str] = UNSET
         if self.start_time and not isinstance(self.start_time, Unset):
             start_time = self.start_time.isoformat()
 
-        finish_time: Union[Unset, str] = UNSET
+        finish_time: Union[None, Unset, str] = UNSET
         if self.finish_time and not isinstance(self.finish_time, Unset):
             finish_time = self.finish_time.isoformat()
 
@@ -88,14 +88,14 @@ class QualerApiModelsServiceOrdersFromServiceOrderTaskUpdateModel:
         task_details = d.pop("TaskDetails", UNSET)
 
         _start_time = d.pop("StartTime", UNSET)
-        start_time: Union[Unset, datetime.datetime]
+        start_time: Union[None, Unset, datetime.datetime]
         if isinstance(_start_time, Unset):
             start_time = UNSET
         else:
             start_time = isoparse(_start_time)
 
         _finish_time = d.pop("FinishTime", UNSET)
-        finish_time: Union[Unset, datetime.datetime]
+        finish_time: Union[None, Unset, datetime.datetime]
         if isinstance(_finish_time, Unset):
             finish_time = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_payment_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_payment_status_model.py
@@ -15,11 +15,11 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromUpdatePaymentStatusModel
 class QualerApiModelsServiceOrdersFromUpdatePaymentStatusModel:
     """
     Attributes:
-        payment_status (Union[Unset, str]):
+        payment_status (Union[None, Unset, str]):
         invoiced_on (Union[None, Unset, datetime.datetime]):
     """
 
-    payment_status: Union[Unset, str] = UNSET
+    payment_status: Union[None, Unset, str] = UNSET
     invoiced_on: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_shipment_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_shipment_status_model.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersFromUpdateShipmentStatusMode
 class QualerApiModelsServiceOrdersFromUpdateShipmentStatusModel:
     """
     Attributes:
-        shipment_status (Union[Unset, str]):
+        shipment_status (Union[None, Unset, str]):
     """
 
-    shipment_status: Union[Unset, str] = UNSET
+    shipment_status: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_asset_add_result_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_asset_add_result_response_model.py
@@ -13,18 +13,18 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToAssetAddResultResponseMode
 class QualerApiModelsServiceOrdersToAssetAddResultResponseModel:
     """
     Attributes:
-        asset_count (Union[Unset, int]):
-        already_added_asset_serials (Union[Unset, list[str]]):
+        asset_count (Union[None, Unset, int]):
+        already_added_asset_serials (Union[None, Unset, list[str]]):
     """
 
-    asset_count: Union[Unset, int] = UNSET
-    already_added_asset_serials: Union[Unset, list[str]] = UNSET
+    asset_count: Union[None, Unset, int] = UNSET
+    already_added_asset_serials: Union[None, Unset, list[str]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         asset_count = self.asset_count
 
-        already_added_asset_serials: Union[Unset, list[str]] = UNSET
+        already_added_asset_serials: Union[None, Unset, list[str]] = UNSET
         if self.already_added_asset_serials and not isinstance(
             self.already_added_asset_serials, Unset
         ):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model.py
@@ -22,49 +22,46 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToBaseWorkItemModel")
 class QualerApiModelsServiceOrdersToBaseWorkItemModel:
     """
     Attributes:
-        tasks (Union[Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel']]):
-        parts (Union[Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel']]):
-        repairs (Union[Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel']]):
-        work_item_id (Union[Unset, int]):
-        vendor_tag (Union[Unset, str]):
+        tasks (Union[None, Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel']]):
+        parts (Union[None, Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel']]):
+        repairs (Union[None, Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel']]):
+        work_item_id (Union[None, Unset, int]):
+        vendor_tag (Union[None, Unset, str]):
     """
 
-    tasks: Union[
-        Unset,
+    tasks: Union[None, Unset,
         list["QualerApiModelsServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel"],
     ] = UNSET
-    parts: Union[
-        Unset,
+    parts: Union[None, Unset,
         list[
             "QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel"
         ],
     ] = UNSET
-    repairs: Union[
-        Unset,
+    repairs: Union[None, Unset,
         list[
             "QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel"
         ],
     ] = UNSET
-    work_item_id: Union[Unset, int] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
+    work_item_id: Union[None, Unset, int] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        tasks: Union[Unset, list[dict[str, Any]]] = UNSET
+        tasks: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.tasks and not isinstance(self.tasks, Unset):
             tasks = []
             for tasks_item_data in self.tasks:
                 tasks_item = tasks_item_data.to_dict()
                 tasks.append(tasks_item)
 
-        parts: Union[Unset, list[dict[str, Any]]] = UNSET
+        parts: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.parts and not isinstance(self.parts, Unset):
             parts = []
             for parts_item_data in self.parts:
                 parts_item = parts_item_data.to_dict()
                 parts.append(parts_item)
 
-        repairs: Union[Unset, list[dict[str, Any]]] = UNSET
+        repairs: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.repairs and not isinstance(self.repairs, Unset):
             repairs = []
             for repairs_item_data in self.repairs:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model.py
@@ -15,14 +15,14 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel:
     """
     Attributes:
-        contract_discount (Union[Unset, float]):
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
+        contract_discount (Union[None, Unset, float]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
     """
 
-    contract_discount: Union[Unset, float] = UNSET
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
+    contract_discount: Union[None, Unset, float] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model.py
@@ -16,26 +16,26 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel:
     """
     Attributes:
-        delivery_charge (Union[Unset, float]):
-        quantity (Union[Unset, float]):
-        time_spent_in_minutes (Union[Unset, float]):
-        is_hourly_pricing (Union[Unset, bool]):
-        description (Union[Unset, str]):
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
-        unit_name (Union[Unset, str]):
-        is_taxable (Union[Unset, bool]):
+        delivery_charge (Union[None, Unset, float]):
+        quantity (Union[None, Unset, float]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        description (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
+        unit_name (Union[None, Unset, str]):
+        is_taxable (Union[None, Unset, bool]):
     """
 
-    delivery_charge: Union[Unset, float] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    description: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model.py
@@ -16,24 +16,24 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel:
     """
     Attributes:
-        delivery_charge (Union[Unset, float]):
-        quantity (Union[Unset, float]):
-        time_spent_in_minutes (Union[Unset, float]):
-        is_hourly_pricing (Union[Unset, bool]):
-        description (Union[Unset, str]):
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
+        delivery_charge (Union[None, Unset, float]):
+        quantity (Union[None, Unset, float]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        description (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
     """
 
-    delivery_charge: Union[Unset, float] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    description: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model.py
@@ -16,20 +16,20 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel:
     """
     Attributes:
-        contract_discount (Union[Unset, float]):
-        time_spent (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
-        details (Union[Unset, str]):
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
+        contract_discount (Union[None, Unset, float]):
+        time_spent (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
+        details (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
     """
 
-    contract_discount: Union[Unset, float] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
-    details: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
+    contract_discount: Union[None, Unset, float] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
+    details: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_price_model.py
@@ -15,12 +15,12 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToChargeResponseModelBasePriceModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        price (Union[Unset, float]):
+        name (Union[None, Unset, str]):
+        price (Union[None, Unset, float]):
     """
 
-    name: Union[Unset, str] = UNSET
-    price: Union[Unset, float] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_item_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_item_response_model.py
@@ -21,36 +21,36 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToClientOrderItemResponseMod
 class QualerApiModelsServiceOrdersToClientOrderItemResponseModel:
     """
     Attributes:
-        work_item_id (Union[Unset, int]):
-        client_notes (Union[Unset, str]):
-        service_comments (Union[Unset, str]):
-        private_comments (Union[Unset, str]):
-        order_item_number (Union[Unset, int]):
-        service_order_id (Union[Unset, int]):
-        channel_count (Union[Unset, int]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        parts_total_before_discount (Union[Unset, float]):
-        override_service_total (Union[Unset, bool]):
-        override_repairs_total (Union[Unset, bool]):
-        override_parts_total (Union[Unset, bool]):
-        service_type (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        work_status (Union[Unset, str]):
-        custom_work_status (Union[Unset, str]):
-        is_limited (Union[Unset, bool]):
+        work_item_id (Union[None, Unset, int]):
+        client_notes (Union[None, Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        private_comments (Union[None, Unset, str]):
+        order_item_number (Union[None, Unset, int]):
+        service_order_id (Union[None, Unset, int]):
+        channel_count (Union[None, Unset, int]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        parts_total_before_discount (Union[None, Unset, float]):
+        override_service_total (Union[None, Unset, bool]):
+        override_repairs_total (Union[None, Unset, bool]):
+        override_parts_total (Union[None, Unset, bool]):
+        service_type (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        work_status (Union[None, Unset, str]):
+        custom_work_status (Union[None, Unset, str]):
+        is_limited (Union[None, Unset, bool]):
         checked_on (Union[None, Unset, datetime.datetime]):
-        checked_by_name (Union[Unset, str]):
-        checked_by_id (Union[Unset, int]):
+        checked_by_name (Union[None, Unset, str]):
+        checked_by_id (Union[None, Unset, int]):
         completed_on (Union[None, Unset, datetime.datetime]):
-        completed_by_name (Union[Unset, str]):
-        completed_by_id (Union[Unset, int]):
-        updated_by_id (Union[Unset, int]):
-        updated_by (Union[Unset, str]):
-        as_found_check (Union[Unset, str]):
-        as_left_check (Union[Unset, str]):
+        completed_by_name (Union[None, Unset, str]):
+        completed_by_id (Union[None, Unset, int]):
+        updated_by_id (Union[None, Unset, int]):
+        updated_by (Union[None, Unset, str]):
+        as_found_check (Union[None, Unset, str]):
+        as_left_check (Union[None, Unset, str]):
         item_result_status (Union[None, Unset, str]):
         item_as_found_result (Union[None, Unset, str]):
         item_as_left_result (Union[None, Unset, str]):
@@ -96,44 +96,44 @@ class QualerApiModelsServiceOrdersToClientOrderItemResponseModel:
         service_date (Union[None, Unset, datetime.datetime]):
         due_date (Union[None, Unset, datetime.datetime]):
         next_service_date (Union[None, Unset, datetime.datetime]):
-        maintenance_task (Union[Unset, str]):
+        maintenance_task (Union[None, Unset, str]):
         maintenance_plan (Union[None, Unset, str]):
-        service_options (Union[Unset, list['QualerApiModelsServiceOptionsToServiceOptionResponseModel']]):
-        vendor_tag (Union[Unset, str]):
-        legacy_id (Union[Unset, str]):
-        asset_ownership (Union[Unset, str]):
+        service_options (Union[None, Unset, list['QualerApiModelsServiceOptionsToServiceOptionResponseModel']]):
+        vendor_tag (Union[None, Unset, str]):
+        legacy_id (Union[None, Unset, str]):
+        asset_ownership (Union[None, Unset, str]):
     """
 
-    work_item_id: Union[Unset, int] = UNSET
-    client_notes: Union[Unset, str] = UNSET
-    service_comments: Union[Unset, str] = UNSET
-    private_comments: Union[Unset, str] = UNSET
-    order_item_number: Union[Unset, int] = UNSET
-    service_order_id: Union[Unset, int] = UNSET
-    channel_count: Union[Unset, int] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
-    parts_total_before_discount: Union[Unset, float] = UNSET
-    override_service_total: Union[Unset, bool] = UNSET
-    override_repairs_total: Union[Unset, bool] = UNSET
-    override_parts_total: Union[Unset, bool] = UNSET
-    service_type: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
+    work_item_id: Union[None, Unset, int] = UNSET
+    client_notes: Union[None, Unset, str] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    private_comments: Union[None, Unset, str] = UNSET
+    order_item_number: Union[None, Unset, int] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    channel_count: Union[None, Unset, int] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
+    parts_total_before_discount: Union[None, Unset, float] = UNSET
+    override_service_total: Union[None, Unset, bool] = UNSET
+    override_repairs_total: Union[None, Unset, bool] = UNSET
+    override_parts_total: Union[None, Unset, bool] = UNSET
+    service_type: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
     work_status: Union[None, Unset, str] = UNSET
-    custom_work_status: Union[Unset, str] = UNSET
-    is_limited: Union[Unset, bool] = UNSET
+    custom_work_status: Union[None, Unset, str] = UNSET
+    is_limited: Union[None, Unset, bool] = UNSET
     checked_on: Union[None, Unset, datetime.datetime] = UNSET
-    checked_by_name: Union[Unset, str] = UNSET
-    checked_by_id: Union[Unset, int] = UNSET
+    checked_by_name: Union[None, Unset, str] = UNSET
+    checked_by_id: Union[None, Unset, int] = UNSET
     completed_on: Union[None, Unset, datetime.datetime] = UNSET
-    completed_by_name: Union[Unset, str] = UNSET
-    completed_by_id: Union[Unset, int] = UNSET
-    updated_by_id: Union[Unset, int] = UNSET
-    updated_by: Union[Unset, str] = UNSET
-    as_found_check: Union[Unset, str] = UNSET
-    as_left_check: Union[Unset, str] = UNSET
+    completed_by_name: Union[None, Unset, str] = UNSET
+    completed_by_id: Union[None, Unset, int] = UNSET
+    updated_by_id: Union[None, Unset, int] = UNSET
+    updated_by: Union[None, Unset, str] = UNSET
+    as_found_check: Union[None, Unset, str] = UNSET
+    as_left_check: Union[None, Unset, str] = UNSET
     item_result_status: Union[None, Unset, str] = UNSET
     item_as_found_result: Union[None, Unset, str] = UNSET
     item_as_left_result: Union[None, Unset, str] = UNSET
@@ -179,14 +179,13 @@ class QualerApiModelsServiceOrdersToClientOrderItemResponseModel:
     service_date: Union[None, Unset, datetime.datetime] = UNSET
     due_date: Union[None, Unset, datetime.datetime] = UNSET
     next_service_date: Union[None, Unset, datetime.datetime] = UNSET
-    maintenance_task: Union[Unset, str] = UNSET
+    maintenance_task: Union[None, Unset, str] = UNSET
     maintenance_plan: Union[None, Unset, str] = UNSET
-    service_options: Union[
-        Unset, list["QualerApiModelsServiceOptionsToServiceOptionResponseModel"]
+    service_options: Union[None, Unset, list["QualerApiModelsServiceOptionsToServiceOptionResponseModel"]
     ] = UNSET
-    vendor_tag: Union[Unset, str] = UNSET
-    legacy_id: Union[Unset, str] = UNSET
-    asset_ownership: Union[Unset, str] = UNSET
+    vendor_tag: Union[None, Unset, str] = UNSET
+    legacy_id: Union[None, Unset, str] = UNSET
+    asset_ownership: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -578,7 +577,7 @@ class QualerApiModelsServiceOrdersToClientOrderItemResponseModel:
         else:
             maintenance_plan = self.maintenance_plan
 
-        service_options: Union[Unset, list[dict[str, Any]]] = UNSET
+        service_options: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.service_options and not isinstance(self.service_options, Unset):
             service_options = []
             for service_options_item_data in self.service_options:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model.py
@@ -25,31 +25,31 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToClientOrderResponseModel")
 class QualerApiModelsServiceOrdersToClientOrderResponseModel:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        parent_order_id (Union[Unset, int]):
-        client_legacy_id (Union[Unset, str]):
-        owner_name (Union[Unset, str]):
-        submited_by_name (Union[Unset, str]):
-        sign_off_by_name (Union[Unset, str]):
-        vendor_sign_off_by_name (Union[Unset, str]):
-        approved_by_name (Union[Unset, str]):
-        accepted_by_name (Union[Unset, str]):
-        ready_for_quality_control_by_name (Union[Unset, str]):
-        quality_control_by_name (Union[Unset, str]):
-        created_by_name (Union[Unset, str]):
-        completed_by_name (Union[Unset, str]):
-        shipped_by_name (Union[Unset, str]):
-        delivered_by_name (Union[Unset, str]):
-        invoiced_by_name (Union[Unset, str]):
-        paid_by_name (Union[Unset, str]):
-        cancelled_by_name (Union[Unset, str]):
-        closed_by_name (Union[Unset, str]):
-        client_company_id (Union[Unset, int]):
-        client_company_name (Union[Unset, str]):
-        client_domain_name (Union[Unset, str]):
-        client_alternative_names (Union[Unset, str]):
-        service_comments (Union[Unset, str]):
-        service_private_comments (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        parent_order_id (Union[None, Unset, int]):
+        client_legacy_id (Union[None, Unset, str]):
+        owner_name (Union[None, Unset, str]):
+        submited_by_name (Union[None, Unset, str]):
+        sign_off_by_name (Union[None, Unset, str]):
+        vendor_sign_off_by_name (Union[None, Unset, str]):
+        approved_by_name (Union[None, Unset, str]):
+        accepted_by_name (Union[None, Unset, str]):
+        ready_for_quality_control_by_name (Union[None, Unset, str]):
+        quality_control_by_name (Union[None, Unset, str]):
+        created_by_name (Union[None, Unset, str]):
+        completed_by_name (Union[None, Unset, str]):
+        shipped_by_name (Union[None, Unset, str]):
+        delivered_by_name (Union[None, Unset, str]):
+        invoiced_by_name (Union[None, Unset, str]):
+        paid_by_name (Union[None, Unset, str]):
+        cancelled_by_name (Union[None, Unset, str]):
+        closed_by_name (Union[None, Unset, str]):
+        client_company_id (Union[None, Unset, int]):
+        client_company_name (Union[None, Unset, str]):
+        client_domain_name (Union[None, Unset, str]):
+        client_alternative_names (Union[None, Unset, str]):
+        service_comments (Union[None, Unset, str]):
+        service_private_comments (Union[None, Unset, str]):
         created_on (Union[None, Unset, datetime.datetime]):
         approved_on (Union[None, Unset, datetime.datetime]):
         sign_off_on (Union[None, Unset, datetime.datetime]):
@@ -68,102 +68,102 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
         late_fee_on (Union[None, Unset, datetime.datetime]):
         cancelled_on (Union[None, Unset, datetime.datetime]):
         closed_on (Union[None, Unset, datetime.datetime]):
-        last_updated_on (Union[Unset, datetime.datetime]):
-        last_updated_by (Union[Unset, str]):
-        submited_by_id (Union[Unset, int]):
-        sign_off_by_id (Union[Unset, int]):
-        vendor_sign_off_by_id (Union[Unset, int]):
-        approved_by_id (Union[Unset, int]):
-        late_fee_by_id (Union[Unset, int]):
-        accepted_by_id (Union[Unset, int]):
-        ready_for_quality_control_by_id (Union[Unset, int]):
-        quality_control_by_id (Union[Unset, int]):
-        created_by_id (Union[Unset, int]):
-        completed_by_id (Union[Unset, int]):
-        shipped_by_id (Union[Unset, int]):
-        delivered_by_id (Union[Unset, int]):
-        invoiced_by_id (Union[Unset, int]):
-        paid_by_id (Union[Unset, int]):
-        cancelled_by_id (Union[Unset, int]):
-        closed_by_id (Union[Unset, int]):
-        po_number (Union[Unset, str]):
-        secondary_po (Union[Unset, str]):
-        service_total (Union[Unset, float]):
-        repairs_total (Union[Unset, float]):
-        parts_total (Union[Unset, float]):
-        parts_total_before_discount (Union[Unset, float]):
-        parts_discount_total (Union[Unset, float]):
-        effective_tax_rate (Union[Unset, float]):
-        tax_amount (Union[Unset, float]):
-        shipping_fee (Union[Unset, float]):
-        travel_charge (Union[Unset, float]):
-        late_fee (Union[Unset, float]):
-        is_tax_exempt (Union[Unset, bool]):
-        service_discount (Union[Unset, float]):
-        trade_in_credit (Union[Unset, float]):
-        prepaid_credit (Union[Unset, float]):
-        grand_total (Union[Unset, float]):
-        paid_amount (Union[Unset, float]):
-        remaining_balance (Union[Unset, float]):
-        service_discount_details (Union[Unset, str]):
-        trade_in_credit_details (Union[Unset, str]):
-        prepaid_credit_details (Union[Unset, str]):
-        payment_notes (Union[Unset, str]):
-        service_order_number (Union[Unset, int]):
-        legacy_order_number (Union[Unset, str]):
-        custom_order_number (Union[Unset, str]):
-        payment_status (Union[Unset, str]):
-        payment_option (Union[Unset, str]):
-        shipment_status (Union[Unset, str]):
-        order_status (Union[Unset, str]):
-        owner_id (Union[Unset, int]):
-        owner_department (Union[Unset, str]):
-        client_site (Union[Unset, str]):
-        client_site_code (Union[Unset, str]):
-        vendor_site (Union[Unset, str]):
-        internal (Union[Unset, bool]):
-        guid (Union[Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
+        last_updated_on (Union[None, Unset, datetime.datetime]):
+        last_updated_by (Union[None, Unset, str]):
+        submited_by_id (Union[None, Unset, int]):
+        sign_off_by_id (Union[None, Unset, int]):
+        vendor_sign_off_by_id (Union[None, Unset, int]):
+        approved_by_id (Union[None, Unset, int]):
+        late_fee_by_id (Union[None, Unset, int]):
+        accepted_by_id (Union[None, Unset, int]):
+        ready_for_quality_control_by_id (Union[None, Unset, int]):
+        quality_control_by_id (Union[None, Unset, int]):
+        created_by_id (Union[None, Unset, int]):
+        completed_by_id (Union[None, Unset, int]):
+        shipped_by_id (Union[None, Unset, int]):
+        delivered_by_id (Union[None, Unset, int]):
+        invoiced_by_id (Union[None, Unset, int]):
+        paid_by_id (Union[None, Unset, int]):
+        cancelled_by_id (Union[None, Unset, int]):
+        closed_by_id (Union[None, Unset, int]):
+        po_number (Union[None, Unset, str]):
+        secondary_po (Union[None, Unset, str]):
+        service_total (Union[None, Unset, float]):
+        repairs_total (Union[None, Unset, float]):
+        parts_total (Union[None, Unset, float]):
+        parts_total_before_discount (Union[None, Unset, float]):
+        parts_discount_total (Union[None, Unset, float]):
+        effective_tax_rate (Union[None, Unset, float]):
+        tax_amount (Union[None, Unset, float]):
+        shipping_fee (Union[None, Unset, float]):
+        travel_charge (Union[None, Unset, float]):
+        late_fee (Union[None, Unset, float]):
+        is_tax_exempt (Union[None, Unset, bool]):
+        service_discount (Union[None, Unset, float]):
+        trade_in_credit (Union[None, Unset, float]):
+        prepaid_credit (Union[None, Unset, float]):
+        grand_total (Union[None, Unset, float]):
+        paid_amount (Union[None, Unset, float]):
+        remaining_balance (Union[None, Unset, float]):
+        service_discount_details (Union[None, Unset, str]):
+        trade_in_credit_details (Union[None, Unset, str]):
+        prepaid_credit_details (Union[None, Unset, str]):
+        payment_notes (Union[None, Unset, str]):
+        service_order_number (Union[None, Unset, int]):
+        legacy_order_number (Union[None, Unset, str]):
+        custom_order_number (Union[None, Unset, str]):
+        payment_status (Union[None, Unset, str]):
+        payment_option (Union[None, Unset, str]):
+        shipment_status (Union[None, Unset, str]):
+        order_status (Union[None, Unset, str]):
+        owner_id (Union[None, Unset, int]):
+        owner_department (Union[None, Unset, str]):
+        client_site (Union[None, Unset, str]):
+        client_site_code (Union[None, Unset, str]):
+        vendor_site (Union[None, Unset, str]):
+        internal (Union[None, Unset, bool]):
+        guid (Union[None, Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
         business_from_time (Union[None, Unset, datetime.datetime]):
         business_to_time (Union[None, Unset, datetime.datetime]):
-        site_access_notes (Union[Unset, str]):
+        site_access_notes (Union[None, Unset, str]):
         desired_date (Union[None, Unset, datetime.datetime]):
         deadline_date (Union[None, Unset, datetime.datetime]):
         request_from_date (Union[None, Unset, datetime.datetime]):
         request_from_time (Union[None, Unset, datetime.datetime]):
         request_to_date (Union[None, Unset, datetime.datetime]):
         request_to_time (Union[None, Unset, datetime.datetime]):
-        order_notes (Union[Unset, str]):
+        order_notes (Union[None, Unset, str]):
         billing_address (Union['QualerApiModelsServiceOrdersToClientOrderResponseModelBillingAddressType0', None,
             Unset]):
         shipping_address (Union['QualerApiModelsServiceOrdersToClientOrderResponseModelShippingAddressType0', None,
             Unset]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    parent_order_id: Union[Unset, int] = UNSET
-    client_legacy_id: Union[Unset, str] = UNSET
-    owner_name: Union[Unset, str] = UNSET
-    submited_by_name: Union[Unset, str] = UNSET
-    sign_off_by_name: Union[Unset, str] = UNSET
-    vendor_sign_off_by_name: Union[Unset, str] = UNSET
-    approved_by_name: Union[Unset, str] = UNSET
-    accepted_by_name: Union[Unset, str] = UNSET
-    ready_for_quality_control_by_name: Union[Unset, str] = UNSET
-    quality_control_by_name: Union[Unset, str] = UNSET
-    created_by_name: Union[Unset, str] = UNSET
-    completed_by_name: Union[Unset, str] = UNSET
-    shipped_by_name: Union[Unset, str] = UNSET
-    delivered_by_name: Union[Unset, str] = UNSET
-    invoiced_by_name: Union[Unset, str] = UNSET
-    paid_by_name: Union[Unset, str] = UNSET
-    cancelled_by_name: Union[Unset, str] = UNSET
-    closed_by_name: Union[Unset, str] = UNSET
-    client_company_id: Union[Unset, int] = UNSET
-    client_company_name: Union[Unset, str] = UNSET
-    client_domain_name: Union[Unset, str] = UNSET
-    client_alternative_names: Union[Unset, str] = UNSET
-    service_comments: Union[Unset, str] = UNSET
-    service_private_comments: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    parent_order_id: Union[None, Unset, int] = UNSET
+    client_legacy_id: Union[None, Unset, str] = UNSET
+    owner_name: Union[None, Unset, str] = UNSET
+    submited_by_name: Union[None, Unset, str] = UNSET
+    sign_off_by_name: Union[None, Unset, str] = UNSET
+    vendor_sign_off_by_name: Union[None, Unset, str] = UNSET
+    approved_by_name: Union[None, Unset, str] = UNSET
+    accepted_by_name: Union[None, Unset, str] = UNSET
+    ready_for_quality_control_by_name: Union[None, Unset, str] = UNSET
+    quality_control_by_name: Union[None, Unset, str] = UNSET
+    created_by_name: Union[None, Unset, str] = UNSET
+    completed_by_name: Union[None, Unset, str] = UNSET
+    shipped_by_name: Union[None, Unset, str] = UNSET
+    delivered_by_name: Union[None, Unset, str] = UNSET
+    invoiced_by_name: Union[None, Unset, str] = UNSET
+    paid_by_name: Union[None, Unset, str] = UNSET
+    cancelled_by_name: Union[None, Unset, str] = UNSET
+    closed_by_name: Union[None, Unset, str] = UNSET
+    client_company_id: Union[None, Unset, int] = UNSET
+    client_company_name: Union[None, Unset, str] = UNSET
+    client_domain_name: Union[None, Unset, str] = UNSET
+    client_alternative_names: Union[None, Unset, str] = UNSET
+    service_comments: Union[None, Unset, str] = UNSET
+    service_private_comments: Union[None, Unset, str] = UNSET
     created_on: Union[None, Unset, datetime.datetime] = UNSET
     approved_on: Union[None, Unset, datetime.datetime] = UNSET
     sign_off_on: Union[None, Unset, datetime.datetime] = UNSET
@@ -182,71 +182,71 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
     late_fee_on: Union[None, Unset, datetime.datetime] = UNSET
     cancelled_on: Union[None, Unset, datetime.datetime] = UNSET
     closed_on: Union[None, Unset, datetime.datetime] = UNSET
-    last_updated_on: Union[Unset, datetime.datetime] = UNSET
-    last_updated_by: Union[Unset, str] = UNSET
-    submited_by_id: Union[Unset, int] = UNSET
-    sign_off_by_id: Union[Unset, int] = UNSET
-    vendor_sign_off_by_id: Union[Unset, int] = UNSET
-    approved_by_id: Union[Unset, int] = UNSET
-    late_fee_by_id: Union[Unset, int] = UNSET
-    accepted_by_id: Union[Unset, int] = UNSET
-    ready_for_quality_control_by_id: Union[Unset, int] = UNSET
-    quality_control_by_id: Union[Unset, int] = UNSET
-    created_by_id: Union[Unset, int] = UNSET
-    completed_by_id: Union[Unset, int] = UNSET
-    shipped_by_id: Union[Unset, int] = UNSET
-    delivered_by_id: Union[Unset, int] = UNSET
-    invoiced_by_id: Union[Unset, int] = UNSET
-    paid_by_id: Union[Unset, int] = UNSET
-    cancelled_by_id: Union[Unset, int] = UNSET
-    closed_by_id: Union[Unset, int] = UNSET
-    po_number: Union[Unset, str] = UNSET
-    secondary_po: Union[Unset, str] = UNSET
-    service_total: Union[Unset, float] = UNSET
-    repairs_total: Union[Unset, float] = UNSET
-    parts_total: Union[Unset, float] = UNSET
-    parts_total_before_discount: Union[Unset, float] = UNSET
-    parts_discount_total: Union[Unset, float] = UNSET
-    effective_tax_rate: Union[Unset, float] = UNSET
-    tax_amount: Union[Unset, float] = UNSET
-    shipping_fee: Union[Unset, float] = UNSET
-    travel_charge: Union[Unset, float] = UNSET
-    late_fee: Union[Unset, float] = UNSET
-    is_tax_exempt: Union[Unset, bool] = UNSET
-    service_discount: Union[Unset, float] = UNSET
-    trade_in_credit: Union[Unset, float] = UNSET
-    prepaid_credit: Union[Unset, float] = UNSET
-    grand_total: Union[Unset, float] = UNSET
-    paid_amount: Union[Unset, float] = UNSET
-    remaining_balance: Union[Unset, float] = UNSET
-    service_discount_details: Union[Unset, str] = UNSET
-    trade_in_credit_details: Union[Unset, str] = UNSET
-    prepaid_credit_details: Union[Unset, str] = UNSET
-    payment_notes: Union[Unset, str] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    legacy_order_number: Union[Unset, str] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
-    payment_status: Union[Unset, str] = UNSET
-    payment_option: Union[Unset, str] = UNSET
-    shipment_status: Union[Unset, str] = UNSET
-    order_status: Union[Unset, str] = UNSET
-    owner_id: Union[Unset, int] = UNSET
-    owner_department: Union[Unset, str] = UNSET
-    client_site: Union[Unset, str] = UNSET
-    client_site_code: Union[Unset, str] = UNSET
-    vendor_site: Union[Unset, str] = UNSET
-    internal: Union[Unset, bool] = UNSET
-    guid: Union[Unset, UUID] = UNSET
+    last_updated_on: Union[None, Unset, datetime.datetime] = UNSET
+    last_updated_by: Union[None, Unset, str] = UNSET
+    submited_by_id: Union[None, Unset, int] = UNSET
+    sign_off_by_id: Union[None, Unset, int] = UNSET
+    vendor_sign_off_by_id: Union[None, Unset, int] = UNSET
+    approved_by_id: Union[None, Unset, int] = UNSET
+    late_fee_by_id: Union[None, Unset, int] = UNSET
+    accepted_by_id: Union[None, Unset, int] = UNSET
+    ready_for_quality_control_by_id: Union[None, Unset, int] = UNSET
+    quality_control_by_id: Union[None, Unset, int] = UNSET
+    created_by_id: Union[None, Unset, int] = UNSET
+    completed_by_id: Union[None, Unset, int] = UNSET
+    shipped_by_id: Union[None, Unset, int] = UNSET
+    delivered_by_id: Union[None, Unset, int] = UNSET
+    invoiced_by_id: Union[None, Unset, int] = UNSET
+    paid_by_id: Union[None, Unset, int] = UNSET
+    cancelled_by_id: Union[None, Unset, int] = UNSET
+    closed_by_id: Union[None, Unset, int] = UNSET
+    po_number: Union[None, Unset, str] = UNSET
+    secondary_po: Union[None, Unset, str] = UNSET
+    service_total: Union[None, Unset, float] = UNSET
+    repairs_total: Union[None, Unset, float] = UNSET
+    parts_total: Union[None, Unset, float] = UNSET
+    parts_total_before_discount: Union[None, Unset, float] = UNSET
+    parts_discount_total: Union[None, Unset, float] = UNSET
+    effective_tax_rate: Union[None, Unset, float] = UNSET
+    tax_amount: Union[None, Unset, float] = UNSET
+    shipping_fee: Union[None, Unset, float] = UNSET
+    travel_charge: Union[None, Unset, float] = UNSET
+    late_fee: Union[None, Unset, float] = UNSET
+    is_tax_exempt: Union[None, Unset, bool] = UNSET
+    service_discount: Union[None, Unset, float] = UNSET
+    trade_in_credit: Union[None, Unset, float] = UNSET
+    prepaid_credit: Union[None, Unset, float] = UNSET
+    grand_total: Union[None, Unset, float] = UNSET
+    paid_amount: Union[None, Unset, float] = UNSET
+    remaining_balance: Union[None, Unset, float] = UNSET
+    service_discount_details: Union[None, Unset, str] = UNSET
+    trade_in_credit_details: Union[None, Unset, str] = UNSET
+    prepaid_credit_details: Union[None, Unset, str] = UNSET
+    payment_notes: Union[None, Unset, str] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    legacy_order_number: Union[None, Unset, str] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
+    payment_status: Union[None, Unset, str] = UNSET
+    payment_option: Union[None, Unset, str] = UNSET
+    shipment_status: Union[None, Unset, str] = UNSET
+    order_status: Union[None, Unset, str] = UNSET
+    owner_id: Union[None, Unset, int] = UNSET
+    owner_department: Union[None, Unset, str] = UNSET
+    client_site: Union[None, Unset, str] = UNSET
+    client_site_code: Union[None, Unset, str] = UNSET
+    vendor_site: Union[None, Unset, str] = UNSET
+    internal: Union[None, Unset, bool] = UNSET
+    guid: Union[None, Unset, UUID] = UNSET
     business_from_time: Union[None, Unset, datetime.datetime] = UNSET
     business_to_time: Union[None, Unset, datetime.datetime] = UNSET
-    site_access_notes: Union[Unset, str] = UNSET
+    site_access_notes: Union[None, Unset, str] = UNSET
     desired_date: Union[None, Unset, datetime.datetime] = UNSET
     deadline_date: Union[None, Unset, datetime.datetime] = UNSET
     request_from_date: Union[None, Unset, datetime.datetime] = UNSET
     request_from_time: Union[None, Unset, datetime.datetime] = UNSET
     request_to_date: Union[None, Unset, datetime.datetime] = UNSET
     request_to_time: Union[None, Unset, datetime.datetime] = UNSET
-    order_notes: Union[Unset, str] = UNSET
+    order_notes: Union[None, Unset, str] = UNSET
     billing_address: Union[
         "QualerApiModelsServiceOrdersToClientOrderResponseModelBillingAddressType0",
         None,
@@ -461,7 +461,7 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
         else:
             closed_on = self.closed_on
 
-        last_updated_on: Union[Unset, str] = UNSET
+        last_updated_on: Union[None, Unset, str] = UNSET
         if self.last_updated_on and not isinstance(self.last_updated_on, Unset):
             last_updated_on = self.last_updated_on.isoformat()
 
@@ -571,7 +571,7 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
 
         internal = self.internal
 
-        guid: Union[Unset, str] = UNSET
+        guid: Union[None, Unset, str] = UNSET
         if self.guid and not isinstance(self.guid, Unset):
             guid = str(self.guid)
 
@@ -1272,7 +1272,7 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
         closed_on = _parse_closed_on(d.pop("ClosedOn", UNSET))
 
         _last_updated_on = d.pop("LastUpdatedOn", UNSET)
-        last_updated_on: Union[Unset, datetime.datetime]
+        last_updated_on: Union[None, Unset, datetime.datetime]
         if isinstance(_last_updated_on, Unset):
             last_updated_on = UNSET
         else:
@@ -1385,7 +1385,7 @@ class QualerApiModelsServiceOrdersToClientOrderResponseModel:
         internal = d.pop("Internal", UNSET)
 
         _guid = d.pop("Guid", UNSET)
-        guid: Union[Unset, UUID]
+        guid: Union[None, Unset, UUID]
         if isinstance(_guid, Unset):
             guid = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_created_work_order_payment_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_created_work_order_payment_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToCreatedWorkOrderPaymentRes
 class QualerApiModelsServiceOrdersToCreatedWorkOrderPaymentResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_order_assignment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_order_assignment_response_model.py
@@ -15,31 +15,31 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToOrderAssignmentResponseMod
 class QualerApiModelsServiceOrdersToOrderAssignmentResponseModel:
     """
     Attributes:
-        work_item_id (Union[Unset, int]):
-        employee_id (Union[Unset, int]):
-        company_id (Union[Unset, int]):
-        subscription_email (Union[Unset, str]):
-        subscription_phone (Union[Unset, str]):
-        office_phone (Union[Unset, str]):
-        is_locked (Union[Unset, bool]):
-        image_url (Union[Unset, str]):
-        alias (Union[Unset, str]):
-        title (Union[Unset, str]):
-        is_deleted (Union[Unset, bool]):
+        work_item_id (Union[None, Unset, int]):
+        employee_id (Union[None, Unset, int]):
+        company_id (Union[None, Unset, int]):
+        subscription_email (Union[None, Unset, str]):
+        subscription_phone (Union[None, Unset, str]):
+        office_phone (Union[None, Unset, str]):
+        is_locked (Union[None, Unset, bool]):
+        image_url (Union[None, Unset, str]):
+        alias (Union[None, Unset, str]):
+        title (Union[None, Unset, str]):
+        is_deleted (Union[None, Unset, bool]):
         last_seen_date_utc (Union[None, Unset, datetime.datetime]):
     """
 
-    work_item_id: Union[Unset, int] = UNSET
-    employee_id: Union[Unset, int] = UNSET
-    company_id: Union[Unset, int] = UNSET
-    subscription_email: Union[Unset, str] = UNSET
-    subscription_phone: Union[Unset, str] = UNSET
-    office_phone: Union[Unset, str] = UNSET
-    is_locked: Union[Unset, bool] = UNSET
-    image_url: Union[Unset, str] = UNSET
-    alias: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    is_deleted: Union[Unset, bool] = UNSET
+    work_item_id: Union[None, Unset, int] = UNSET
+    employee_id: Union[None, Unset, int] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    subscription_email: Union[None, Unset, str] = UNSET
+    subscription_phone: Union[None, Unset, str] = UNSET
+    office_phone: Union[None, Unset, str] = UNSET
+    is_locked: Union[None, Unset, bool] = UNSET
+    image_url: Union[None, Unset, str] = UNSET
+    alias: Union[None, Unset, str] = UNSET
+    title: Union[None, Unset, str] = UNSET
+    is_deleted: Union[None, Unset, bool] = UNSET
     last_seen_date_utc: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_payment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_payment_response_model.py
@@ -13,24 +13,24 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToPaymentResponseModel")
 class QualerApiModelsServiceOrdersToPaymentResponseModel:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        created_by_id (Union[Unset, int]):
-        transaction_id (Union[Unset, str]):
-        transaction_status (Union[Unset, str]):
-        payment_type (Union[Unset, str]):
-        service_order_payment_id (Union[Unset, int]):
-        payment_amount (Union[Unset, float]):
-        details (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        created_by_id (Union[None, Unset, int]):
+        transaction_id (Union[None, Unset, str]):
+        transaction_status (Union[None, Unset, str]):
+        payment_type (Union[None, Unset, str]):
+        service_order_payment_id (Union[None, Unset, int]):
+        payment_amount (Union[None, Unset, float]):
+        details (Union[None, Unset, str]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    created_by_id: Union[Unset, int] = UNSET
-    transaction_id: Union[Unset, str] = UNSET
-    transaction_status: Union[Unset, str] = UNSET
-    payment_type: Union[Unset, str] = UNSET
-    service_order_payment_id: Union[Unset, int] = UNSET
-    payment_amount: Union[Unset, float] = UNSET
-    details: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    created_by_id: Union[None, Unset, int] = UNSET
+    transaction_id: Union[None, Unset, str] = UNSET
+    transaction_status: Union[None, Unset, str] = UNSET
+    payment_type: Union[None, Unset, str] = UNSET
+    service_order_payment_id: Union[None, Unset, int] = UNSET
+    payment_amount: Union[None, Unset, float] = UNSET
+    details: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_provider_service_order_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_provider_service_order_response_model.py
@@ -24,24 +24,24 @@ T = TypeVar(
 class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
     """
     Attributes:
-        service_order_id (Union[Unset, int]):
-        guid (Union[Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
-        service_order_number (Union[Unset, int]):
-        custom_order_number (Union[Unset, str]):
+        service_order_id (Union[None, Unset, int]):
+        guid (Union[None, Unset, UUID]):  Example: 00000000-0000-0000-0000-000000000000.
+        service_order_number (Union[None, Unset, int]):
+        custom_order_number (Union[None, Unset, str]):
         due_date (Union[None, Unset, datetime.datetime]):
-        assets (Union[Unset, int]):
-        completed_assets (Union[Unset, int]):
-        order_status (Union[Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelOrderStatus]):
-        is_quality_control_fail (Union[Unset, bool]):
-        service_private_comments (Union[Unset, str]):
-        client_company_id (Union[Unset, int]):
-        client_company_name (Union[Unset, str]):
-        client_site_name (Union[Unset, str]):
-        client_legacy_id (Union[Unset, str]):
+        assets (Union[None, Unset, int]):
+        completed_assets (Union[None, Unset, int]):
+        order_status (Union[None, Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelOrderStatus]):
+        is_quality_control_fail (Union[None, Unset, bool]):
+        service_private_comments (Union[None, Unset, str]):
+        client_company_id (Union[None, Unset, int]):
+        client_company_name (Union[None, Unset, str]):
+        client_site_name (Union[None, Unset, str]):
+        client_legacy_id (Union[None, Unset, str]):
         business_from_time (Union[None, Unset, datetime.datetime]):
         business_to_time (Union[None, Unset, datetime.datetime]):
-        timeframe (Union[Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelTimeframe]):
-        site_access_notes (Union[Unset, str]):
+        timeframe (Union[None, Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelTimeframe]):
+        site_access_notes (Union[None, Unset, str]):
         desired_date (Union[None, Unset, datetime.datetime]):
         deadline_date (Union[None, Unset, datetime.datetime]):
         request_from_date (Union[None, Unset, datetime.datetime]):
@@ -50,29 +50,27 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
         request_to_time (Union[None, Unset, datetime.datetime]):
     """
 
-    service_order_id: Union[Unset, int] = UNSET
-    guid: Union[Unset, UUID] = UNSET
-    service_order_number: Union[Unset, int] = UNSET
-    custom_order_number: Union[Unset, str] = UNSET
+    service_order_id: Union[None, Unset, int] = UNSET
+    guid: Union[None, Unset, UUID] = UNSET
+    service_order_number: Union[None, Unset, int] = UNSET
+    custom_order_number: Union[None, Unset, str] = UNSET
     due_date: Union[None, Unset, datetime.datetime] = UNSET
-    assets: Union[Unset, int] = UNSET
-    completed_assets: Union[Unset, int] = UNSET
-    order_status: Union[
-        Unset,
+    assets: Union[None, Unset, int] = UNSET
+    completed_assets: Union[None, Unset, int] = UNSET
+    order_status: Union[None, Unset,
         QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelOrderStatus,
     ] = UNSET
-    is_quality_control_fail: Union[Unset, bool] = UNSET
-    service_private_comments: Union[Unset, str] = UNSET
-    client_company_id: Union[Unset, int] = UNSET
-    client_company_name: Union[Unset, str] = UNSET
-    client_site_name: Union[Unset, str] = UNSET
-    client_legacy_id: Union[Unset, str] = UNSET
+    is_quality_control_fail: Union[None, Unset, bool] = UNSET
+    service_private_comments: Union[None, Unset, str] = UNSET
+    client_company_id: Union[None, Unset, int] = UNSET
+    client_company_name: Union[None, Unset, str] = UNSET
+    client_site_name: Union[None, Unset, str] = UNSET
+    client_legacy_id: Union[None, Unset, str] = UNSET
     business_from_time: Union[None, Unset, datetime.datetime] = UNSET
     business_to_time: Union[None, Unset, datetime.datetime] = UNSET
-    timeframe: Union[
-        Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelTimeframe
+    timeframe: Union[None, Unset, QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelTimeframe
     ] = UNSET
-    site_access_notes: Union[Unset, str] = UNSET
+    site_access_notes: Union[None, Unset, str] = UNSET
     desired_date: Union[None, Unset, datetime.datetime] = UNSET
     deadline_date: Union[None, Unset, datetime.datetime] = UNSET
     request_from_date: Union[None, Unset, datetime.datetime] = UNSET
@@ -84,7 +82,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
     def to_dict(self) -> dict[str, Any]:
         service_order_id = self.service_order_id
 
-        guid: Union[Unset, str] = UNSET
+        guid: Union[None, Unset, str] = UNSET
         if self.guid and not isinstance(self.guid, Unset):
             guid = str(self.guid)
 
@@ -104,7 +102,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
 
         completed_assets = self.completed_assets
 
-        order_status: Union[Unset, str] = UNSET
+        order_status: Union[None, Unset, str] = UNSET
         if self.order_status and not isinstance(self.order_status, Unset):
             order_status = self.order_status.value
 
@@ -136,7 +134,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
         else:
             business_to_time = self.business_to_time
 
-        timeframe: Union[Unset, str] = UNSET
+        timeframe: Union[None, Unset, str] = UNSET
         if self.timeframe and not isinstance(self.timeframe, Unset):
             timeframe = self.timeframe.value
 
@@ -250,7 +248,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
         service_order_id = d.pop("ServiceOrderId", UNSET)
 
         _guid = d.pop("Guid", UNSET)
-        guid: Union[Unset, UUID]
+        guid: Union[None, Unset, UUID]
         if isinstance(_guid, Unset):
             guid = UNSET
         else:
@@ -282,8 +280,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
         completed_assets = d.pop("CompletedAssets", UNSET)
 
         _order_status = d.pop("OrderStatus", UNSET)
-        order_status: Union[
-            Unset,
+        order_status: Union[None, Unset,
             QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelOrderStatus,
         ]
         if isinstance(_order_status, Unset):
@@ -344,8 +341,7 @@ class QualerApiModelsServiceOrdersToProviderServiceOrderResponseModel:
         business_to_time = _parse_business_to_time(d.pop("BusinessToTime", UNSET))
 
         _timeframe = d.pop("Timeframe", UNSET)
-        timeframe: Union[
-            Unset,
+        timeframe: Union[None, Unset,
             QualerApiModelsServiceOrdersToProviderServiceOrderResponseModelTimeframe,
         ]
         if isinstance(_timeframe, Unset):

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_part_repair_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_part_repair_response.py
@@ -15,54 +15,54 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToServiceOrderPartRepairResp
 class QualerApiModelsServiceOrdersToServiceOrderPartRepairResponse:
     """
     Attributes:
-        service_order_item_part_id (Union[Unset, int]):
-        price (Union[Unset, float]):
-        description (Union[Unset, str]):
-        name (Union[Unset, str]):
-        unit_name (Union[Unset, str]):
-        quantity (Union[Unset, float]):
-        discount (Union[Unset, float]):
-        delivery_charge (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
-        time_spent_in_minutes (Union[Unset, float]):
-        is_hourly_pricing (Union[Unset, bool]):
-        free_quantity (Union[Unset, int]):
-        currency_iso_symbol (Union[Unset, str]):
-        created_by_id (Union[Unset, int]):
-        created_by (Union[Unset, str]):
-        created_on_utc (Union[Unset, datetime.datetime]):
-        charge_date (Union[Unset, datetime.datetime]):
-        contract_repairs_discount (Union[Unset, float]):
-        contract_parts_discount (Union[Unset, float]):
-        service_order_charge_type (Union[Unset, str]):
-        total_discount (Union[Unset, float]):
-        total_price (Union[Unset, float]):
-        discount_price (Union[Unset, float]):
+        service_order_item_part_id (Union[None, Unset, int]):
+        price (Union[None, Unset, float]):
+        description (Union[None, Unset, str]):
+        name (Union[None, Unset, str]):
+        unit_name (Union[None, Unset, str]):
+        quantity (Union[None, Unset, float]):
+        discount (Union[None, Unset, float]):
+        delivery_charge (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        free_quantity (Union[None, Unset, int]):
+        currency_iso_symbol (Union[None, Unset, str]):
+        created_by_id (Union[None, Unset, int]):
+        created_by (Union[None, Unset, str]):
+        created_on_utc (Union[None, Unset, datetime.datetime]):
+        charge_date (Union[None, Unset, datetime.datetime]):
+        contract_repairs_discount (Union[None, Unset, float]):
+        contract_parts_discount (Union[None, Unset, float]):
+        service_order_charge_type (Union[None, Unset, str]):
+        total_discount (Union[None, Unset, float]):
+        total_price (Union[None, Unset, float]):
+        discount_price (Union[None, Unset, float]):
     """
 
-    service_order_item_part_id: Union[Unset, int] = UNSET
-    price: Union[Unset, float] = UNSET
-    description: Union[Unset, str] = UNSET
-    name: Union[Unset, str] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    discount: Union[Unset, float] = UNSET
-    delivery_charge: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    free_quantity: Union[Unset, int] = UNSET
-    currency_iso_symbol: Union[Unset, str] = UNSET
-    created_by_id: Union[Unset, int] = UNSET
-    created_by: Union[Unset, str] = UNSET
-    created_on_utc: Union[Unset, datetime.datetime] = UNSET
-    charge_date: Union[Unset, datetime.datetime] = UNSET
-    contract_repairs_discount: Union[Unset, float] = UNSET
-    contract_parts_discount: Union[Unset, float] = UNSET
-    service_order_charge_type: Union[Unset, str] = UNSET
-    total_discount: Union[Unset, float] = UNSET
-    total_price: Union[Unset, float] = UNSET
-    discount_price: Union[Unset, float] = UNSET
+    service_order_item_part_id: Union[None, Unset, int] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    discount: Union[None, Unset, float] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    free_quantity: Union[None, Unset, int] = UNSET
+    currency_iso_symbol: Union[None, Unset, str] = UNSET
+    created_by_id: Union[None, Unset, int] = UNSET
+    created_by: Union[None, Unset, str] = UNSET
+    created_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    charge_date: Union[None, Unset, datetime.datetime] = UNSET
+    contract_repairs_discount: Union[None, Unset, float] = UNSET
+    contract_parts_discount: Union[None, Unset, float] = UNSET
+    service_order_charge_type: Union[None, Unset, str] = UNSET
+    total_discount: Union[None, Unset, float] = UNSET
+    total_price: Union[None, Unset, float] = UNSET
+    discount_price: Union[None, Unset, float] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -96,11 +96,11 @@ class QualerApiModelsServiceOrdersToServiceOrderPartRepairResponse:
 
         created_by = self.created_by
 
-        created_on_utc: Union[Unset, str] = UNSET
+        created_on_utc: Union[None, Unset, str] = UNSET
         if self.created_on_utc and not isinstance(self.created_on_utc, Unset):
             created_on_utc = self.created_on_utc.isoformat()
 
-        charge_date: Union[Unset, str] = UNSET
+        charge_date: Union[None, Unset, str] = UNSET
         if self.charge_date and not isinstance(self.charge_date, Unset):
             charge_date = self.charge_date.isoformat()
 
@@ -202,14 +202,14 @@ class QualerApiModelsServiceOrdersToServiceOrderPartRepairResponse:
         created_by = d.pop("CreatedBy", UNSET)
 
         _created_on_utc = d.pop("CreatedOnUtc", UNSET)
-        created_on_utc: Union[Unset, datetime.datetime]
+        created_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_created_on_utc, Unset):
             created_on_utc = UNSET
         else:
             created_on_utc = isoparse(_created_on_utc)
 
         _charge_date = d.pop("ChargeDate", UNSET)
-        charge_date: Union[Unset, datetime.datetime]
+        charge_date: Union[None, Unset, datetime.datetime]
         if isinstance(_charge_date, Unset):
             charge_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_task_response.py
@@ -15,28 +15,28 @@ T = TypeVar("T", bound="QualerApiModelsServiceOrdersToServiceOrderTaskResponse")
 class QualerApiModelsServiceOrdersToServiceOrderTaskResponse:
     """
     Attributes:
-        service_order_task_id (Union[Unset, int]):
-        task_name (Union[Unset, str]):
-        task_order (Union[Unset, int]):
-        task_details (Union[Unset, str]):
-        time_spent (Union[Unset, float]):
-        time_spent_in_minutes (Union[Unset, int]):
-        start_time (Union[Unset, datetime.datetime]):
-        finish_time (Union[Unset, datetime.datetime]):
-        price (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
+        service_order_task_id (Union[None, Unset, int]):
+        task_name (Union[None, Unset, str]):
+        task_order (Union[None, Unset, int]):
+        task_details (Union[None, Unset, str]):
+        time_spent (Union[None, Unset, float]):
+        time_spent_in_minutes (Union[None, Unset, int]):
+        start_time (Union[None, Unset, datetime.datetime]):
+        finish_time (Union[None, Unset, datetime.datetime]):
+        price (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
     """
 
-    service_order_task_id: Union[Unset, int] = UNSET
-    task_name: Union[Unset, str] = UNSET
-    task_order: Union[Unset, int] = UNSET
-    task_details: Union[Unset, str] = UNSET
-    time_spent: Union[Unset, float] = UNSET
-    time_spent_in_minutes: Union[Unset, int] = UNSET
-    start_time: Union[Unset, datetime.datetime] = UNSET
-    finish_time: Union[Unset, datetime.datetime] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
+    service_order_task_id: Union[None, Unset, int] = UNSET
+    task_name: Union[None, Unset, str] = UNSET
+    task_order: Union[None, Unset, int] = UNSET
+    task_details: Union[None, Unset, str] = UNSET
+    time_spent: Union[None, Unset, float] = UNSET
+    time_spent_in_minutes: Union[None, Unset, int] = UNSET
+    start_time: Union[None, Unset, datetime.datetime] = UNSET
+    finish_time: Union[None, Unset, datetime.datetime] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -52,11 +52,11 @@ class QualerApiModelsServiceOrdersToServiceOrderTaskResponse:
 
         time_spent_in_minutes = self.time_spent_in_minutes
 
-        start_time: Union[Unset, str] = UNSET
+        start_time: Union[None, Unset, str] = UNSET
         if self.start_time and not isinstance(self.start_time, Unset):
             start_time = self.start_time.isoformat()
 
-        finish_time: Union[Unset, str] = UNSET
+        finish_time: Union[None, Unset, str] = UNSET
         if self.finish_time and not isinstance(self.finish_time, Unset):
             finish_time = self.finish_time.isoformat()
 
@@ -106,14 +106,14 @@ class QualerApiModelsServiceOrdersToServiceOrderTaskResponse:
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", UNSET)
 
         _start_time = d.pop("StartTime", UNSET)
-        start_time: Union[Unset, datetime.datetime]
+        start_time: Union[None, Unset, datetime.datetime]
         if isinstance(_start_time, Unset):
             start_time = UNSET
         else:
             start_time = isoparse(_start_time)
 
         _finish_time = d.pop("FinishTime", UNSET)
-        finish_time: Union[Unset, datetime.datetime]
+        finish_time: Union[None, Unset, datetime.datetime]
         if isinstance(_finish_time, Unset):
             finish_time = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_site_from_site_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_from_site_create_model.py
@@ -19,42 +19,42 @@ T = TypeVar("T", bound="QualerApiModelsSiteFromSiteCreateModel")
 class QualerApiModelsSiteFromSiteCreateModel:
     """
     Attributes:
-        site_name (Union[Unset, str]):
-        site_code (Union[Unset, str]):
-        shipping_inherited (Union[Unset, bool]):
-        default_account_representative_employee_id (Union[Unset, int]):
-        billing_inherited (Union[Unset, bool]):
-        federal_number (Union[Unset, str]):
-        state_number (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        is_science_facility (Union[Unset, bool]):
-        is_service_center (Union[Unset, bool]):
-        is_inventory_storage (Union[Unset, bool]):
-        is_production (Union[Unset, bool]):
-        time_zone_id (Union[Unset, str]):
-        time_zone_offset_minutes (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        site_name (Union[None, Unset, str]):
+        site_code (Union[None, Unset, str]):
+        shipping_inherited (Union[None, Unset, bool]):
+        default_account_representative_employee_id (Union[None, Unset, int]):
+        billing_inherited (Union[None, Unset, bool]):
+        federal_number (Union[None, Unset, str]):
+        state_number (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        is_science_facility (Union[None, Unset, bool]):
+        is_service_center (Union[None, Unset, bool]):
+        is_inventory_storage (Union[None, Unset, bool]):
+        is_production (Union[None, Unset, bool]):
+        time_zone_id (Union[None, Unset, str]):
+        time_zone_offset_minutes (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    site_name: Union[Unset, str] = UNSET
-    site_code: Union[Unset, str] = UNSET
-    shipping_inherited: Union[Unset, bool] = UNSET
-    default_account_representative_employee_id: Union[Unset, int] = UNSET
-    billing_inherited: Union[Unset, bool] = UNSET
-    federal_number: Union[Unset, str] = UNSET
-    state_number: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    is_science_facility: Union[Unset, bool] = UNSET
-    is_service_center: Union[Unset, bool] = UNSET
-    is_inventory_storage: Union[Unset, bool] = UNSET
-    is_production: Union[Unset, bool] = UNSET
-    time_zone_id: Union[Unset, str] = UNSET
-    time_zone_offset_minutes: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_code: Union[None, Unset, str] = UNSET
+    shipping_inherited: Union[None, Unset, bool] = UNSET
+    default_account_representative_employee_id: Union[None, Unset, int] = UNSET
+    billing_inherited: Union[None, Unset, bool] = UNSET
+    federal_number: Union[None, Unset, str] = UNSET
+    state_number: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    is_science_facility: Union[None, Unset, bool] = UNSET
+    is_service_center: Union[None, Unset, bool] = UNSET
+    is_inventory_storage: Union[None, Unset, bool] = UNSET
+    is_production: Union[None, Unset, bool] = UNSET
+    time_zone_id: Union[None, Unset, str] = UNSET
+    time_zone_offset_minutes: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -90,11 +90,11 @@ class QualerApiModelsSiteFromSiteCreateModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -180,7 +180,7 @@ class QualerApiModelsSiteFromSiteCreateModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -189,7 +189,7 @@ class QualerApiModelsSiteFromSiteCreateModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_site_from_site_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_from_site_update_model.py
@@ -19,44 +19,44 @@ T = TypeVar("T", bound="QualerApiModelsSiteFromSiteUpdateModel")
 class QualerApiModelsSiteFromSiteUpdateModel:
     """
     Attributes:
-        site_id (Union[Unset, int]):
-        site_name (Union[Unset, str]):
-        site_code (Union[Unset, str]):
-        shipping_inherited (Union[Unset, bool]):
-        default_account_representative_employee_id (Union[Unset, int]):
-        billing_inherited (Union[Unset, bool]):
-        federal_number (Union[Unset, str]):
-        state_number (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        is_science_facility (Union[Unset, bool]):
-        is_service_center (Union[Unset, bool]):
-        is_inventory_storage (Union[Unset, bool]):
-        is_production (Union[Unset, bool]):
-        time_zone_id (Union[Unset, str]):
-        time_zone_offset_minutes (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        site_id (Union[None, Unset, int]):
+        site_name (Union[None, Unset, str]):
+        site_code (Union[None, Unset, str]):
+        shipping_inherited (Union[None, Unset, bool]):
+        default_account_representative_employee_id (Union[None, Unset, int]):
+        billing_inherited (Union[None, Unset, bool]):
+        federal_number (Union[None, Unset, str]):
+        state_number (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        is_science_facility (Union[None, Unset, bool]):
+        is_service_center (Union[None, Unset, bool]):
+        is_inventory_storage (Union[None, Unset, bool]):
+        is_production (Union[None, Unset, bool]):
+        time_zone_id (Union[None, Unset, str]):
+        time_zone_offset_minutes (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    site_id: Union[Unset, int] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_code: Union[Unset, str] = UNSET
-    shipping_inherited: Union[Unset, bool] = UNSET
-    default_account_representative_employee_id: Union[Unset, int] = UNSET
-    billing_inherited: Union[Unset, bool] = UNSET
-    federal_number: Union[Unset, str] = UNSET
-    state_number: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    is_science_facility: Union[Unset, bool] = UNSET
-    is_service_center: Union[Unset, bool] = UNSET
-    is_inventory_storage: Union[Unset, bool] = UNSET
-    is_production: Union[Unset, bool] = UNSET
-    time_zone_id: Union[Unset, str] = UNSET
-    time_zone_offset_minutes: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_code: Union[None, Unset, str] = UNSET
+    shipping_inherited: Union[None, Unset, bool] = UNSET
+    default_account_representative_employee_id: Union[None, Unset, int] = UNSET
+    billing_inherited: Union[None, Unset, bool] = UNSET
+    federal_number: Union[None, Unset, str] = UNSET
+    state_number: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    is_science_facility: Union[None, Unset, bool] = UNSET
+    is_service_center: Union[None, Unset, bool] = UNSET
+    is_inventory_storage: Union[None, Unset, bool] = UNSET
+    is_production: Union[None, Unset, bool] = UNSET
+    time_zone_id: Union[None, Unset, str] = UNSET
+    time_zone_offset_minutes: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -94,11 +94,11 @@ class QualerApiModelsSiteFromSiteUpdateModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -188,7 +188,7 @@ class QualerApiModelsSiteFromSiteUpdateModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -197,7 +197,7 @@ class QualerApiModelsSiteFromSiteUpdateModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response.py
@@ -27,50 +27,50 @@ T = TypeVar("T", bound="QualerApiModelsSiteToClientSiteResponse")
 class QualerApiModelsSiteToClientSiteResponse:
     """
     Attributes:
-        site_id (Union[Unset, int]):
-        site_name (Union[Unset, str]):
-        site_code (Union[Unset, str]):
+        site_id (Union[None, Unset, int]):
+        site_name (Union[None, Unset, str]):
+        site_code (Union[None, Unset, str]):
         shipping_address (Union['QualerApiModelsSiteToClientSiteResponseShippingAddressType0', None, Unset]):
-        shipping_inherited (Union[Unset, bool]):
+        shipping_inherited (Union[None, Unset, bool]):
         billing_address (Union['QualerApiModelsSiteToClientSiteResponseBillingAddressType0', None, Unset]):
-        default_account_representative_employee_id (Union[Unset, int]):
-        billing_inherited (Union[Unset, bool]):
-        federal_number (Union[Unset, str]):
-        state_number (Union[Unset, str]):
-        culture_name (Union[Unset, str]):
-        is_science_facility (Union[Unset, bool]):
-        is_service_center (Union[Unset, bool]):
-        is_inventory_storage (Union[Unset, bool]):
-        is_production (Union[Unset, bool]):
-        time_zone_id (Union[Unset, str]):
-        time_zone_offset_minutes (Union[Unset, int]):
-        updated_on_utc (Union[Unset, datetime.datetime]):
-        attributes (Union[Unset, list['QualerApiModelsCommonFromAttributeModel']]):
+        default_account_representative_employee_id (Union[None, Unset, int]):
+        billing_inherited (Union[None, Unset, bool]):
+        federal_number (Union[None, Unset, str]):
+        state_number (Union[None, Unset, str]):
+        culture_name (Union[None, Unset, str]):
+        is_science_facility (Union[None, Unset, bool]):
+        is_service_center (Union[None, Unset, bool]):
+        is_inventory_storage (Union[None, Unset, bool]):
+        is_production (Union[None, Unset, bool]):
+        time_zone_id (Union[None, Unset, str]):
+        time_zone_offset_minutes (Union[None, Unset, int]):
+        updated_on_utc (Union[None, Unset, datetime.datetime]):
+        attributes (Union[None, Unset, list['QualerApiModelsCommonFromAttributeModel']]):
     """
 
-    site_id: Union[Unset, int] = UNSET
-    site_name: Union[Unset, str] = UNSET
-    site_code: Union[Unset, str] = UNSET
+    site_id: Union[None, Unset, int] = UNSET
+    site_name: Union[None, Unset, str] = UNSET
+    site_code: Union[None, Unset, str] = UNSET
     shipping_address: Union[
         "QualerApiModelsSiteToClientSiteResponseShippingAddressType0", None, Unset
     ] = UNSET
-    shipping_inherited: Union[Unset, bool] = UNSET
+    shipping_inherited: Union[None, Unset, bool] = UNSET
     billing_address: Union[
         "QualerApiModelsSiteToClientSiteResponseBillingAddressType0", None, Unset
     ] = UNSET
-    default_account_representative_employee_id: Union[Unset, int] = UNSET
-    billing_inherited: Union[Unset, bool] = UNSET
-    federal_number: Union[Unset, str] = UNSET
-    state_number: Union[Unset, str] = UNSET
-    culture_name: Union[Unset, str] = UNSET
-    is_science_facility: Union[Unset, bool] = UNSET
-    is_service_center: Union[Unset, bool] = UNSET
-    is_inventory_storage: Union[Unset, bool] = UNSET
-    is_production: Union[Unset, bool] = UNSET
-    time_zone_id: Union[Unset, str] = UNSET
-    time_zone_offset_minutes: Union[Unset, int] = UNSET
-    updated_on_utc: Union[Unset, datetime.datetime] = UNSET
-    attributes: Union[Unset, list["QualerApiModelsCommonFromAttributeModel"]] = UNSET
+    default_account_representative_employee_id: Union[None, Unset, int] = UNSET
+    billing_inherited: Union[None, Unset, bool] = UNSET
+    federal_number: Union[None, Unset, str] = UNSET
+    state_number: Union[None, Unset, str] = UNSET
+    culture_name: Union[None, Unset, str] = UNSET
+    is_science_facility: Union[None, Unset, bool] = UNSET
+    is_service_center: Union[None, Unset, bool] = UNSET
+    is_inventory_storage: Union[None, Unset, bool] = UNSET
+    is_production: Union[None, Unset, bool] = UNSET
+    time_zone_id: Union[None, Unset, str] = UNSET
+    time_zone_offset_minutes: Union[None, Unset, int] = UNSET
+    updated_on_utc: Union[None, Unset, datetime.datetime] = UNSET
+    attributes: Union[None, Unset, list["QualerApiModelsCommonFromAttributeModel"]] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -135,11 +135,11 @@ class QualerApiModelsSiteToClientSiteResponse:
 
         time_zone_offset_minutes = self.time_zone_offset_minutes
 
-        updated_on_utc: Union[Unset, str] = UNSET
+        updated_on_utc: Union[None, Unset, str] = UNSET
         if self.updated_on_utc and not isinstance(self.updated_on_utc, Unset):
             updated_on_utc = self.updated_on_utc.isoformat()
 
-        attributes: Union[Unset, list[dict[str, Any]]] = UNSET
+        attributes: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.attributes and not isinstance(self.attributes, Unset):
             attributes = []
             for attributes_item_data in self.attributes:
@@ -298,7 +298,7 @@ class QualerApiModelsSiteToClientSiteResponse:
         time_zone_offset_minutes = d.pop("TimeZoneOffsetMinutes", UNSET)
 
         _updated_on_utc = d.pop("UpdatedOnUtc", UNSET)
-        updated_on_utc: Union[Unset, datetime.datetime]
+        updated_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on_utc, Unset):
             updated_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_create_model.py
@@ -19,22 +19,22 @@ T = TypeVar("T", bound="QualerApiModelsVendorsFromSponsoredVendorCreateModel")
 class QualerApiModelsVendorsFromSponsoredVendorCreateModel:
     """
     Attributes:
-        account_number_text (Union[Unset, str]):
-        domain_name (Union[Unset, str]):
-        custom_vendor_name (Union[Unset, str]):
-        currency_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        account_number_text (Union[None, Unset, str]):
+        domain_name (Union[None, Unset, str]):
+        custom_vendor_name (Union[None, Unset, str]):
+        currency_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    account_number_text: Union[Unset, str] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_vendor_name: Union[Unset, str] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_vendor_name: Union[None, Unset, str] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -48,11 +48,11 @@ class QualerApiModelsVendorsFromSponsoredVendorCreateModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -94,7 +94,7 @@ class QualerApiModelsVendorsFromSponsoredVendorCreateModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -103,7 +103,7 @@ class QualerApiModelsVendorsFromSponsoredVendorCreateModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_edit_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_edit_model.py
@@ -19,24 +19,24 @@ T = TypeVar("T", bound="QualerApiModelsVendorsFromSponsoredVendorEditModel")
 class QualerApiModelsVendorsFromSponsoredVendorEditModel:
     """
     Attributes:
-        company_id (Union[Unset, int]):
-        account_number_text (Union[Unset, str]):
-        domain_name (Union[Unset, str]):
-        custom_vendor_name (Union[Unset, str]):
-        currency_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        billing_address (Union[Unset, QualerApiModelsAddressAddressModel]):
-        shipping_address (Union[Unset, QualerApiModelsAddressAddressModel]):
+        company_id (Union[None, Unset, int]):
+        account_number_text (Union[None, Unset, str]):
+        domain_name (Union[None, Unset, str]):
+        custom_vendor_name (Union[None, Unset, str]):
+        currency_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        billing_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
+        shipping_address (Union[None, Unset, QualerApiModelsAddressAddressModel]):
     """
 
-    company_id: Union[Unset, int] = UNSET
-    account_number_text: Union[Unset, str] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_vendor_name: Union[Unset, str] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    billing_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
-    shipping_address: Union[Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_vendor_name: Union[None, Unset, str] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    billing_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
+    shipping_address: Union[None, Unset, "QualerApiModelsAddressAddressModel"] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -52,11 +52,11 @@ class QualerApiModelsVendorsFromSponsoredVendorEditModel:
 
         company_name = self.company_name
 
-        billing_address: Union[Unset, dict[str, Any]] = UNSET
+        billing_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.billing_address and not isinstance(self.billing_address, Unset):
             billing_address = self.billing_address.to_dict()
 
-        shipping_address: Union[Unset, dict[str, Any]] = UNSET
+        shipping_address: Union[None, Unset, dict[str, Any]] = UNSET
         if self.shipping_address and not isinstance(self.shipping_address, Unset):
             shipping_address = self.shipping_address.to_dict()
 
@@ -102,7 +102,7 @@ class QualerApiModelsVendorsFromSponsoredVendorEditModel:
         company_name = d.pop("CompanyName", UNSET)
 
         _billing_address = d.pop("BillingAddress", UNSET)
-        billing_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        billing_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_billing_address, Unset):
             billing_address = UNSET
         else:
@@ -111,7 +111,7 @@ class QualerApiModelsVendorsFromSponsoredVendorEditModel:
             )
 
         _shipping_address = d.pop("ShippingAddress", UNSET)
-        shipping_address: Union[Unset, QualerApiModelsAddressAddressModel]
+        shipping_address: Union[None, Unset, QualerApiModelsAddressAddressModel]
         if isinstance(_shipping_address, Unset):
             shipping_address = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_vendor_company_search_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_vendor_company_search_model.py
@@ -15,16 +15,16 @@ T = TypeVar("T", bound="QualerApiModelsVendorsFromVendorCompanySearchModel")
 class QualerApiModelsVendorsFromVendorCompanySearchModel:
     """
     Attributes:
-        account_number_text (Union[Unset, str]):
-        company_name (Union[Unset, str]):
-        take (Union[Unset, int]):
-        modified_after (Union[Unset, datetime.datetime]):
+        account_number_text (Union[None, Unset, str]):
+        company_name (Union[None, Unset, str]):
+        take (Union[None, Unset, int]):
+        modified_after (Union[None, Unset, datetime.datetime]):
     """
 
-    account_number_text: Union[Unset, str] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    take: Union[Unset, int] = UNSET
-    modified_after: Union[Unset, datetime.datetime] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    take: Union[None, Unset, int] = UNSET
+    modified_after: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -34,7 +34,7 @@ class QualerApiModelsVendorsFromVendorCompanySearchModel:
 
         take = self.take
 
-        modified_after: Union[Unset, str] = UNSET
+        modified_after: Union[None, Unset, str] = UNSET
         if self.modified_after and not isinstance(self.modified_after, Unset):
             modified_after = self.modified_after.isoformat()
 
@@ -62,7 +62,7 @@ class QualerApiModelsVendorsFromVendorCompanySearchModel:
         take = d.pop("Take", UNSET)
 
         _modified_after = d.pop("ModifiedAfter", UNSET)
-        modified_after: Union[Unset, datetime.datetime]
+        modified_after: Union[None, Unset, datetime.datetime]
         if isinstance(_modified_after, Unset):
             modified_after = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_created_vendor_company_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_created_vendor_company_response.py
@@ -13,10 +13,10 @@ T = TypeVar("T", bound="QualerApiModelsVendorsToCreatedVendorCompanyResponse")
 class QualerApiModelsVendorsToCreatedVendorCompanyResponse:
     """
     Attributes:
-        id (Union[Unset, int]):
+        id (Union[None, Unset, int]):
     """
 
-    id: Union[Unset, int] = UNSET
+    id: Union[None, Unset, int] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model.py
@@ -24,25 +24,25 @@ T = TypeVar("T", bound="QualerApiModelsVendorsToVendorCompanyResponseModel")
 class QualerApiModelsVendorsToVendorCompanyResponseModel:
     """
     Attributes:
-        account_number_text (Union[Unset, str]):
-        account_number (Union[Unset, int]):
-        currency_id (Union[Unset, int]):
-        company_id (Union[Unset, int]):
-        company_name (Union[Unset, str]):
-        domain_name (Union[Unset, str]):
-        custom_name (Union[Unset, str]):
+        account_number_text (Union[None, Unset, str]):
+        account_number (Union[None, Unset, int]):
+        currency_id (Union[None, Unset, int]):
+        company_id (Union[None, Unset, int]):
+        company_name (Union[None, Unset, str]):
+        domain_name (Union[None, Unset, str]):
+        custom_name (Union[None, Unset, str]):
         billing_address (Union['QualerApiModelsVendorsToVendorCompanyResponseModelBillingAddressType0', None, Unset]):
         shipping_address (Union['QualerApiModelsVendorsToVendorCompanyResponseModelShippingAddressType0', None, Unset]):
-        updated_on_utc (Union[Unset, datetime.datetime]):
+        updated_on_utc (Union[None, Unset, datetime.datetime]):
     """
 
-    account_number_text: Union[Unset, str] = UNSET
-    account_number: Union[Unset, int] = UNSET
-    currency_id: Union[Unset, int] = UNSET
-    company_id: Union[Unset, int] = UNSET
-    company_name: Union[Unset, str] = UNSET
-    domain_name: Union[Unset, str] = UNSET
-    custom_name: Union[Unset, str] = UNSET
+    account_number_text: Union[None, Unset, str] = UNSET
+    account_number: Union[None, Unset, int] = UNSET
+    currency_id: Union[None, Unset, int] = UNSET
+    company_id: Union[None, Unset, int] = UNSET
+    company_name: Union[None, Unset, str] = UNSET
+    domain_name: Union[None, Unset, str] = UNSET
+    custom_name: Union[None, Unset, str] = UNSET
     billing_address: Union[
         "QualerApiModelsVendorsToVendorCompanyResponseModelBillingAddressType0",
         None,
@@ -53,7 +53,7 @@ class QualerApiModelsVendorsToVendorCompanyResponseModel:
         None,
         Unset,
     ] = UNSET
-    updated_on_utc: Union[Unset, datetime.datetime] = UNSET
+    updated_on_utc: Union[None, Unset, datetime.datetime] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -100,7 +100,7 @@ class QualerApiModelsVendorsToVendorCompanyResponseModel:
         else:
             shipping_address = self.shipping_address
 
-        updated_on_utc: Union[Unset, str] = UNSET
+        updated_on_utc: Union[None, Unset, str] = UNSET
         if self.updated_on_utc and not isinstance(self.updated_on_utc, Unset):
             updated_on_utc = self.updated_on_utc.isoformat()
 
@@ -219,7 +219,7 @@ class QualerApiModelsVendorsToVendorCompanyResponseModel:
         shipping_address = _parse_shipping_address(d.pop("ShippingAddress", UNSET))
 
         _updated_on_utc = d.pop("UpdatedOnUtc", UNSET)
-        updated_on_utc: Union[Unset, datetime.datetime]
+        updated_on_utc: Union[None, Unset, datetime.datetime]
         if isinstance(_updated_on_utc, Unset):
             updated_on_utc = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits.py
+++ b/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits.py
@@ -21,15 +21,14 @@ T = TypeVar(
 class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits:
     """
     Attributes:
-        title (Union[Unset, str]):
-        subtitle (Union[Unset, str]):
-        exhibits (Union[Unset, list['QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue']]):
+        title (Union[None, Unset, str]):
+        subtitle (Union[None, Unset, str]):
+        exhibits (Union[None, Unset, list['QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue']]):
     """
 
-    title: Union[Unset, str] = UNSET
-    subtitle: Union[Unset, str] = UNSET
-    exhibits: Union[
-        Unset,
+    title: Union[None, Unset, str] = UNSET
+    subtitle: Union[None, Unset, str] = UNSET
+    exhibits: Union[None, Unset,
         list[
             "QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue"
         ],
@@ -41,7 +40,7 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits:
 
         subtitle = self.subtitle
 
-        exhibits: Union[Unset, list[dict[str, Any]]] = UNSET
+        exhibits: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.exhibits and not isinstance(self.exhibits, Unset):
             exhibits = []
             for exhibits_item_data in self.exhibits:

--- a/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value.py
+++ b/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value.py
@@ -16,12 +16,12 @@ T = TypeVar(
 class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue:
     """
     Attributes:
-        name (Union[Unset, str]):
-        value (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        value (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    value: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    value: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_account_to_login_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_account_to_login_model.py
@@ -15,12 +15,12 @@ class QualerWebMvcAreasApiModelsAccountToLoginModel:
     Attributes:
         user_name (str):
         password (str):
-        clear_previous_tokens (Union[Unset, bool]):
+        clear_previous_tokens (Union[None, Unset, bool]):
     """
 
     user_name: str
     password: str
-    clear_previous_tokens: Union[Unset, bool] = UNSET
+    clear_previous_tokens: Union[None, Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_add_department_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_add_department_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerWebMvcAreasApiModelsCompanyFromAddDepartmentModel"
 class QualerWebMvcAreasApiModelsCompanyFromAddDepartmentModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        description (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_update_department_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_update_department_model.py
@@ -13,12 +13,12 @@ T = TypeVar("T", bound="QualerWebMvcAreasApiModelsCompanyFromUpdateDepartmentMod
 class QualerWebMvcAreasApiModelsCompanyFromUpdateDepartmentModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        description (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_product_from_product_api_edit_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_product_from_product_api_edit_model.py
@@ -13,34 +13,34 @@ T = TypeVar("T", bound="QualerWebMvcAreasApiModelsProductFromProductApiEditModel
 class QualerWebMvcAreasApiModelsProductFromProductApiEditModel:
     """
     Attributes:
-        product_description (Union[Unset, str]):
-        category_id (Union[Unset, int]):
-        manufacturer_id (Union[Unset, int]):
-        parent_product_id (Union[Unset, int]):
-        product_name (Union[Unset, str]):
-        manufacturer_part_number (Union[Unset, str]):
-        is_family (Union[Unset, bool]):
-        is_discontinued (Union[Unset, bool]):
-        is_stock_item (Union[Unset, bool]):
-        unit_sale_price (Union[Unset, float]):
-        supplier_information (Union[Unset, str]):
-        quantity_on_hand (Union[Unset, int]):
-        product_code (Union[Unset, str]):
+        product_description (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        manufacturer_id (Union[None, Unset, int]):
+        parent_product_id (Union[None, Unset, int]):
+        product_name (Union[None, Unset, str]):
+        manufacturer_part_number (Union[None, Unset, str]):
+        is_family (Union[None, Unset, bool]):
+        is_discontinued (Union[None, Unset, bool]):
+        is_stock_item (Union[None, Unset, bool]):
+        unit_sale_price (Union[None, Unset, float]):
+        supplier_information (Union[None, Unset, str]):
+        quantity_on_hand (Union[None, Unset, int]):
+        product_code (Union[None, Unset, str]):
     """
 
-    product_description: Union[Unset, str] = UNSET
-    category_id: Union[Unset, int] = UNSET
-    manufacturer_id: Union[Unset, int] = UNSET
-    parent_product_id: Union[Unset, int] = UNSET
-    product_name: Union[Unset, str] = UNSET
-    manufacturer_part_number: Union[Unset, str] = UNSET
-    is_family: Union[Unset, bool] = UNSET
-    is_discontinued: Union[Unset, bool] = UNSET
-    is_stock_item: Union[Unset, bool] = UNSET
-    unit_sale_price: Union[Unset, float] = UNSET
-    supplier_information: Union[Unset, str] = UNSET
-    quantity_on_hand: Union[Unset, int] = UNSET
-    product_code: Union[Unset, str] = UNSET
+    product_description: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    manufacturer_id: Union[None, Unset, int] = UNSET
+    parent_product_id: Union[None, Unset, int] = UNSET
+    product_name: Union[None, Unset, str] = UNSET
+    manufacturer_part_number: Union[None, Unset, str] = UNSET
+    is_family: Union[None, Unset, bool] = UNSET
+    is_discontinued: Union[None, Unset, bool] = UNSET
+    is_stock_item: Union[None, Unset, bool] = UNSET
+    unit_sale_price: Union[None, Unset, float] = UNSET
+    supplier_information: Union[None, Unset, str] = UNSET
+    quantity_on_hand: Union[None, Unset, int] = UNSET
+    product_code: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model.py
@@ -18,36 +18,36 @@ T = TypeVar(
 class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateModel:
     """
     Attributes:
-        name (Union[Unset, str]):
-        description (Union[Unset, str]):
-        charge_date (Union[Unset, datetime.datetime]):
-        price (Union[Unset, float]):
-        unit_name (Union[Unset, str]):
-        is_hourly_pricing (Union[Unset, bool]):
-        time_spent_in_minutes (Union[Unset, float]):
-        quantity (Union[Unset, float]):
-        discount (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
-        delivery_charge (Union[Unset, float]):
-        free_quantity (Union[Unset, int]):
-        created_by_id (Union[Unset, int]):
-        service_order_charge_type (Union[Unset, str]):
+        name (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
+        charge_date (Union[None, Unset, datetime.datetime]):
+        price (Union[None, Unset, float]):
+        unit_name (Union[None, Unset, str]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        quantity (Union[None, Unset, float]):
+        discount (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
+        delivery_charge (Union[None, Unset, float]):
+        free_quantity (Union[None, Unset, int]):
+        created_by_id (Union[None, Unset, int]):
+        service_order_charge_type (Union[None, Unset, str]):
     """
 
-    name: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
-    charge_date: Union[Unset, datetime.datetime] = UNSET
-    price: Union[Unset, float] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    discount: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    delivery_charge: Union[Unset, float] = UNSET
-    free_quantity: Union[Unset, int] = UNSET
-    created_by_id: Union[Unset, int] = UNSET
-    service_order_charge_type: Union[Unset, str] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    charge_date: Union[None, Unset, datetime.datetime] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    discount: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    free_quantity: Union[None, Unset, int] = UNSET
+    created_by_id: Union[None, Unset, int] = UNSET
+    service_order_charge_type: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -55,7 +55,7 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateMod
 
         description = self.description
 
-        charge_date: Union[Unset, str] = UNSET
+        charge_date: Union[None, Unset, str] = UNSET
         if self.charge_date and not isinstance(self.charge_date, Unset):
             charge_date = self.charge_date.isoformat()
 
@@ -123,7 +123,7 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateMod
         description = d.pop("Description", UNSET)
 
         _charge_date = d.pop("ChargeDate", UNSET)
-        charge_date: Union[Unset, datetime.datetime]
+        charge_date: Union[None, Unset, datetime.datetime]
         if isinstance(_charge_date, Unset):
             charge_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model.py
@@ -18,38 +18,38 @@ T = TypeVar(
 class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateModel:
     """
     Attributes:
-        service_order_item_part_id (Union[Unset, int]):
-        name (Union[Unset, str]):
-        description (Union[Unset, str]):
-        charge_date (Union[Unset, datetime.datetime]):
-        price (Union[Unset, float]):
-        unit_name (Union[Unset, str]):
-        is_hourly_pricing (Union[Unset, bool]):
-        time_spent_in_minutes (Union[Unset, float]):
-        quantity (Union[Unset, float]):
-        discount (Union[Unset, float]):
-        is_taxable (Union[Unset, bool]):
-        delivery_charge (Union[Unset, float]):
-        free_quantity (Union[Unset, int]):
-        created_by_id (Union[Unset, int]):
-        service_order_charge_type (Union[Unset, str]):
+        service_order_item_part_id (Union[None, Unset, int]):
+        name (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
+        charge_date (Union[None, Unset, datetime.datetime]):
+        price (Union[None, Unset, float]):
+        unit_name (Union[None, Unset, str]):
+        is_hourly_pricing (Union[None, Unset, bool]):
+        time_spent_in_minutes (Union[None, Unset, float]):
+        quantity (Union[None, Unset, float]):
+        discount (Union[None, Unset, float]):
+        is_taxable (Union[None, Unset, bool]):
+        delivery_charge (Union[None, Unset, float]):
+        free_quantity (Union[None, Unset, int]):
+        created_by_id (Union[None, Unset, int]):
+        service_order_charge_type (Union[None, Unset, str]):
     """
 
-    service_order_item_part_id: Union[Unset, int] = UNSET
-    name: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
-    charge_date: Union[Unset, datetime.datetime] = UNSET
-    price: Union[Unset, float] = UNSET
-    unit_name: Union[Unset, str] = UNSET
-    is_hourly_pricing: Union[Unset, bool] = UNSET
-    time_spent_in_minutes: Union[Unset, float] = UNSET
-    quantity: Union[Unset, float] = UNSET
-    discount: Union[Unset, float] = UNSET
-    is_taxable: Union[Unset, bool] = UNSET
-    delivery_charge: Union[Unset, float] = UNSET
-    free_quantity: Union[Unset, int] = UNSET
-    created_by_id: Union[Unset, int] = UNSET
-    service_order_charge_type: Union[Unset, str] = UNSET
+    service_order_item_part_id: Union[None, Unset, int] = UNSET
+    name: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    charge_date: Union[None, Unset, datetime.datetime] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    unit_name: Union[None, Unset, str] = UNSET
+    is_hourly_pricing: Union[None, Unset, bool] = UNSET
+    time_spent_in_minutes: Union[None, Unset, float] = UNSET
+    quantity: Union[None, Unset, float] = UNSET
+    discount: Union[None, Unset, float] = UNSET
+    is_taxable: Union[None, Unset, bool] = UNSET
+    delivery_charge: Union[None, Unset, float] = UNSET
+    free_quantity: Union[None, Unset, int] = UNSET
+    created_by_id: Union[None, Unset, int] = UNSET
+    service_order_charge_type: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -59,7 +59,7 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateMod
 
         description = self.description
 
-        charge_date: Union[Unset, str] = UNSET
+        charge_date: Union[None, Unset, str] = UNSET
         if self.charge_date and not isinstance(self.charge_date, Unset):
             charge_date = self.charge_date.isoformat()
 
@@ -131,7 +131,7 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateMod
         description = d.pop("Description", UNSET)
 
         _charge_date = d.pop("ChargeDate", UNSET)
-        charge_date: Union[Unset, datetime.datetime]
+        charge_date: Union[None, Unset, datetime.datetime]
         if isinstance(_charge_date, Unset):
             charge_date = UNSET
         else:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model.py
@@ -28,69 +28,64 @@ T = TypeVar("T", bound="QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseM
 class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
     """
     Attributes:
-        charges (Union[Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBasePriceModel']]):
-        tasks (Union[Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel']]):
-        parts (Union[Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel']]):
-        repairs (Union[Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel']]):
-        work_items (Union[Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModel']]):
+        charges (Union[None, Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBasePriceModel']]):
+        tasks (Union[None, Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel']]):
+        parts (Union[None, Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel']]):
+        repairs (Union[None, Unset, list['QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel']]):
+        work_items (Union[None, Unset, list['QualerApiModelsServiceOrdersToBaseWorkItemModel']]):
     """
 
-    charges: Union[
-        Unset, list["QualerApiModelsServiceOrdersToChargeResponseModelBasePriceModel"]
+    charges: Union[None, Unset, list["QualerApiModelsServiceOrdersToChargeResponseModelBasePriceModel"]
     ] = UNSET
-    tasks: Union[
-        Unset,
+    tasks: Union[None, Unset,
         list[
             "QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel"
         ],
     ] = UNSET
-    parts: Union[
-        Unset,
+    parts: Union[None, Unset,
         list[
             "QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel"
         ],
     ] = UNSET
-    repairs: Union[
-        Unset,
+    repairs: Union[None, Unset,
         list[
             "QualerApiModelsServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel"
         ],
     ] = UNSET
-    work_items: Union[
-        Unset, list["QualerApiModelsServiceOrdersToBaseWorkItemModel"]
+    work_items: Union[None, Unset, list["QualerApiModelsServiceOrdersToBaseWorkItemModel"]
     ] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        charges: Union[Unset, list[dict[str, Any]]] = UNSET
+        charges: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.charges and not isinstance(self.charges, Unset):
             charges = []
             for charges_item_data in self.charges:
                 charges_item = charges_item_data.to_dict()
                 charges.append(charges_item)
 
-        tasks: Union[Unset, list[dict[str, Any]]] = UNSET
+        tasks: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.tasks and not isinstance(self.tasks, Unset):
             tasks = []
             for tasks_item_data in self.tasks:
                 tasks_item = tasks_item_data.to_dict()
                 tasks.append(tasks_item)
 
-        parts: Union[Unset, list[dict[str, Any]]] = UNSET
+        parts: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.parts and not isinstance(self.parts, Unset):
             parts = []
             for parts_item_data in self.parts:
                 parts_item = parts_item_data.to_dict()
                 parts.append(parts_item)
 
-        repairs: Union[Unset, list[dict[str, Any]]] = UNSET
+        repairs: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.repairs and not isinstance(self.repairs, Unset):
             repairs = []
             for repairs_item_data in self.repairs:
                 repairs_item = repairs_item_data.to_dict()
                 repairs.append(repairs_item)
 
-        work_items: Union[Unset, list[dict[str, Any]]] = UNSET
+        work_items: Union[None, Unset, list[dict[str, Any]]] = UNSET
         if self.work_items and not isinstance(self.work_items, Unset):
             work_items = []
             for work_items_item_data in self.work_items:

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model.py
@@ -15,42 +15,42 @@ T = TypeVar(
 class QualerWebMvcAreasApiModelsServicePricesFromServicePriceBulkEditModel:
     """
     Attributes:
-        service_option_id (Union[Unset, int]):
-        service_option (Union[Unset, str]):
-        service_option_code (Union[Unset, str]):
-        option_type (Union[Unset, str]):
-        description (Union[Unset, str]):
-        service_task_id (Union[Unset, int]):
-        service_code (Union[Unset, str]):
-        document_number (Union[Unset, str]):
-        document_section (Union[Unset, str]):
-        capability_id (Union[Unset, int]):
-        service_type_id (Union[Unset, int]):
-        service_task_price_id (Union[Unset, int]):
-        service_pricing_id (Union[Unset, int]):
-        price (Union[Unset, float]):
-        is_hourly (Union[Unset, bool]):
-        issue (Union[Unset, str]):
-        log_error (Union[Unset, str]):
+        service_option_id (Union[None, Unset, int]):
+        service_option (Union[None, Unset, str]):
+        service_option_code (Union[None, Unset, str]):
+        option_type (Union[None, Unset, str]):
+        description (Union[None, Unset, str]):
+        service_task_id (Union[None, Unset, int]):
+        service_code (Union[None, Unset, str]):
+        document_number (Union[None, Unset, str]):
+        document_section (Union[None, Unset, str]):
+        capability_id (Union[None, Unset, int]):
+        service_type_id (Union[None, Unset, int]):
+        service_task_price_id (Union[None, Unset, int]):
+        service_pricing_id (Union[None, Unset, int]):
+        price (Union[None, Unset, float]):
+        is_hourly (Union[None, Unset, bool]):
+        issue (Union[None, Unset, str]):
+        log_error (Union[None, Unset, str]):
     """
 
-    service_option_id: Union[Unset, int] = UNSET
-    service_option: Union[Unset, str] = UNSET
-    service_option_code: Union[Unset, str] = UNSET
-    option_type: Union[Unset, str] = UNSET
-    description: Union[Unset, str] = UNSET
-    service_task_id: Union[Unset, int] = UNSET
-    service_code: Union[Unset, str] = UNSET
-    document_number: Union[Unset, str] = UNSET
-    document_section: Union[Unset, str] = UNSET
-    capability_id: Union[Unset, int] = UNSET
-    service_type_id: Union[Unset, int] = UNSET
-    service_task_price_id: Union[Unset, int] = UNSET
-    service_pricing_id: Union[Unset, int] = UNSET
-    price: Union[Unset, float] = UNSET
-    is_hourly: Union[Unset, bool] = UNSET
-    issue: Union[Unset, str] = UNSET
-    log_error: Union[Unset, str] = UNSET
+    service_option_id: Union[None, Unset, int] = UNSET
+    service_option: Union[None, Unset, str] = UNSET
+    service_option_code: Union[None, Unset, str] = UNSET
+    option_type: Union[None, Unset, str] = UNSET
+    description: Union[None, Unset, str] = UNSET
+    service_task_id: Union[None, Unset, int] = UNSET
+    service_code: Union[None, Unset, str] = UNSET
+    document_number: Union[None, Unset, str] = UNSET
+    document_section: Union[None, Unset, str] = UNSET
+    capability_id: Union[None, Unset, int] = UNSET
+    service_type_id: Union[None, Unset, int] = UNSET
+    service_task_price_id: Union[None, Unset, int] = UNSET
+    service_pricing_id: Union[None, Unset, int] = UNSET
+    price: Union[None, Unset, float] = UNSET
+    is_hourly: Union[None, Unset, bool] = UNSET
+    issue: Union[None, Unset, str] = UNSET
+    log_error: Union[None, Unset, str] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:


### PR DESCRIPTION
Improve type hinting in the generated SDK by replacing `Union[Unset, int]` with `Union[None, Unset, int]` and similar updates for other attributes, enhancing clarity and type safety.