### PR TITLE
Rename NONE to UNSET in FilterType enum for compatibility

### DIFF
--- a/src/qualer_sdk/models/filter_type.py
+++ b/src/qualer_sdk/models/filter_type.py
@@ -4,7 +4,7 @@ from enum import Enum
 class FilterType(str, Enum):
     """Filter types for GetAssetManagerList API endpoint."""
 
-    NONE = "None"
+    UNSET = "Unset"
     DUE_FOR_SERVICE = "DueForService"
     RECENTLY_SERVICED = "RecentlyServiced"
     NOT_SERVICED = "NotServiced"


### PR DESCRIPTION
Update the FilterType enum to replace "NONE" with "UNSET" to enhance compatibility.