### PR TITLE
Fix service order ID endpoint and response model handling

### DIFF
--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
@@ -4129,6 +4129,8 @@ class QualerApiModelsReportDatasetsToMeasurementAllResponse:
         completed_on: Union[None, Unset, datetime.datetime]
         if isinstance(_completed_on, Unset):
             completed_on = UNSET
+        elif _completed_on is None:
+            completed_on = None
         else:
             completed_on = isoparse(_completed_on)
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
@@ -3143,6 +3143,8 @@ class QualerApiModelsReportDatasetsToMeasurementResponse:
         completed_on: Union[None, Unset, datetime.datetime]
         if isinstance(_completed_on, Unset):
             completed_on = UNSET
+        elif _completed_on is None:
+            completed_on = None
         else:
             completed_on = isoparse(_completed_on)
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
@@ -1489,6 +1489,8 @@ class QualerApiModelsReportDatasetsToServiceOrderResponse:
         quality_control_date: Union[None, Unset, datetime.datetime]
         if isinstance(_quality_control_date, Unset):
             quality_control_date = UNSET
+        elif _quality_control_date is None:
+            quality_control_date = None
         else:
             quality_control_date = isoparse(_quality_control_date)
 

--- a/tests/integration/test_the_other_get_endpoints.py
+++ b/tests/integration/test_the_other_get_endpoints.py
@@ -9,7 +9,7 @@ from qualer_sdk.client import AuthenticatedClient
 ASSET_ID = 1235564  # valid asset ID for testing
 ASSET_POOL_ID = 620646  # valid asset pool ID for testing
 CLIENT_COMPANY_ID = 57613  # valid client company id
-SERVICE_ORDER_ID = 1235369  # valid service order ID
+SERVICE_ORDER_ID = 281552  # valid service order ID
 SERVICE_ORDER_ITEM_ID = 3662396  # valid work item ID
 ASSET_SERVICE_RECORD_ID = 2325444  # valid record ID
 PDF_DOCUMENT_UUID = "c4ab6a7c-e2f1-4984-837f-9390f9a84dfc"  # known PDF

--- a/tests/test_endpoints_integration.py
+++ b/tests/test_endpoints_integration.py
@@ -449,9 +449,9 @@ def discover_service_order_item_id_endpoints() -> List[Tuple[str, Any]]:
 
 # Test data for Asset Service Record ID endpoints
 try:
-    import qualer_sdk.api.asset_service_records.get_asset_service_record
     import qualer_sdk.api.asset_service_records.document_list
     import qualer_sdk.api.asset_service_records.download_documents
+    import qualer_sdk.api.asset_service_records.get_asset_service_record
     import qualer_sdk.api.asset_service_records.upload_documents
 
     ASSET_SERVICE_RECORD_ID_ONLY_ENDPOINTS = [
@@ -484,9 +484,9 @@ PROBLEMATIC_ASSET_SERVICE_RECORD_ENDPOINTS = [
 
 # Test data for Employee ID endpoints
 try:
+    import qualer_sdk.api.client_employees.get_employee
     import qualer_sdk.api.employees.get_employee_get_2
     import qualer_sdk.api.service_orders.get_work_orders_employee
-    import qualer_sdk.api.client_employees.get_employee
 
     EMPLOYEE_ID_ONLY_ENDPOINTS = [
         (
@@ -553,8 +553,8 @@ try:
     ]
 
     # Maintenance Plan ID endpoints (the GET ones only)
-    import qualer_sdk.api.maintenance_plans.get_maintenance_plan_assets_get_2
     import qualer_sdk.api.client_maintenance_plans.get_maintenance_plan_assets
+    import qualer_sdk.api.maintenance_plans.get_maintenance_plan_assets_get_2
 
     MAINTENANCE_PLAN_ID_ENDPOINTS = [
         (
@@ -922,17 +922,17 @@ def test_service_order_id_endpoint_response_parsing(
     3. No parsing/enum/date errors occur
     """
     # Skip problematic endpoints with known OpenAPI generator issues
-    problematic_endpoints = [
-        "report_datasets.get_all_measurements_by_order",  # AsFoundMeasurementNotTakenResult enum doesn't handle None
-        "report_datasets.get_as_found_measurements_by_order",  # GuardBandLogic enum doesn't handle None
-        "report_datasets.get_as_left_measurements_by_order",  # GuardBandLogic enum doesn't handle None
-        "report_datasets.get_service_orders",  # Date parsing error with None values
-    ]
+    # problematic_endpoints = [
+    #     "report_datasets.get_all_measurements_by_order",  # AsFoundMeasurementNotTakenResult enum doesn't handle None
+    #     "report_datasets.get_as_found_measurements_by_order",  # GuardBandLogic enum doesn't handle None
+    #     "report_datasets.get_as_left_measurements_by_order",  # GuardBandLogic enum doesn't handle None
+    #     "report_datasets.get_service_orders",  # Date parsing error with None values
+    # ]
 
-    if endpoint_name in problematic_endpoints:
-        pytest.skip(
-            f"Skipping {endpoint_name} - known OpenAPI generator issue with nullable enums"
-        )
+    # if endpoint_name in problematic_endpoints:
+    #     pytest.skip(
+    #         f"Skipping {endpoint_name} - known OpenAPI generator issue with nullable enums"
+    #     )
     # Get the service order ID parameter name from the function signature
     sig = inspect.signature(endpoint_func)
     service_order_param_name = None


### PR DESCRIPTION
Remove problematic endpoints from the test skipping logic and improve handling of `None` cases in response models for `completed_on` and `quality_control_date`. Update the service order ID for testing purposes.