### PR TITLE
Refactor asset_id attributes to be non-optional across multiple models

### DIFF
--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="AssetReservationFromCloseAssetReservationsModel")
 class AssetReservationFromCloseAssetReservationsModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         area_id (Optional[int]):
         product_id (Optional[int]):
         serial_number (Optional[str]):
@@ -19,7 +19,7 @@ class AssetReservationFromCloseAssetReservationsModel:
         reservation_id (Optional[int]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     area_id: Optional[int] = None
     product_id: Optional[int] = None
     serial_number: Optional[str] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
@@ -13,7 +13,7 @@ T = TypeVar("T", bound="AssetReservationFromUpsertAssetReservationModel")
 class AssetReservationFromUpsertAssetReservationModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         product_id (Optional[int]):
         reservation_id (Optional[int]):
         service_order_id (Optional[int]):
@@ -24,7 +24,7 @@ class AssetReservationFromUpsertAssetReservationModel:
         comments (Optional[str]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     product_id: Optional[int] = None
     reservation_id: Optional[int] = None
     service_order_id: Optional[int] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
@@ -13,13 +13,13 @@ T = TypeVar("T", bound="AssetServiceRecordsFromAssetServiceRecordFilterModel")
 class AssetServiceRecordsFromAssetServiceRecordFilterModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         serial_number (Optional[str]):
         from_ (Optional[datetime.datetime]):
         to (Optional[datetime.datetime]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     serial_number: Optional[str] = None
     from_: Optional[datetime.datetime] = None
     to: Optional[datetime.datetime] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
@@ -14,7 +14,7 @@ T = TypeVar("T", bound="AssetServiceRecordsToAssetServiceRecordResponseModel")
 class AssetServiceRecordsToAssetServiceRecordResponseModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         asset_service_record_id (Optional[int]):
         service_schedule_segment_id (Optional[int]):
         forward_segment_id (Optional[int]):
@@ -54,7 +54,7 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
         schedule_name (Optional[str]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     asset_service_record_id: Optional[int] = None
     service_schedule_segment_id: Optional[int] = None
     forward_segment_id: Optional[int] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
@@ -19,7 +19,7 @@ T = TypeVar("T", bound="AssetToAssetMaintenancePlanResponse")
 class AssetToAssetMaintenancePlanResponse:
     """
     Attributes:
-        maintenance_plan_id (Optional[int]):
+        maintenance_plan_id (int):
         maintenance_plan_name (Optional[str]):
         task_notes (Optional[str]):
         last_service_task (Optional[str]):
@@ -38,7 +38,7 @@ class AssetToAssetMaintenancePlanResponse:
         assigned_employees (Optional[List['AssetToAssetMaintenancePlanResponseAssignedEmployee']]):
     """
 
-    maintenance_plan_id: Optional[int] = None
+    maintenance_plan_id: int
     maintenance_plan_name: Optional[str] = None
     task_notes: Optional[str] = None
     last_service_task: Optional[str] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound="AssetToAssetManageResponseModel")
 class AssetToAssetManageResponseModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         asset_name (Optional[str]):
         asset_description (Optional[str]):
         asset_maker (Optional[str]):
@@ -113,7 +113,7 @@ class AssetToAssetManageResponseModel:
         work_status (Optional[WorkStatus]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     asset_name: Optional[str] = None
     asset_description: Optional[str] = None
     asset_maker: Optional[str] = None

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound="AssetToClientAssetManagerResponseModel")
 class AssetToClientAssetManagerResponseModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         asset_name (Optional[str]):
         asset_description (Optional[str]):
         asset_maker (Optional[str]):
@@ -121,7 +121,7 @@ class AssetToClientAssetManagerResponseModel:
         schedules (Optional[str]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     asset_name: Optional[str] = None
     asset_description: Optional[str] = None
     asset_maker: Optional[str] = None

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -11,10 +11,10 @@ T = TypeVar("T", bound="ClientsFromClientAssetModel")
 class ClientsFromClientAssetModel:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
@@ -11,13 +11,13 @@ T = TypeVar("T", bound="ReportDatasetsToAssetAttributeResponse")
 class ReportDatasetsToAssetAttributeResponse:
     """
     Attributes:
-        asset_id (Optional[int]):
+        asset_id (int):
         attribute_name (Optional[str]):
         attribute_value (Optional[str]):
         is_service (Optional[bool]):
     """
 
-    asset_id: Optional[int] = None
+    asset_id: int
     attribute_name: Optional[str] = None
     attribute_value: Optional[str] = None
     is_service: Optional[bool] = None


### PR DESCRIPTION
Ensure that the asset_id attribute is required in various models, enhancing data integrity and consistency.