### PR TITLE
Simplify model to_dict helpers

### DIFF
--- a/src/qualer_sdk/models/add_asset_service_record_response_200.py
+++ b/src/qualer_sdk/models/add_asset_service_record_response_200.py
@@ -16,14 +16,12 @@ class AddAssetServiceRecordResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_asset_service_record_response_200 = cls()
-
         add_asset_service_record_response_200.additional_properties = d
         return add_asset_service_record_response_200
 

--- a/src/qualer_sdk/models/add_auxiliary_tools_response_200.py
+++ b/src/qualer_sdk/models/add_auxiliary_tools_response_200.py
@@ -16,14 +16,12 @@ class AddAuxiliaryToolsResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_auxiliary_tools_response_200 = cls()
-
         add_auxiliary_tools_response_200.additional_properties = d
         return add_auxiliary_tools_response_200
 

--- a/src/qualer_sdk/models/add_department_response_204.py
+++ b/src/qualer_sdk/models/add_department_response_204.py
@@ -16,14 +16,12 @@ class AddDepartmentResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_department_response_204 = cls()
-
         add_department_response_204.additional_properties = d
         return add_department_response_204
 

--- a/src/qualer_sdk/models/add_employee_department_response_204.py
+++ b/src/qualer_sdk/models/add_employee_department_response_204.py
@@ -16,14 +16,12 @@ class AddEmployeeDepartmentResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_employee_department_response_204 = cls()
-
         add_employee_department_response_204.additional_properties = d
         return add_employee_department_response_204
 

--- a/src/qualer_sdk/models/add_manufacturer_response_200.py
+++ b/src/qualer_sdk/models/add_manufacturer_response_200.py
@@ -16,14 +16,12 @@ class AddManufacturerResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_manufacturer_response_200 = cls()
-
         add_manufacturer_response_200.additional_properties = d
         return add_manufacturer_response_200
 

--- a/src/qualer_sdk/models/add_product_response_200.py
+++ b/src/qualer_sdk/models/add_product_response_200.py
@@ -16,14 +16,12 @@ class AddProductResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         add_product_response_200 = cls()
-
         add_product_response_200.additional_properties = d
         return add_product_response_200
 

--- a/src/qualer_sdk/models/append_shipment_tracking_number_response_200.py
+++ b/src/qualer_sdk/models/append_shipment_tracking_number_response_200.py
@@ -16,14 +16,12 @@ class AppendShipmentTrackingNumberResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         append_shipment_tracking_number_response_200 = cls()
-
         append_shipment_tracking_number_response_200.additional_properties = d
         return append_shipment_tracking_number_response_200
 

--- a/src/qualer_sdk/models/change_order_status_response_200.py
+++ b/src/qualer_sdk/models/change_order_status_response_200.py
@@ -16,14 +16,12 @@ class ChangeOrderStatusResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         change_order_status_response_200 = cls()
-
         change_order_status_response_200.additional_properties = d
         return change_order_status_response_200
 

--- a/src/qualer_sdk/models/change_work_order_payment_status_response_200.py
+++ b/src/qualer_sdk/models/change_work_order_payment_status_response_200.py
@@ -16,14 +16,12 @@ class ChangeWorkOrderPaymentStatusResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         change_work_order_payment_status_response_200 = cls()
-
         change_work_order_payment_status_response_200.additional_properties = d
         return change_work_order_payment_status_response_200
 

--- a/src/qualer_sdk/models/close_response_200.py
+++ b/src/qualer_sdk/models/close_response_200.py
@@ -16,14 +16,12 @@ class CloseResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         close_response_200 = cls()
-
         close_response_200.additional_properties = d
         return close_response_200
 

--- a/src/qualer_sdk/models/collect_assets_response_200.py
+++ b/src/qualer_sdk/models/collect_assets_response_200.py
@@ -16,14 +16,12 @@ class CollectAssetsResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         collect_assets_response_200 = cls()
-
         collect_assets_response_200.additional_properties = d
         return collect_assets_response_200
 

--- a/src/qualer_sdk/models/companies_response_200.py
+++ b/src/qualer_sdk/models/companies_response_200.py
@@ -16,14 +16,12 @@ class CompaniesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         companies_response_200 = cls()
-
         companies_response_200.additional_properties = d
         return companies_response_200
 

--- a/src/qualer_sdk/models/create_asset_response_200.py
+++ b/src/qualer_sdk/models/create_asset_response_200.py
@@ -16,14 +16,12 @@ class CreateAssetResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_asset_response_200 = cls()
-
         create_asset_response_200.additional_properties = d
         return create_asset_response_200
 

--- a/src/qualer_sdk/models/create_async_response_201.py
+++ b/src/qualer_sdk/models/create_async_response_201.py
@@ -16,14 +16,12 @@ class CreateAsyncResponse201:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_async_response_201 = cls()
-
         create_async_response_201.additional_properties = d
         return create_async_response_201
 

--- a/src/qualer_sdk/models/create_client_site_response_200.py
+++ b/src/qualer_sdk/models/create_client_site_response_200.py
@@ -16,14 +16,12 @@ class CreateClientSiteResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_client_site_response_200 = cls()
-
         create_client_site_response_200.additional_properties = d
         return create_client_site_response_200
 

--- a/src/qualer_sdk/models/create_employee_response_200.py
+++ b/src/qualer_sdk/models/create_employee_response_200.py
@@ -16,14 +16,12 @@ class CreateEmployeeResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_employee_response_200 = cls()
-
         create_employee_response_200.additional_properties = d
         return create_employee_response_200
 

--- a/src/qualer_sdk/models/create_measurement_form_response_200.py
+++ b/src/qualer_sdk/models/create_measurement_form_response_200.py
@@ -16,14 +16,12 @@ class CreateMeasurementFormResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_measurement_form_response_200 = cls()
-
         create_measurement_form_response_200.additional_properties = d
         return create_measurement_form_response_200
 

--- a/src/qualer_sdk/models/create_order_by_schedule_response_200.py
+++ b/src/qualer_sdk/models/create_order_by_schedule_response_200.py
@@ -16,14 +16,12 @@ class CreateOrderByScheduleResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_order_by_schedule_response_200 = cls()
-
         create_order_by_schedule_response_200.additional_properties = d
         return create_order_by_schedule_response_200
 

--- a/src/qualer_sdk/models/create_post_2_response_200.py
+++ b/src/qualer_sdk/models/create_post_2_response_200.py
@@ -16,14 +16,12 @@ class CreatePost2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_post_2_response_200 = cls()
-
         create_post_2_response_200.additional_properties = d
         return create_post_2_response_200
 

--- a/src/qualer_sdk/models/create_work_item_task_response_200.py
+++ b/src/qualer_sdk/models/create_work_item_task_response_200.py
@@ -16,14 +16,12 @@ class CreateWorkItemTaskResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_work_item_task_response_200 = cls()
-
         create_work_item_task_response_200.additional_properties = d
         return create_work_item_task_response_200
 

--- a/src/qualer_sdk/models/create_work_order_parts_response_204.py
+++ b/src/qualer_sdk/models/create_work_order_parts_response_204.py
@@ -16,14 +16,12 @@ class CreateWorkOrderPartsResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_work_order_parts_response_204 = cls()
-
         create_work_order_parts_response_204.additional_properties = d
         return create_work_order_parts_response_204
 

--- a/src/qualer_sdk/models/create_work_order_task_response_204.py
+++ b/src/qualer_sdk/models/create_work_order_task_response_204.py
@@ -16,14 +16,12 @@ class CreateWorkOrderTaskResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         create_work_order_task_response_204 = cls()
-
         create_work_order_task_response_204.additional_properties = d
         return create_work_order_task_response_204
 

--- a/src/qualer_sdk/models/delete_delete_2_response_200.py
+++ b/src/qualer_sdk/models/delete_delete_2_response_200.py
@@ -16,14 +16,12 @@ class DeleteDelete2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_delete_2_response_200 = cls()
-
         delete_delete_2_response_200.additional_properties = d
         return delete_delete_2_response_200
 

--- a/src/qualer_sdk/models/delete_department_response_204.py
+++ b/src/qualer_sdk/models/delete_department_response_204.py
@@ -16,14 +16,12 @@ class DeleteDepartmentResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_department_response_204 = cls()
-
         delete_department_response_204.additional_properties = d
         return delete_department_response_204
 

--- a/src/qualer_sdk/models/delete_employee_department_response_204.py
+++ b/src/qualer_sdk/models/delete_employee_department_response_204.py
@@ -16,14 +16,12 @@ class DeleteEmployeeDepartmentResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_employee_department_response_204 = cls()
-
         delete_employee_department_response_204.additional_properties = d
         return delete_employee_department_response_204
 

--- a/src/qualer_sdk/models/delete_response_200.py
+++ b/src/qualer_sdk/models/delete_response_200.py
@@ -16,14 +16,12 @@ class DeleteResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_response_200 = cls()
-
         delete_response_200.additional_properties = d
         return delete_response_200
 

--- a/src/qualer_sdk/models/delete_work_item_image_response_200.py
+++ b/src/qualer_sdk/models/delete_work_item_image_response_200.py
@@ -16,14 +16,12 @@ class DeleteWorkItemImageResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_work_item_image_response_200 = cls()
-
         delete_work_item_image_response_200.additional_properties = d
         return delete_work_item_image_response_200
 

--- a/src/qualer_sdk/models/delete_work_item_task_response_200.py
+++ b/src/qualer_sdk/models/delete_work_item_task_response_200.py
@@ -16,14 +16,12 @@ class DeleteWorkItemTaskResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_work_item_task_response_200 = cls()
-
         delete_work_item_task_response_200.additional_properties = d
         return delete_work_item_task_response_200
 

--- a/src/qualer_sdk/models/delete_work_order_task_delete_2_response_204.py
+++ b/src/qualer_sdk/models/delete_work_order_task_delete_2_response_204.py
@@ -16,14 +16,12 @@ class DeleteWorkOrderTaskDelete2Response204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_work_order_task_delete_2_response_204 = cls()
-
         delete_work_order_task_delete_2_response_204.additional_properties = d
         return delete_work_order_task_delete_2_response_204
 

--- a/src/qualer_sdk/models/delete_work_order_task_response_204.py
+++ b/src/qualer_sdk/models/delete_work_order_task_response_204.py
@@ -16,14 +16,12 @@ class DeleteWorkOrderTaskResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delete_work_order_task_response_204 = cls()
-
         delete_work_order_task_response_204.additional_properties = d
         return delete_work_order_task_response_204
 

--- a/src/qualer_sdk/models/get_client_attributes_response_200.py
+++ b/src/qualer_sdk/models/get_client_attributes_response_200.py
@@ -16,14 +16,12 @@ class GetClientAttributesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         get_client_attributes_response_200 = cls()
-
         get_client_attributes_response_200.additional_properties = d
         return get_client_attributes_response_200
 

--- a/src/qualer_sdk/models/get_get_6_response_200.py
+++ b/src/qualer_sdk/models/get_get_6_response_200.py
@@ -16,14 +16,12 @@ class GetGet6Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         get_get_6_response_200 = cls()
-
         get_get_6_response_200.additional_properties = d
         return get_get_6_response_200
 

--- a/src/qualer_sdk/models/get_order_status_response_200.py
+++ b/src/qualer_sdk/models/get_order_status_response_200.py
@@ -16,14 +16,12 @@ class GetOrderStatusResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         get_order_status_response_200 = cls()
-
         get_order_status_response_200.additional_properties = d
         return get_order_status_response_200
 

--- a/src/qualer_sdk/models/get_work_item_charges_response_200.py
+++ b/src/qualer_sdk/models/get_work_item_charges_response_200.py
@@ -16,14 +16,12 @@ class GetWorkItemChargesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         get_work_item_charges_response_200 = cls()
-
         get_work_item_charges_response_200.additional_properties = d
         return get_work_item_charges_response_200
 

--- a/src/qualer_sdk/models/get_work_item_task_response_200.py
+++ b/src/qualer_sdk/models/get_work_item_task_response_200.py
@@ -16,14 +16,12 @@ class GetWorkItemTaskResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         get_work_item_task_response_200 = cls()
-
         get_work_item_task_response_200.additional_properties = d
         return get_work_item_task_response_200
 

--- a/src/qualer_sdk/models/logout_response_200.py
+++ b/src/qualer_sdk/models/logout_response_200.py
@@ -16,14 +16,12 @@ class LogoutResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         logout_response_200 = cls()
-
         logout_response_200.additional_properties = d
         return logout_response_200
 

--- a/src/qualer_sdk/models/order_cancel_response_200.py
+++ b/src/qualer_sdk/models/order_cancel_response_200.py
@@ -16,14 +16,12 @@ class OrderCancelResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         order_cancel_response_200 = cls()
-
         order_cancel_response_200.additional_properties = d
         return order_cancel_response_200
 

--- a/src/qualer_sdk/models/post_asset_images_response_200.py
+++ b/src/qualer_sdk/models/post_asset_images_response_200.py
@@ -16,14 +16,12 @@ class PostAssetImagesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         post_asset_images_response_200 = cls()
-
         post_asset_images_response_200.additional_properties = d
         return post_asset_images_response_200
 

--- a/src/qualer_sdk/models/post_employee_location_response_200.py
+++ b/src/qualer_sdk/models/post_employee_location_response_200.py
@@ -16,14 +16,12 @@ class PostEmployeeLocationResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         post_employee_location_response_200 = cls()
-
         post_employee_location_response_200.additional_properties = d
         return post_employee_location_response_200
 

--- a/src/qualer_sdk/models/post_response_200.py
+++ b/src/qualer_sdk/models/post_response_200.py
@@ -16,14 +16,12 @@ class PostResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         post_response_200 = cls()
-
         post_response_200.additional_properties = d
         return post_response_200
 

--- a/src/qualer_sdk/models/product_response_200.py
+++ b/src/qualer_sdk/models/product_response_200.py
@@ -16,14 +16,12 @@ class ProductResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         product_response_200 = cls()
-
         product_response_200.additional_properties = d
         return product_response_200
 

--- a/src/qualer_sdk/models/put_charges_put_2_response_200.py
+++ b/src/qualer_sdk/models/put_charges_put_2_response_200.py
@@ -16,14 +16,12 @@ class PutChargesPut2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         put_charges_put_2_response_200 = cls()
-
         put_charges_put_2_response_200.additional_properties = d
         return put_charges_put_2_response_200
 

--- a/src/qualer_sdk/models/put_charges_response_200.py
+++ b/src/qualer_sdk/models/put_charges_response_200.py
@@ -16,14 +16,12 @@ class PutChargesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         put_charges_response_200 = cls()
-
         put_charges_response_200.additional_properties = d
         return put_charges_response_200
 

--- a/src/qualer_sdk/models/put_inventory_count_response_200.py
+++ b/src/qualer_sdk/models/put_inventory_count_response_200.py
@@ -16,14 +16,12 @@ class PutInventoryCountResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         put_inventory_count_response_200 = cls()
-
         put_inventory_count_response_200.additional_properties = d
         return put_inventory_count_response_200
 

--- a/src/qualer_sdk/models/qualer_api_models_account_from_employee_messages_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_from_employee_messages_model.py
@@ -21,9 +21,7 @@ class AccountFromEmployeeMessagesModel:
 
     def to_dict(self) -> Dict[str, Any]:
         period = self.period
-
         site_id = self.site_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AccountFromEmployeeMessagesModel:
             field_dict["Period"] = period
         if site_id is not None:
             field_dict["SiteId"] = site_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         period = d.pop("Period", None)
-
         site_id = d.pop("SiteId", None)
-
         qualer_api_models_account_from_employee_messages_model = cls(
             period=period,
             site_id=site_id,
         )
-
         qualer_api_models_account_from_employee_messages_model.additional_properties = d
         return qualer_api_models_account_from_employee_messages_model
 

--- a/src/qualer_sdk/models/qualer_api_models_account_from_login_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_from_login_response_model.py
@@ -22,13 +22,11 @@ class AccountFromLoginResponseModel:
         token: Optional[str] = None
         if self.token:
             token = str(self.token)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if token is not None:
             field_dict["Token"] = token
-
         return field_dict
 
     @classmethod
@@ -40,11 +38,9 @@ class AccountFromLoginResponseModel:
             token = None
         else:
             token = UUID(_token)
-
         qualer_api_models_account_from_login_response_model = cls(
             token=token,
         )
-
         qualer_api_models_account_from_login_response_model.additional_properties = d
         return qualer_api_models_account_from_login_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_message_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_message_response_model.py
@@ -19,24 +19,20 @@ class AccountToEmployeeEventMessageResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         message = self.message
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if message is not None:
             field_dict["Message"] = message
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         message = d.pop("Message", None)
-
         qualer_api_models_account_to_employee_event_message_response_model = cls(
             message=message,
         )
-
         qualer_api_models_account_to_employee_event_message_response_model.additional_properties = d
         return qualer_api_models_account_to_employee_event_message_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_employee_event_response_model.py
@@ -29,17 +29,12 @@ class AccountToEmployeeEventResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         subject = self.subject
-
         created_on_utc: Optional[str] = None
         if self.created_on_utc:
             created_on_utc = self.created_on_utc.isoformat()
-
         event_type_id = self.event_type_id
-
         event_type_group = self.event_type_group
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -53,27 +48,21 @@ class AccountToEmployeeEventResponseModel:
             field_dict["EventTypeId"] = event_type_id
         if event_type_group is not None:
             field_dict["EventTypeGroup"] = event_type_group
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         subject = d.pop("Subject", None)
-
         _created_on_utc = d.pop("CreatedOnUtc", None)
         created_on_utc: Optional[datetime.datetime]
         if not _created_on_utc:
             created_on_utc = None
         else:
             created_on_utc = isoparse(_created_on_utc)
-
         event_type_id = d.pop("EventTypeId", None)
-
         event_type_group = d.pop("EventTypeGroup", None)
-
         qualer_api_models_account_to_employee_event_response_model = cls(
             id=id,
             subject=subject,
@@ -81,7 +70,6 @@ class AccountToEmployeeEventResponseModel:
             event_type_id=event_type_id,
             event_type_group=event_type_group,
         )
-
         qualer_api_models_account_to_employee_event_response_model.additional_properties = d
         return qualer_api_models_account_to_employee_event_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_account_to_logout_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_account_to_logout_model.py
@@ -19,24 +19,20 @@ class AccountToLogoutModel:
 
     def to_dict(self) -> Dict[str, Any]:
         logout_action = self.logout_action
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if logout_action is not None:
             field_dict["LogoutAction"] = logout_action
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         logout_action = d.pop("LogoutAction", None)
-
         qualer_api_models_account_to_logout_model = cls(
             logout_action=logout_action,
         )
-
         qualer_api_models_account_to_logout_model.additional_properties = d
         return qualer_api_models_account_to_logout_model
 

--- a/src/qualer_sdk/models/qualer_api_models_address_address_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_address_address_model.py
@@ -47,35 +47,20 @@ class AddressAddressModel:
 
     def to_dict(self) -> Dict[str, Any]:
         first_name = self.first_name
-
         last_name = self.last_name
-
         email = self.email
-
         company = self.company
-
         city = self.city
-
         address_1 = self.address_1
-
         address_2 = self.address_2
-
         zip_postal_code = self.zip_postal_code
-
         phone_number = self.phone_number
-
         fax_number = self.fax_number
-
         attention_1 = self.attention_1
-
         attention_2 = self.attention_2
-
         country = self.country
-
         state_province = self.state_province
-
         state_province_abbreviation = self.state_province_abbreviation
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -109,42 +94,26 @@ class AddressAddressModel:
             field_dict["StateProvince"] = state_province
         if state_province_abbreviation is not None:
             field_dict["StateProvinceAbbreviation"] = state_province_abbreviation
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         email = d.pop("Email", None)
-
         company = d.pop("Company", None)
-
         city = d.pop("City", None)
-
         address_1 = d.pop("Address1", None)
-
         address_2 = d.pop("Address2", None)
-
         zip_postal_code = d.pop("ZipPostalCode", None)
-
         phone_number = d.pop("PhoneNumber", None)
-
         fax_number = d.pop("FaxNumber", None)
-
         attention_1 = d.pop("Attention1", None)
-
         attention_2 = d.pop("Attention2", None)
-
         country = d.pop("Country", None)
-
         state_province = d.pop("StateProvince", None)
-
         state_province_abbreviation = d.pop("StateProvinceAbbreviation", None)
-
         qualer_api_models_address_address_model = cls(
             first_name=first_name,
             last_name=last_name,
@@ -162,7 +131,6 @@ class AddressAddressModel:
             state_province=state_province,
             state_province_abbreviation=state_province_abbreviation,
         )
-
         qualer_api_models_address_address_model.additional_properties = d
         return qualer_api_models_address_address_model
 

--- a/src/qualer_sdk/models/qualer_api_models_address_to_address_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_address_to_address_response_model.py
@@ -47,35 +47,20 @@ class AddressToAddressResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         first_name = self.first_name
-
         last_name = self.last_name
-
         email = self.email
-
         company = self.company
-
         city = self.city
-
         address_1 = self.address_1
-
         address_2 = self.address_2
-
         zip_postal_code = self.zip_postal_code
-
         phone_number = self.phone_number
-
         fax_number = self.fax_number
-
         attention_1 = self.attention_1
-
         attention_2 = self.attention_2
-
         country = self.country
-
         state_province = self.state_province
-
         state_province_abbreviation = self.state_province_abbreviation
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -109,42 +94,26 @@ class AddressToAddressResponseModel:
             field_dict["StateProvince"] = state_province
         if state_province_abbreviation is not None:
             field_dict["StateProvinceAbbreviation"] = state_province_abbreviation
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         email = d.pop("Email", None)
-
         company = d.pop("Company", None)
-
         city = d.pop("City", None)
-
         address_1 = d.pop("Address1", None)
-
         address_2 = d.pop("Address2", None)
-
         zip_postal_code = d.pop("ZipPostalCode", None)
-
         phone_number = d.pop("PhoneNumber", None)
-
         fax_number = d.pop("FaxNumber", None)
-
         attention_1 = d.pop("Attention1", None)
-
         attention_2 = d.pop("Attention2", None)
-
         country = d.pop("Country", None)
-
         state_province = d.pop("StateProvince", None)
-
         state_province_abbreviation = d.pop("StateProvinceAbbreviation", None)
-
         qualer_api_models_address_to_address_response_model = cls(
             first_name=first_name,
             last_name=last_name,
@@ -162,7 +131,6 @@ class AddressToAddressResponseModel:
             state_province=state_province,
             state_province_abbreviation=state_province_abbreviation,
         )
-
         qualer_api_models_address_to_address_response_model.additional_properties = d
         return qualer_api_models_address_to_address_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_attributes_to_asset_attributes_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_attributes_to_asset_attributes_response.py
@@ -21,9 +21,7 @@ class AssetAttributesToAssetAttributesResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AssetAttributesToAssetAttributesResponse:
             field_dict["Name"] = name
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_asset_attributes_to_asset_attributes_response = cls(
             name=name,
             value=value,
         )
-
         qualer_api_models_asset_attributes_to_asset_attributes_response.additional_properties = d
         return qualer_api_models_asset_attributes_to_asset_attributes_response
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_client_asset_manager_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_client_asset_manager_list_model.py
@@ -25,13 +25,9 @@ class AssetFromClientAssetManagerListModel:
 
     def to_dict(self) -> Dict[str, Any]:
         filter_type = self.filter_type
-
         search_string = self.search_string
-
         page = self.page
-
         page_size = self.page_size
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class AssetFromClientAssetManagerListModel:
             field_dict["Page"] = page
         if page_size is not None:
             field_dict["PageSize"] = page_size
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         filter_type = d.pop("FilterType", None)
-
         search_string = d.pop("SearchString", None)
-
         page = d.pop("Page", None)
-
         page_size = d.pop("PageSize", None)
-
         qualer_api_models_asset_from_client_asset_manager_list_model = cls(
             filter_type=filter_type,
             search_string=search_string,
             page=page,
             page_size=page_size,
         )
-
         qualer_api_models_asset_from_client_asset_manager_list_model.additional_properties = d
         return qualer_api_models_asset_from_client_asset_manager_list_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_counter_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_counter_model.py
@@ -19,24 +19,20 @@ class AssetFromGetAssetManagerCounterModel:
 
     def to_dict(self) -> Dict[str, Any]:
         search_string = self.search_string
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if search_string is not None:
             field_dict["SearchString"] = search_string
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         search_string = d.pop("SearchString", None)
-
         qualer_api_models_asset_from_get_asset_manager_counter_model = cls(
             search_string=search_string,
         )
-
         qualer_api_models_asset_from_get_asset_manager_counter_model.additional_properties = d
         return qualer_api_models_asset_from_get_asset_manager_counter_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_get_asset_manager_list_model.py
@@ -25,13 +25,9 @@ class AssetFromGetAssetManagerListModel:
 
     def to_dict(self) -> Dict[str, Any]:
         filter_type = self.filter_type
-
         search_string = self.search_string
-
         page = self.page
-
         page_size = self.page_size
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class AssetFromGetAssetManagerListModel:
             field_dict["Page"] = page
         if page_size is not None:
             field_dict["PageSize"] = page_size
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         filter_type = d.pop("FilterType", None)
-
         search_string = d.pop("SearchString", None)
-
         page = d.pop("Page", None)
-
         page_size = d.pop("PageSize", None)
-
         qualer_api_models_asset_from_get_asset_manager_list_model = cls(
             filter_type=filter_type,
             search_string=search_string,
             page=page,
             page_size=page_size,
         )
-
         qualer_api_models_asset_from_get_asset_manager_list_model.additional_properties = d
         return qualer_api_models_asset_from_get_asset_manager_list_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_class_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_class_model.py
@@ -19,24 +19,20 @@ class AssetFromUpdateAssetClassModel:
 
     def to_dict(self) -> Dict[str, Any]:
         class_ = self.class_
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if class_ is not None:
             field_dict["Class"] = class_
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         class_ = d.pop("Class", None)
-
         qualer_api_models_asset_from_update_asset_class_model = cls(
             class_=class_,
         )
-
         qualer_api_models_asset_from_update_asset_class_model.additional_properties = d
         return qualer_api_models_asset_from_update_asset_class_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_department_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_department_model.py
@@ -19,24 +19,20 @@ class AssetFromUpdateAssetDepartmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         department_name = self.department_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if department_name is not None:
             field_dict["DepartmentName"] = department_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         department_name = d.pop("DepartmentName", None)
-
         qualer_api_models_asset_from_update_asset_department_model = cls(
             department_name=department_name,
         )
-
         qualer_api_models_asset_from_update_asset_department_model.additional_properties = d
         return qualer_api_models_asset_from_update_asset_department_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_maintenance_service_dat.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_maintenance_service_dat.py
@@ -25,9 +25,7 @@ class AssetFromUpdateAssetMaintenanceServiceDat:
         reset_service_date: Optional[str] = None
         if self.reset_service_date:
             reset_service_date = self.reset_service_date.isoformat()
-
         reset_service_task = self.reset_service_task
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -35,7 +33,6 @@ class AssetFromUpdateAssetMaintenanceServiceDat:
             field_dict["ResetServiceDate"] = reset_service_date
         if reset_service_task is not None:
             field_dict["ResetServiceTask"] = reset_service_task
-
         return field_dict
 
     @classmethod
@@ -47,14 +44,11 @@ class AssetFromUpdateAssetMaintenanceServiceDat:
             reset_service_date = None
         else:
             reset_service_date = isoparse(_reset_service_date)
-
         reset_service_task = d.pop("ResetServiceTask", None)
-
         qualer_api_models_asset_from_update_asset_maintenance_service_dat = cls(
             reset_service_date=reset_service_date,
             reset_service_task=reset_service_task,
         )
-
         qualer_api_models_asset_from_update_asset_maintenance_service_dat.additional_properties = d
         return qualer_api_models_asset_from_update_asset_maintenance_service_dat
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_room_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_asset_room_model.py
@@ -19,24 +19,20 @@ class AssetFromUpdateAssetRoomModel:
 
     def to_dict(self) -> Dict[str, Any]:
         room_number = self.room_number
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if room_number is not None:
             field_dict["RoomNumber"] = room_number
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         room_number = d.pop("RoomNumber", None)
-
         qualer_api_models_asset_from_update_asset_room_model = cls(
             room_number=room_number,
         )
-
         qualer_api_models_asset_from_update_asset_room_model.additional_properties = d
         return qualer_api_models_asset_from_update_asset_room_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_filter_preference_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_filter_preference_model.py
@@ -29,27 +29,10 @@ class AssetFromUpdateFilterPreferenceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         filter_type = self.filter_type
-
         within_days = self.within_days
-
         use_date_range = self.use_date_range
-
-        start_date: Optional[str]
-        if not self.start_date:
-            start_date = None
-        elif isinstance(self.start_date, datetime.datetime):
-            start_date = self.start_date.isoformat()
-        else:
-            start_date = self.start_date
-
-        end_date: Optional[str]
-        if not self.end_date:
-            end_date = None
-        elif isinstance(self.end_date, datetime.datetime):
-            end_date = self.end_date.isoformat()
-        else:
-            end_date = self.end_date
-
+        start_date = self.start_date.isoformat() if self.start_date else None
+        end_date = self.end_date.isoformat() if self.end_date else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -63,18 +46,14 @@ class AssetFromUpdateFilterPreferenceModel:
             field_dict["StartDate"] = start_date
         if end_date is not None:
             field_dict["EndDate"] = end_date
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         filter_type = d.pop("FilterType", None)
-
         within_days = d.pop("WithinDays", None)
-
         use_date_range = d.pop("UseDateRange", None)
-
         def _parse_start_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -82,14 +61,11 @@ class AssetFromUpdateFilterPreferenceModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 start_date_type_0 = isoparse(data)
-
                 return start_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         start_date = _parse_start_date(d.pop("StartDate", None))
-
         def _parse_end_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -97,14 +73,11 @@ class AssetFromUpdateFilterPreferenceModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 end_date_type_0 = isoparse(data)
-
                 return end_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         end_date = _parse_end_date(d.pop("EndDate", None))
-
         qualer_api_models_asset_from_update_filter_preference_model = cls(
             filter_type=filter_type,
             within_days=within_days,
@@ -112,7 +85,6 @@ class AssetFromUpdateFilterPreferenceModel:
             start_date=start_date,
             end_date=end_date,
         )
-
         qualer_api_models_asset_from_update_filter_preference_model.additional_properties = d
         return qualer_api_models_asset_from_update_filter_preference_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_from_update_room_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_from_update_room_model.py
@@ -21,9 +21,7 @@ class AssetFromUpdateRoomModel:
 
     def to_dict(self) -> Dict[str, Any]:
         room = self.room
-
         tracking_id = self.tracking_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AssetFromUpdateRoomModel:
             field_dict["Room"] = room
         if tracking_id is not None:
             field_dict["TrackingId"] = tracking_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         room = d.pop("Room", None)
-
         tracking_id = d.pop("TrackingId", None)
-
         qualer_api_models_asset_from_update_room_model = cls(
             room=room,
             tracking_id=tracking_id,
         )
-
         qualer_api_models_asset_from_update_room_model.additional_properties = d
         return qualer_api_models_asset_from_update_room_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_pools_to_asset_pool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_pools_to_asset_pool_model.py
@@ -21,9 +21,7 @@ class AssetPoolsToAssetPoolModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_pool_id = self.asset_pool_id
-
         asset_pool_name = self.asset_pool_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AssetPoolsToAssetPoolModel:
             field_dict["AssetPoolId"] = asset_pool_id
         if asset_pool_name is not None:
             field_dict["AssetPoolName"] = asset_pool_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_pool_id = d.pop("AssetPoolId", None)
-
         asset_pool_name = d.pop("AssetPoolName", None)
-
         qualer_api_models_asset_pools_to_asset_pool_model = cls(
             asset_pool_id=asset_pool_id,
             asset_pool_name=asset_pool_name,
         )
-
         qualer_api_models_asset_pools_to_asset_pool_model.additional_properties = d
         return qualer_api_models_asset_pools_to_asset_pool_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_close_asset_reservations_model.py
@@ -29,17 +29,11 @@ class AssetReservationFromCloseAssetReservationsModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         area_id = self.area_id
-
         product_id = self.product_id
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         reservation_id = self.reservation_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -55,24 +49,17 @@ class AssetReservationFromCloseAssetReservationsModel:
             field_dict["AssetTag"] = asset_tag
         if reservation_id is not None:
             field_dict["ReservationId"] = reservation_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         area_id = d.pop("AreaId", None)
-
         product_id = d.pop("ProductId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         reservation_id = d.pop("ReservationId", None)
-
         qualer_api_models_asset_reservation_from_close_asset_reservations_model = cls(
             asset_id=asset_id,
             area_id=area_id,
@@ -81,7 +68,6 @@ class AssetReservationFromCloseAssetReservationsModel:
             asset_tag=asset_tag,
             reservation_id=reservation_id,
         )
-
         qualer_api_models_asset_reservation_from_close_asset_reservations_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_get_asset_reservations_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_get_asset_reservations_model.py
@@ -37,23 +37,15 @@ class AssetReservationFromGetAssetReservationsModel:
         from_: Optional[str] = None
         if self.from_:
             from_ = self.from_.isoformat()
-
         to: Optional[str] = None
         if self.to:
             to = self.to.isoformat()
-
         asset_id = self.asset_id
-
         area_id = self.area_id
-
         product_id = self.product_id
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         reservation_id = self.reservation_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -73,7 +65,6 @@ class AssetReservationFromGetAssetReservationsModel:
             field_dict["AssetTag"] = asset_tag
         if reservation_id is not None:
             field_dict["ReservationId"] = reservation_id
-
         return field_dict
 
     @classmethod
@@ -85,26 +76,18 @@ class AssetReservationFromGetAssetReservationsModel:
             from_ = None
         else:
             from_ = isoparse(_from_)
-
         _to = d.pop("To", None)
         to: Optional[datetime.datetime]
         if not _to:
             to = None
         else:
             to = isoparse(_to)
-
         asset_id = d.pop("AssetId", None)
-
         area_id = d.pop("AreaId", None)
-
         product_id = d.pop("ProductId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         reservation_id = d.pop("ReservationId", None)
-
         qualer_api_models_asset_reservation_from_get_asset_reservations_model = cls(
             from_=from_,
             to=to,
@@ -115,7 +98,6 @@ class AssetReservationFromGetAssetReservationsModel:
             asset_tag=asset_tag,
             reservation_id=reservation_id,
         )
-
         qualer_api_models_asset_reservation_from_get_asset_reservations_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.py
@@ -37,27 +37,18 @@ class AssetReservationFromUpsertAssetReservationModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         product_id = self.product_id
-
         reservation_id = self.reservation_id
-
         service_order_id = self.service_order_id
-
         begin_date: Optional[str] = None
         if self.begin_date:
             begin_date = self.begin_date.isoformat()
-
         end_date: Optional[str] = None
         if self.end_date:
             end_date = self.end_date.isoformat()
-
         reserved_by = self.reserved_by
-
         reserved_by_name = self.reserved_by_name
-
         comments = self.comments
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -79,40 +70,30 @@ class AssetReservationFromUpsertAssetReservationModel:
             field_dict["ReservedByName"] = reserved_by_name
         if comments is not None:
             field_dict["Comments"] = comments
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         product_id = d.pop("ProductId", None)
-
         reservation_id = d.pop("ReservationId", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         _begin_date = d.pop("BeginDate", None)
         begin_date: Optional[datetime.datetime]
         if not _begin_date:
             begin_date = None
         else:
             begin_date = isoparse(_begin_date)
-
         _end_date = d.pop("EndDate", None)
         end_date: Optional[datetime.datetime]
         if not _end_date:
             end_date = None
         else:
             end_date = isoparse(_end_date)
-
         reserved_by = d.pop("ReservedBy", None)
-
         reserved_by_name = d.pop("ReservedByName", None)
-
         comments = d.pop("Comments", None)
-
         qualer_api_models_asset_reservation_from_upsert_asset_reservation_model = cls(
             asset_id=asset_id,
             product_id=product_id,
@@ -124,7 +105,6 @@ class AssetReservationFromUpsertAssetReservationModel:
             reserved_by_name=reserved_by_name,
             comments=comments,
         )
-
         qualer_api_models_asset_reservation_from_upsert_asset_reservation_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_asset_reservation_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_asset_reservation_response.py
@@ -45,39 +45,27 @@ class AssetReservationToAssetReservationResponse:
         original_begin_date: Optional[str] = None
         if self.original_begin_date:
             original_begin_date = self.original_begin_date.isoformat()
-
         original_end_date: Optional[str] = None
         if self.original_end_date:
             original_end_date = self.original_end_date.isoformat()
-
         begin_date: Optional[str] = None
         if self.begin_date:
             begin_date = self.begin_date.isoformat()
-
         end_date: Optional[str] = None
         if self.end_date:
             end_date = self.end_date.isoformat()
-
         reserved_on: Optional[str] = None
         if self.reserved_on:
             reserved_on = self.reserved_on.isoformat()
-
         reserved_on_utc: Optional[str] = None
         if self.reserved_on_utc:
             reserved_on_utc = self.reserved_on_utc.isoformat()
-
         comments = self.comments
-
         product_id = self.product_id
-
         asset_id = self.asset_id
-
         service_order_id = self.service_order_id
-
         reserved_by_id = self.reserved_by_id
-
         reserved_by_name = self.reserved_by_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -105,7 +93,6 @@ class AssetReservationToAssetReservationResponse:
             field_dict["ReservedById"] = reserved_by_id
         if reserved_by_name is not None:
             field_dict["ReservedByName"] = reserved_by_name
-
         return field_dict
 
     @classmethod
@@ -117,54 +104,42 @@ class AssetReservationToAssetReservationResponse:
             original_begin_date = None
         else:
             original_begin_date = isoparse(_original_begin_date)
-
         _original_end_date = d.pop("OriginalEndDate", None)
         original_end_date: Optional[datetime.datetime]
         if not _original_end_date:
             original_end_date = None
         else:
             original_end_date = isoparse(_original_end_date)
-
         _begin_date = d.pop("BeginDate", None)
         begin_date: Optional[datetime.datetime]
         if not _begin_date:
             begin_date = None
         else:
             begin_date = isoparse(_begin_date)
-
         _end_date = d.pop("EndDate", None)
         end_date: Optional[datetime.datetime]
         if not _end_date:
             end_date = None
         else:
             end_date = isoparse(_end_date)
-
         _reserved_on = d.pop("ReservedOn", None)
         reserved_on: Optional[datetime.datetime]
         if not _reserved_on:
             reserved_on = None
         else:
             reserved_on = isoparse(_reserved_on)
-
         _reserved_on_utc = d.pop("ReservedOnUtc", None)
         reserved_on_utc: Optional[datetime.datetime]
         if not _reserved_on_utc:
             reserved_on_utc = None
         else:
             reserved_on_utc = isoparse(_reserved_on_utc)
-
         comments = d.pop("Comments", None)
-
         product_id = d.pop("ProductId", None)
-
         asset_id = d.pop("AssetId", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         reserved_by_id = d.pop("ReservedById", None)
-
         reserved_by_name = d.pop("ReservedByName", None)
-
         qualer_api_models_asset_reservation_to_asset_reservation_response = cls(
             original_begin_date=original_begin_date,
             original_end_date=original_end_date,
@@ -179,7 +154,6 @@ class AssetReservationToAssetReservationResponse:
             reserved_by_id=reserved_by_id,
             reserved_by_name=reserved_by_name,
         )
-
         qualer_api_models_asset_reservation_to_asset_reservation_response.additional_properties = d
         return qualer_api_models_asset_reservation_to_asset_reservation_response
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_upsert_asset_reservation_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_reservation_to_upsert_asset_reservation_response.py
@@ -19,24 +19,20 @@ class AssetReservationToUpsertAssetReservationResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_reservation_id = self.asset_reservation_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if asset_reservation_id is not None:
             field_dict["AssetReservationId"] = asset_reservation_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_reservation_id = d.pop("AssetReservationId", None)
-
         qualer_api_models_asset_reservation_to_upsert_asset_reservation_response = cls(
             asset_reservation_id=asset_reservation_id,
         )
-
         qualer_api_models_asset_reservation_to_upsert_asset_reservation_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_add_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_add_asset_service_record_model.py
@@ -83,21 +83,15 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
         order_item_number = self.order_item_number
-
         certificate_number = self.certificate_number
-
         result_status: Optional[str]
         if not self.result_status:
             result_status = None
         else:
             result_status: Optional[str]
-
             if not self.result_status:
-
                 result_status = None
             else:
                 result_status = self.result_status
@@ -106,9 +100,7 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
             as_found_result = None
         else:
             as_found_result: Optional[str]
-
             if not self.as_found_result:
-
                 as_found_result = None
             else:
                 as_found_result = self.as_found_result
@@ -117,9 +109,7 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
             as_left_result = None
         else:
             as_left_result: Optional[str]
-
             if not self.as_left_result:
-
                 as_left_result = None
             else:
                 as_left_result = self.as_left_result
@@ -128,157 +118,54 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
             applied_interval = None
         else:
             applied_interval = self.applied_interval
-
         as_found_tolerance: Optional[float]
         if not self.as_found_tolerance:
             as_found_tolerance = None
         else:
             as_found_tolerance = self.as_found_tolerance
-
         as_left_tolerance: Optional[float]
         if not self.as_left_tolerance:
             as_left_tolerance = None
         else:
             as_left_tolerance = self.as_left_tolerance
-
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
-        serial_number: Optional[str]
-        if not self.serial_number:
-            serial_number = None
-        else:
-            serial_number = self.serial_number
-
-        asset_tag: Optional[str]
-        if not self.asset_tag:
-            asset_tag = None
-        else:
-            asset_tag = self.asset_tag
-
-        asset_user: Optional[str]
-        if not self.asset_user:
-            asset_user = None
-        else:
-            asset_user = self.asset_user
-
-        service_notes: Optional[str]
-        if not self.service_notes:
-            service_notes = None
-        else:
-            service_notes = self.service_notes
-
-        due_date: Optional[str]
-        if not self.due_date:
-            due_date = None
-        elif isinstance(self.due_date, datetime.datetime):
-            due_date = self.due_date.isoformat()
-        else:
-            due_date = self.due_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        provider_technician: Optional[str]
-        if not self.provider_technician:
-            provider_technician = None
-        else:
-            provider_technician = self.provider_technician
-
-        provider_phone: Optional[str]
-        if not self.provider_phone:
-            provider_phone = None
-        else:
-            provider_phone = self.provider_phone
-
-        provider_company: Optional[str]
-        if not self.provider_company:
-            provider_company = None
-        else:
-            provider_company = self.provider_company
-
-        service_level: Optional[str]
-        if not self.service_level:
-            service_level = None
-        else:
-            service_level = self.service_level
-
-        service_level_code: Optional[str]
-        if not self.service_level_code:
-            service_level_code = None
-        else:
-            service_level_code = self.service_level_code
-
-        next_service_level: Optional[str]
-        if not self.next_service_level:
-            next_service_level = None
-        else:
-            next_service_level = self.next_service_level
-
-        next_service_level_code: Optional[str]
-        if not self.next_service_level_code:
-            next_service_level_code = None
-        else:
-            next_service_level_code = self.next_service_level_code
-
-        asset_name: Optional[str]
-        if not self.asset_name:
-            asset_name = None
-        else:
-            asset_name = self.asset_name
-
-        asset_description: Optional[str]
-        if not self.asset_description:
-            asset_description = None
-        else:
-            asset_description = self.asset_description
-
+        service_date = self.service_date.isoformat() if self.service_date else None
+        serial_number = self.serial_number
+        asset_tag = self.asset_tag
+        asset_user = self.asset_user
+        service_notes = self.service_notes
+        due_date = self.due_date.isoformat() if self.due_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        provider_technician = self.provider_technician
+        provider_phone = self.provider_phone
+        provider_company = self.provider_company
+        service_level = self.service_level
+        service_level_code = self.service_level_code
+        next_service_level = self.next_service_level
+        next_service_level_code = self.next_service_level_code
+        asset_name = self.asset_name
+        asset_description = self.asset_description
         parts_charge: Optional[float]
         if not self.parts_charge:
             parts_charge = None
         else:
             parts_charge = self.parts_charge
-
         parts_charge_before_discount: Optional[float]
         if not self.parts_charge_before_discount:
             parts_charge_before_discount = None
         else:
             parts_charge_before_discount = self.parts_charge_before_discount
-
         service_charge: Optional[float]
         if not self.service_charge:
             service_charge = None
         else:
             service_charge = self.service_charge
-
         repairs_charge: Optional[float]
         if not self.repairs_charge:
             repairs_charge = None
         else:
             repairs_charge = self.repairs_charge
-
-        segment_name: Optional[str]
-        if not self.segment_name:
-            segment_name = None
-        else:
-            segment_name = self.segment_name
-
-        schedule_name: Optional[str]
-        if not self.schedule_name:
-            schedule_name = None
-        else:
-            schedule_name = self.schedule_name
-
+        segment_name = self.segment_name
+        schedule_name = self.schedule_name
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -346,62 +233,45 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
             field_dict["SegmentName"] = segment_name
         if schedule_name is not None:
             field_dict["ScheduleName"] = schedule_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_as_found_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_applied_interval(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         applied_interval = _parse_applied_interval(d.pop("AppliedInterval", None))
-
         def _parse_as_found_tolerance(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         as_found_tolerance = _parse_as_found_tolerance(d.pop("AsFoundTolerance", None))
-
         def _parse_as_left_tolerance(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         as_left_tolerance = _parse_as_left_tolerance(d.pop("AsLeftTolerance", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -409,42 +279,31 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_serial_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         serial_number = _parse_serial_number(d.pop("SerialNumber", None))
-
         def _parse_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag = _parse_asset_tag(d.pop("AssetTag", None))
-
         def _parse_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user = _parse_asset_user(d.pop("AssetUser", None))
-
         def _parse_service_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_notes = _parse_service_notes(d.pop("ServiceNotes", None))
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -452,14 +311,11 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_date_type_0 = isoparse(data)
-
                 return due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -469,125 +325,92 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_provider_technician(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician = _parse_provider_technician(d.pop("ProviderTechnician", None))
-
         def _parse_provider_phone(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_phone = _parse_provider_phone(d.pop("ProviderPhone", None))
-
         def _parse_provider_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_company = _parse_provider_company(d.pop("ProviderCompany", None))
-
         def _parse_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level = _parse_service_level(d.pop("ServiceLevel", None))
-
         def _parse_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_code = _parse_service_level_code(d.pop("ServiceLevelCode", None))
-
         def _parse_next_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level = _parse_next_service_level(d.pop("NextServiceLevel", None))
-
         def _parse_next_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level_code = _parse_next_service_level_code(
             d.pop("NextServiceLevelCode", None)
         )
-
         def _parse_asset_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_name = _parse_asset_name(d.pop("AssetName", None))
-
         def _parse_asset_description(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_description = _parse_asset_description(d.pop("AssetDescription", None))
-
         def _parse_parts_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge = _parse_parts_charge(d.pop("PartsCharge", None))
-
         def _parse_parts_charge_before_discount(
             data: object,
         ) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge_before_discount = _parse_parts_charge_before_discount(
             d.pop("PartsChargeBeforeDiscount", None)
         )
-
         def _parse_service_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge = _parse_service_charge(d.pop("ServiceCharge", None))
-
         def _parse_repairs_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_charge = _parse_repairs_charge(d.pop("RepairsCharge", None))
-
         def _parse_segment_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         segment_name = _parse_segment_name(d.pop("SegmentName", None))
-
         def _parse_schedule_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         schedule_name = _parse_schedule_name(d.pop("ScheduleName", None))
-
         qualer_api_models_asset_service_records_from_add_asset_service_record_model = cls(
             service_order_number=service_order_number,
             custom_order_number=custom_order_number,
@@ -622,7 +445,6 @@ class AssetServiceRecordsFromAddAssetServiceRecordModel:
             segment_name=segment_name,
             schedule_name=schedule_name,
         )
-
         qualer_api_models_asset_service_records_from_add_asset_service_record_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_download_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_download_model.py
@@ -21,9 +21,7 @@ class AssetServiceRecordsFromAsrDocumentDownloadModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_service_record_id = self.asset_service_record_id
-
         file_name = self.file_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AssetServiceRecordsFromAsrDocumentDownloadModel:
             field_dict["AssetServiceRecordId"] = asset_service_record_id
         if file_name is not None:
             field_dict["FileName"] = file_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         file_name = d.pop("FileName", None)
-
         qualer_api_models_asset_service_records_from_asr_document_download_model = cls(
             asset_service_record_id=asset_service_record_id,
             file_name=file_name,
         )
-
         qualer_api_models_asset_service_records_from_asr_document_download_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asr_document_model.py
@@ -19,24 +19,20 @@ class AssetServiceRecordsFromAsrDocumentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_service_record_id = self.asset_service_record_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if asset_service_record_id is not None:
             field_dict["AssetServiceRecordId"] = asset_service_record_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         qualer_api_models_asset_service_records_from_asr_document_model = cls(
             asset_service_record_id=asset_service_record_id,
         )
-
         qualer_api_models_asset_service_records_from_asr_document_model.additional_properties = d
         return qualer_api_models_asset_service_records_from_asr_document_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_filter_model.py
@@ -27,17 +27,13 @@ class AssetServiceRecordsFromAssetServiceRecordFilterModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         serial_number = self.serial_number
-
         from_: Optional[str] = None
         if self.from_:
             from_ = self.from_.isoformat()
-
         to: Optional[str] = None
         if self.to:
             to = self.to.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,37 +45,31 @@ class AssetServiceRecordsFromAssetServiceRecordFilterModel:
             field_dict["From"] = from_
         if to is not None:
             field_dict["To"] = to
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         _from_ = d.pop("From", None)
         from_: Optional[datetime.datetime]
         if not _from_:
             from_ = None
         else:
             from_ = isoparse(_from_)
-
         _to = d.pop("To", None)
         to: Optional[datetime.datetime]
         if not _to:
             to = None
         else:
             to = isoparse(_to)
-
         qualer_api_models_asset_service_records_from_asset_service_record_filter_model = cls(
             asset_id=asset_id,
             serial_number=serial_number,
             from_=from_,
             to=to,
         )
-
         qualer_api_models_asset_service_records_from_asset_service_record_filter_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_asset_service_record_model.py
@@ -19,24 +19,20 @@ class AssetServiceRecordsFromAssetServiceRecordModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_service_record_id = self.asset_service_record_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if asset_service_record_id is not None:
             field_dict["AssetServiceRecordId"] = asset_service_record_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         qualer_api_models_asset_service_records_from_asset_service_record_model = cls(
             asset_service_record_id=asset_service_record_id,
         )
-
         qualer_api_models_asset_service_records_from_asset_service_record_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_update_asset_service_record_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_from_update_asset_service_record_model.py
@@ -83,21 +83,15 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
         order_item_number = self.order_item_number
-
         certificate_number = self.certificate_number
-
         result_status: Optional[str]
         if not self.result_status:
             result_status = None
         else:
             result_status: Optional[str]
-
             if not self.result_status:
-
                 result_status = None
             else:
                 result_status = self.result_status
@@ -106,9 +100,7 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
             as_found_result = None
         else:
             as_found_result: Optional[str]
-
             if not self.as_found_result:
-
                 as_found_result = None
             else:
                 as_found_result = self.as_found_result
@@ -117,9 +109,7 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
             as_left_result = None
         else:
             as_left_result: Optional[str]
-
             if not self.as_left_result:
-
                 as_left_result = None
             else:
                 as_left_result = self.as_left_result
@@ -128,153 +118,54 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
             applied_interval = None
         else:
             applied_interval = self.applied_interval
-
         as_found_tolerance: Optional[float]
         if not self.as_found_tolerance:
             as_found_tolerance = None
         else:
             as_found_tolerance = self.as_found_tolerance
-
         as_left_tolerance: Optional[float]
         if not self.as_left_tolerance:
             as_left_tolerance = None
         else:
             as_left_tolerance = self.as_left_tolerance
-
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
+        service_date = self.service_date.isoformat() if self.service_date else None
         serial_number = self.serial_number
-
-        asset_tag: Optional[str]
-        if not self.asset_tag:
-            asset_tag = None
-        else:
-            asset_tag = self.asset_tag
-
-        asset_user: Optional[str]
-        if not self.asset_user:
-            asset_user = None
-        else:
-            asset_user = self.asset_user
-
-        service_notes: Optional[str]
-        if not self.service_notes:
-            service_notes = None
-        else:
-            service_notes = self.service_notes
-
-        due_date: Optional[str]
-        if not self.due_date:
-            due_date = None
-        elif isinstance(self.due_date, datetime.datetime):
-            due_date = self.due_date.isoformat()
-        else:
-            due_date = self.due_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        provider_technician: Optional[str]
-        if not self.provider_technician:
-            provider_technician = None
-        else:
-            provider_technician = self.provider_technician
-
-        provider_phone: Optional[str]
-        if not self.provider_phone:
-            provider_phone = None
-        else:
-            provider_phone = self.provider_phone
-
-        provider_company: Optional[str]
-        if not self.provider_company:
-            provider_company = None
-        else:
-            provider_company = self.provider_company
-
-        service_level: Optional[str]
-        if not self.service_level:
-            service_level = None
-        else:
-            service_level = self.service_level
-
-        service_level_code: Optional[str]
-        if not self.service_level_code:
-            service_level_code = None
-        else:
-            service_level_code = self.service_level_code
-
-        next_service_level: Optional[str]
-        if not self.next_service_level:
-            next_service_level = None
-        else:
-            next_service_level = self.next_service_level
-
-        next_service_level_code: Optional[str]
-        if not self.next_service_level_code:
-            next_service_level_code = None
-        else:
-            next_service_level_code = self.next_service_level_code
-
-        asset_name: Optional[str]
-        if not self.asset_name:
-            asset_name = None
-        else:
-            asset_name = self.asset_name
-
-        asset_description: Optional[str]
-        if not self.asset_description:
-            asset_description = None
-        else:
-            asset_description = self.asset_description
-
+        asset_tag = self.asset_tag
+        asset_user = self.asset_user
+        service_notes = self.service_notes
+        due_date = self.due_date.isoformat() if self.due_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        provider_technician = self.provider_technician
+        provider_phone = self.provider_phone
+        provider_company = self.provider_company
+        service_level = self.service_level
+        service_level_code = self.service_level_code
+        next_service_level = self.next_service_level
+        next_service_level_code = self.next_service_level_code
+        asset_name = self.asset_name
+        asset_description = self.asset_description
         parts_charge: Optional[float]
         if not self.parts_charge:
             parts_charge = None
         else:
             parts_charge = self.parts_charge
-
         parts_charge_before_discount: Optional[float]
         if not self.parts_charge_before_discount:
             parts_charge_before_discount = None
         else:
             parts_charge_before_discount = self.parts_charge_before_discount
-
         service_charge: Optional[float]
         if not self.service_charge:
             service_charge = None
         else:
             service_charge = self.service_charge
-
         repairs_charge: Optional[float]
         if not self.repairs_charge:
             repairs_charge = None
         else:
             repairs_charge = self.repairs_charge
-
-        segment_name: Optional[str]
-        if not self.segment_name:
-            segment_name = None
-        else:
-            segment_name = self.segment_name
-
-        schedule_name: Optional[str]
-        if not self.schedule_name:
-            schedule_name = None
-        else:
-            schedule_name = self.schedule_name
-
+        segment_name = self.segment_name
+        schedule_name = self.schedule_name
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -342,62 +233,45 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
             field_dict["SegmentName"] = segment_name
         if schedule_name is not None:
             field_dict["ScheduleName"] = schedule_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_as_found_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_applied_interval(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         applied_interval = _parse_applied_interval(d.pop("AppliedInterval", None))
-
         def _parse_as_found_tolerance(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         as_found_tolerance = _parse_as_found_tolerance(d.pop("AsFoundTolerance", None))
-
         def _parse_as_left_tolerance(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         as_left_tolerance = _parse_as_left_tolerance(d.pop("AsLeftTolerance", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -405,37 +279,27 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         serial_number = d.pop("SerialNumber", None)
-
         def _parse_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag = _parse_asset_tag(d.pop("AssetTag", None))
-
         def _parse_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user = _parse_asset_user(d.pop("AssetUser", None))
-
         def _parse_service_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_notes = _parse_service_notes(d.pop("ServiceNotes", None))
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -443,14 +307,11 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_date_type_0 = isoparse(data)
-
                 return due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -460,125 +321,92 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_provider_technician(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician = _parse_provider_technician(d.pop("ProviderTechnician", None))
-
         def _parse_provider_phone(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_phone = _parse_provider_phone(d.pop("ProviderPhone", None))
-
         def _parse_provider_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_company = _parse_provider_company(d.pop("ProviderCompany", None))
-
         def _parse_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level = _parse_service_level(d.pop("ServiceLevel", None))
-
         def _parse_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_code = _parse_service_level_code(d.pop("ServiceLevelCode", None))
-
         def _parse_next_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level = _parse_next_service_level(d.pop("NextServiceLevel", None))
-
         def _parse_next_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level_code = _parse_next_service_level_code(
             d.pop("NextServiceLevelCode", None)
         )
-
         def _parse_asset_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_name = _parse_asset_name(d.pop("AssetName", None))
-
         def _parse_asset_description(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_description = _parse_asset_description(d.pop("AssetDescription", None))
-
         def _parse_parts_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge = _parse_parts_charge(d.pop("PartsCharge", None))
-
         def _parse_parts_charge_before_discount(
             data: object,
         ) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge_before_discount = _parse_parts_charge_before_discount(
             d.pop("PartsChargeBeforeDiscount", None)
         )
-
         def _parse_service_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge = _parse_service_charge(d.pop("ServiceCharge", None))
-
         def _parse_repairs_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_charge = _parse_repairs_charge(d.pop("RepairsCharge", None))
-
         def _parse_segment_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         segment_name = _parse_segment_name(d.pop("SegmentName", None))
-
         def _parse_schedule_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         schedule_name = _parse_schedule_name(d.pop("ScheduleName", None))
-
         qualer_api_models_asset_service_records_from_update_asset_service_record_model = cls(
             service_order_number=service_order_number,
             custom_order_number=custom_order_number,
@@ -613,7 +441,6 @@ class AssetServiceRecordsFromUpdateAssetServiceRecordModel:
             segment_name=segment_name,
             schedule_name=schedule_name,
         )
-
         qualer_api_models_asset_service_records_from_update_asset_service_record_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_add_asset_service_record_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_add_asset_service_record_response.py
@@ -19,24 +19,20 @@ class AssetServiceRecordsToAddAssetServiceRecordResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_asset_service_records_to_add_asset_service_record_response = cls(
             id=id,
         )
-
         qualer_api_models_asset_service_records_to_add_asset_service_record_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_service_records_to_asset_service_record_response_model.py
@@ -134,7 +134,6 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
         guid = str(self.guid)
         segment_name = self.segment_name
         schedule_name = self.schedule_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -214,7 +213,6 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             field_dict["SegmentName"] = segment_name
         if schedule_name is not None:
             field_dict["ScheduleName"] = schedule_name
-
         return field_dict
 
     @classmethod
@@ -229,28 +227,21 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
         custom_order_number = d.pop("CustomOrderNumber", None)
         order_item_number = d.pop("OrderItemNumber", None)
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_as_found_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_service_date(data: object) -> datetime.datetime:
             try:
                 if not isinstance(data, str):
@@ -260,56 +251,42 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             except Exception:
                 pass
             return cast(datetime.datetime, data)
-
         try:
             service_date_data = d.pop("ServiceDate")
         except KeyError:
             raise ValueError("Missing required field 'ServiceDate' in input dictionary.")
         service_date = _parse_service_date(service_date_data)
         serial_number = d.pop("SerialNumber", None)
-
         def _parse_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag = _parse_asset_tag(d.pop("AssetTag", None))
-
         def _parse_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user = _parse_asset_user(d.pop("AssetUser", None))
-
         def _parse_asset_tag_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag_change = _parse_asset_tag_change(d.pop("AssetTagChange", None))
-
         def _parse_asset_user_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user_change = _parse_asset_user_change(d.pop("AssetUserChange", None))
-
         def _parse_service_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_notes = _parse_service_notes(d.pop("ServiceNotes", None))
-
         def _parse_serial_number_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         serial_number_change = _parse_serial_number_change(d.pop("SerialNumberChange", None))
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -321,9 +298,7 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_next_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -335,104 +310,76 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_provider_technician(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician = _parse_provider_technician(d.pop("ProviderTechnician", None))
-
         def _parse_provider_phone(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_phone = _parse_provider_phone(d.pop("ProviderPhone", None))
-
         def _parse_provider_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_company = _parse_provider_company(d.pop("ProviderCompany", None))
-
         def _parse_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level = _parse_service_level(d.pop("ServiceLevel", None))
-
         def _parse_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_code = _parse_service_level_code(d.pop("ServiceLevelCode", None))
-
         def _parse_next_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level = _parse_next_service_level(d.pop("NextServiceLevel", None))
-
         def _parse_next_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level_code = _parse_next_service_level_code(
             d.pop("NextServiceLevelCode", None)
         )
-
         def _parse_asset_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_name = _parse_asset_name(d.pop("AssetName", None))
-
         def _parse_asset_description(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_description = _parse_asset_description(d.pop("AssetDescription", None))
-
         def _parse_parts_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge = _parse_parts_charge(d.pop("PartsCharge", None))
-
         def _parse_parts_charge_before_discount(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge_before_discount = _parse_parts_charge_before_discount(
             d.pop("PartsChargeBeforeDiscount", None)
         )
-
         def _parse_service_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge = _parse_service_charge(d.pop("ServiceCharge", None))
-
         def _parse_repairs_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_charge = _parse_repairs_charge(d.pop("RepairsCharge", None))
-
         def _parse_guid(data: object) -> Optional[UUID]:
             if not data:
                 return None
@@ -444,23 +391,17 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             except Exception:
                 pass
             return cast(Optional[UUID], data)
-
         guid = _parse_guid(d.pop("Guid", None))
-
         def _parse_segment_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         segment_name = _parse_segment_name(d.pop("SegmentName", None))
-
         def _parse_schedule_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         schedule_name = _parse_schedule_name(d.pop("ScheduleName", None))
-
         model_obj = cls(
             asset_id=asset_id,
             asset_service_record_id=asset_service_record_id,
@@ -501,7 +442,6 @@ class AssetServiceRecordsToAssetServiceRecordResponseModel:
             segment_name=segment_name,
             schedule_name=schedule_name,
         )
-
         model_obj.additional_properties = d
         return model_obj
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_forecast_api_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_forecast_api_response_model.py
@@ -126,152 +126,58 @@ class AssetToAssetForecastApiResponseModel:
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        last_due_date: Optional[str]
-        if not self.last_due_date:
-            last_due_date = None
-        elif isinstance(self.last_due_date, datetime.datetime):
-            last_due_date = self.last_due_date.isoformat()
-        else:
-            last_due_date = self.last_due_date
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        next_service_task: Optional[str]
-        if not self.next_service_task:
-            next_service_task = None
-        else:
-            next_service_task = self.next_service_task
-
+        last_due_date = self.last_due_date.isoformat() if self.last_due_date else None
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        next_service_task = self.next_service_task
         company_id = self.company_id
-
         asset_id = self.asset_id
-
         serial_number = self.serial_number
-
         asset_user = self.asset_user
-
         asset_tag = self.asset_tag
-
         equipment_id = self.equipment_id
-
-        asset_status: Optional[str] = None
-        if self.asset_status:
-            asset_status = self.asset_status.value
-
+        asset_status = self.asset_status.value if self.asset_status else None
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_maker = self.asset_maker
-
         location = self.location
-
         room_number = self.room_number
-
         barcode = self.barcode
-
         legacy_identifier = self.legacy_identifier
-
         root_category_name = self.root_category_name
-
         category_name = self.category_name
-
         class_ = self.class_
-
         custodian_email = self.custodian_email
-
         custodian_first_name = self.custodian_first_name
-
         custodian_last_name = self.custodian_last_name
-
         custodian_name = self.custodian_name
-
         department = self.department
-
         station = self.station
-
         notes = self.notes
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         cumulative_service_cost = self.cumulative_service_cost
-
         product_id = self.product_id
-
         manufacturer_part_number = self.manufacturer_part_number
-
         product_name = self.product_name
-
         product_description = self.product_description
-
         product_manufacturer = self.product_manufacturer
-
         site_name = self.site_name
-
         site_id = self.site_id
-
         condition = self.condition
-
         criticality = self.criticality
-
         pool = self.pool
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
         purchase_cost = self.purchase_cost
-
         life_span_months = self.life_span_months
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
         depreciation_basis = self.depreciation_basis
-
         depreciation_method = self.depreciation_method
-
-        retirement_date: Optional[str]
-        if not self.retirement_date:
-            retirement_date = None
-        elif isinstance(self.retirement_date, datetime.datetime):
-            retirement_date = self.retirement_date.isoformat()
-        else:
-            retirement_date = self.retirement_date
-
+        retirement_date = self.retirement_date.isoformat() if self.retirement_date else None
         salvage_value = self.salvage_value
-
         retirment_reason = self.retirment_reason
-
         composite_parent_id = self.composite_parent_id
-
         composite_child_count = self.composite_child_count
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -379,13 +285,11 @@ class AssetToAssetForecastApiResponseModel:
             field_dict["CompositeParentId"] = composite_parent_id
         if composite_child_count is not None:
             field_dict["CompositeChildCount"] = composite_child_count
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
         def _parse_last_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -393,14 +297,11 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_due_date_type_0 = isoparse(data)
-
                 return last_due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_due_date = _parse_last_due_date(d.pop("LastDueDate", None))
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -410,14 +311,11 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -427,100 +325,58 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_next_service_task(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_task = _parse_next_service_task(d.pop("NextServiceTask", None))
-
         company_id = d.pop("CompanyId", None)
-
         asset_id = d.pop("AssetId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         _asset_status = d.pop("AssetStatus", None)
         asset_status: Optional[AssetToAssetForecastApiResponseModelAssetStatus]
         if not _asset_status:
             asset_status = None
         else:
             asset_status = AssetToAssetForecastApiResponseModelAssetStatus(_asset_status)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         location = d.pop("Location", None)
-
         room_number = d.pop("RoomNumber", None)
-
         barcode = d.pop("Barcode", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         category_name = d.pop("CategoryName", None)
-
         class_ = d.pop("Class", None)
-
         custodian_email = d.pop("CustodianEmail", None)
-
         custodian_first_name = d.pop("CustodianFirstName", None)
-
         custodian_last_name = d.pop("CustodianLastName", None)
-
         custodian_name = d.pop("CustodianName", None)
-
         department = d.pop("Department", None)
-
         station = d.pop("Station", None)
-
         notes = d.pop("Notes", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         cumulative_service_cost = d.pop("CumulativeServiceCost", None)
-
         product_id = d.pop("ProductId", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         product_name = d.pop("ProductName", None)
-
         product_description = d.pop("ProductDescription", None)
-
         product_manufacturer = d.pop("ProductManufacturer", None)
-
         site_name = d.pop("SiteName", None)
-
         site_id = d.pop("SiteId", None)
-
         condition = d.pop("Condition", None)
-
         criticality = d.pop("Criticality", None)
-
         pool = d.pop("Pool", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -528,18 +384,13 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         purchase_cost = d.pop("PurchaseCost", None)
-
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -549,18 +400,13 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         depreciation_basis = d.pop("DepreciationBasis", None)
-
         depreciation_method = d.pop("DepreciationMethod", None)
-
         def _parse_retirement_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -570,22 +416,15 @@ class AssetToAssetForecastApiResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 retirement_date_type_0 = isoparse(data)
-
                 return retirement_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirement_date = _parse_retirement_date(d.pop("RetirementDate", None))
-
         salvage_value = d.pop("SalvageValue", None)
-
         retirment_reason = d.pop("RetirmentReason", None)
-
         composite_parent_id = d.pop("CompositeParentId", None)
-
         composite_child_count = d.pop("CompositeChildCount", None)
-
         qualer_api_models_asset_to_asset_forecast_api_response_model = cls(
             last_due_date=last_due_date,
             last_service_date=last_service_date,
@@ -640,7 +479,6 @@ class AssetToAssetForecastApiResponseModel:
             composite_parent_id=composite_parent_id,
             composite_child_count=composite_child_count,
         )
-
         qualer_api_models_asset_to_asset_forecast_api_response_model.additional_properties = d
         return qualer_api_models_asset_to_asset_forecast_api_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_model.py
@@ -132,123 +132,54 @@ class AssetToAssetMaintenancePlanModel:
             for maintenance_plans_item_data in self.maintenance_plans:
                 maintenance_plans_item = maintenance_plans_item_data.to_dict()
                 maintenance_plans.append(maintenance_plans_item)
-
         company_id = self.company_id
-
         asset_id = self.asset_id
-
         serial_number = self.serial_number
-
         asset_user = self.asset_user
-
         asset_tag = self.asset_tag
-
         equipment_id = self.equipment_id
-
-        asset_status: Optional[str] = None
-        if self.asset_status:
-            asset_status = self.asset_status.value
-
+        asset_status = self.asset_status.value if self.asset_status else None
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_maker = self.asset_maker
-
         location = self.location
-
         room_number = self.room_number
-
         barcode = self.barcode
-
         legacy_identifier = self.legacy_identifier
-
         root_category_name = self.root_category_name
-
         category_name = self.category_name
-
         class_ = self.class_
-
         custodian_email = self.custodian_email
-
         custodian_first_name = self.custodian_first_name
-
         custodian_last_name = self.custodian_last_name
-
         custodian_name = self.custodian_name
-
         department = self.department
-
         station = self.station
-
         notes = self.notes
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         cumulative_service_cost = self.cumulative_service_cost
-
         product_id = self.product_id
-
         manufacturer_part_number = self.manufacturer_part_number
-
         product_name = self.product_name
-
         product_description = self.product_description
-
         product_manufacturer = self.product_manufacturer
-
         site_name = self.site_name
-
         site_id = self.site_id
-
         condition = self.condition
-
         criticality = self.criticality
-
         pool = self.pool
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
         purchase_cost = self.purchase_cost
-
         life_span_months = self.life_span_months
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
         depreciation_basis = self.depreciation_basis
-
         depreciation_method = self.depreciation_method
-
-        retirement_date: Optional[str]
-        if not self.retirement_date:
-            retirement_date = None
-        elif isinstance(self.retirement_date, datetime.datetime):
-            retirement_date = self.retirement_date.isoformat()
-        else:
-            retirement_date = self.retirement_date
-
+        retirement_date = self.retirement_date.isoformat() if self.retirement_date else None
         salvage_value = self.salvage_value
-
         retirment_reason = self.retirment_reason
-
         composite_parent_id = self.composite_parent_id
-
         composite_child_count = self.composite_child_count
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -350,7 +281,6 @@ class AssetToAssetMaintenancePlanModel:
             field_dict["CompositeParentId"] = composite_parent_id
         if composite_child_count is not None:
             field_dict["CompositeChildCount"] = composite_child_count
-
         return field_dict
 
     @classmethod
@@ -358,7 +288,6 @@ class AssetToAssetMaintenancePlanModel:
         from ..models.qualer_api_models_asset_to_asset_maintenance_plan_response import (
             AssetToAssetMaintenancePlanResponse,
         )
-
         d = dict(src_dict)
         maintenance_plans = []
         _maintenance_plans = d.pop("MaintenancePlans", None)
@@ -366,88 +295,49 @@ class AssetToAssetMaintenancePlanModel:
             maintenance_plans_item = AssetToAssetMaintenancePlanResponse.from_dict(
                 maintenance_plans_item_data
             )
-
             maintenance_plans.append(maintenance_plans_item)
-
         company_id = d.pop("CompanyId", None)
-
         asset_id = d.pop("AssetId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         _asset_status = d.pop("AssetStatus", None)
         asset_status: Optional[AssetToAssetMaintenancePlanModelAssetStatus]
         if not _asset_status:
             asset_status = None
         else:
             asset_status = AssetToAssetMaintenancePlanModelAssetStatus(_asset_status)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         location = d.pop("Location", None)
-
         room_number = d.pop("RoomNumber", None)
-
         barcode = d.pop("Barcode", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         category_name = d.pop("CategoryName", None)
-
         class_ = d.pop("Class", None)
-
         custodian_email = d.pop("CustodianEmail", None)
-
         custodian_first_name = d.pop("CustodianFirstName", None)
-
         custodian_last_name = d.pop("CustodianLastName", None)
-
         custodian_name = d.pop("CustodianName", None)
-
         department = d.pop("Department", None)
-
         station = d.pop("Station", None)
-
         notes = d.pop("Notes", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         cumulative_service_cost = d.pop("CumulativeServiceCost", None)
-
         product_id = d.pop("ProductId", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         product_name = d.pop("ProductName", None)
-
         product_description = d.pop("ProductDescription", None)
-
         product_manufacturer = d.pop("ProductManufacturer", None)
-
         site_name = d.pop("SiteName", None)
-
         site_id = d.pop("SiteId", None)
-
         condition = d.pop("Condition", None)
-
         criticality = d.pop("Criticality", None)
-
         pool = d.pop("Pool", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -455,18 +345,13 @@ class AssetToAssetMaintenancePlanModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         purchase_cost = d.pop("PurchaseCost", None)
-
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -476,18 +361,13 @@ class AssetToAssetMaintenancePlanModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         depreciation_basis = d.pop("DepreciationBasis", None)
-
         depreciation_method = d.pop("DepreciationMethod", None)
-
         def _parse_retirement_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -497,22 +377,15 @@ class AssetToAssetMaintenancePlanModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 retirement_date_type_0 = isoparse(data)
-
                 return retirement_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirement_date = _parse_retirement_date(d.pop("RetirementDate", None))
-
         salvage_value = d.pop("SalvageValue", None)
-
         retirment_reason = d.pop("RetirmentReason", None)
-
         composite_parent_id = d.pop("CompositeParentId", None)
-
         composite_child_count = d.pop("CompositeChildCount", None)
-
         qualer_api_models_asset_to_asset_maintenance_plan_model = cls(
             maintenance_plans=maintenance_plans,
             company_id=company_id,
@@ -564,7 +437,6 @@ class AssetToAssetMaintenancePlanModel:
             composite_parent_id=composite_parent_id,
             composite_child_count=composite_child_count,
         )
-
         qualer_api_models_asset_to_asset_maintenance_plan_model.additional_properties = d
         return qualer_api_models_asset_to_asset_maintenance_plan_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response.py
@@ -59,62 +59,27 @@ class AssetToAssetMaintenancePlanResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         maintenance_plan_id = self.maintenance_plan_id
-
         maintenance_plan_name = self.maintenance_plan_name
-
         task_notes = self.task_notes
-
         last_service_task = self.last_service_task
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
         next_service_task = self.next_service_task
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        certificate_due_date: Optional[str]
-        if not self.certificate_due_date:
-            certificate_due_date = None
-        elif isinstance(self.certificate_due_date, datetime.datetime):
-            certificate_due_date = self.certificate_due_date.isoformat()
-        else:
-            certificate_due_date = self.certificate_due_date
-
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        certificate_due_date = self.certificate_due_date.isoformat() if self.certificate_due_date else None
         owner_first_name = self.owner_first_name
-
         owner_last_name = self.owner_last_name
-
         owner_alias = self.owner_alias
-
         owner_department_name = self.owner_department_name
-
         technician_first_name = self.technician_first_name
-
         technician_last_name = self.technician_last_name
-
         technician_alias = self.technician_alias
-
         technician_department_name = self.technician_department_name
-
         assigned_employees: Optional[List[Dict[str, Any]]] = None
         if self.assigned_employees:
             assigned_employees = []
             for assigned_employees_item_data in self.assigned_employees:
                 assigned_employees_item = assigned_employees_item_data.to_dict()
                 assigned_employees.append(assigned_employees_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -152,7 +117,6 @@ class AssetToAssetMaintenancePlanResponse:
             field_dict["TechnicianDepartmentName"] = technician_department_name
         if assigned_employees is not None:
             field_dict["AssignedEmployees"] = assigned_employees
-
         return field_dict
 
     @classmethod
@@ -160,16 +124,11 @@ class AssetToAssetMaintenancePlanResponse:
         from ..models.qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee import (
             AssetToAssetMaintenancePlanResponseAssignedEmployee,
         )
-
         d = dict(src_dict)
         maintenance_plan_id = d.pop("MaintenancePlanId", None)
-
         maintenance_plan_name = d.pop("MaintenancePlanName", None)
-
         task_notes = d.pop("TaskNotes", None)
-
         last_service_task = d.pop("LastServiceTask", None)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -179,16 +138,12 @@ class AssetToAssetMaintenancePlanResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         next_service_task = d.pop("NextServiceTask", None)
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -198,14 +153,11 @@ class AssetToAssetMaintenancePlanResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_certificate_due_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -215,39 +167,26 @@ class AssetToAssetMaintenancePlanResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 certificate_due_date_type_0 = isoparse(data)
-
                 return certificate_due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         certificate_due_date = _parse_certificate_due_date(d.pop("CertificateDueDate", None))
-
         owner_first_name = d.pop("OwnerFirstName", None)
-
         owner_last_name = d.pop("OwnerLastName", None)
-
         owner_alias = d.pop("OwnerAlias", None)
-
         owner_department_name = d.pop("OwnerDepartmentName", None)
-
         technician_first_name = d.pop("TechnicianFirstName", None)
-
         technician_last_name = d.pop("TechnicianLastName", None)
-
         technician_alias = d.pop("TechnicianAlias", None)
-
         technician_department_name = d.pop("TechnicianDepartmentName", None)
-
         assigned_employees = []
         _assigned_employees = d.pop("AssignedEmployees", None)
         for assigned_employees_item_data in _assigned_employees or []:
             assigned_employees_item = AssetToAssetMaintenancePlanResponseAssignedEmployee.from_dict(
                 assigned_employees_item_data
             )
-
             assigned_employees.append(assigned_employees_item)
-
         qualer_api_models_asset_to_asset_maintenance_plan_response = cls(
             maintenance_plan_id=maintenance_plan_id,
             maintenance_plan_name=maintenance_plan_name,
@@ -267,7 +206,6 @@ class AssetToAssetMaintenancePlanResponse:
             technician_department_name=technician_department_name,
             assigned_employees=assigned_employees,
         )
-
         qualer_api_models_asset_to_asset_maintenance_plan_response.additional_properties = d
         return qualer_api_models_asset_to_asset_maintenance_plan_response
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee.py
@@ -23,11 +23,8 @@ class AssetToAssetMaintenancePlanResponseAssignedEmployee:
 
     def to_dict(self) -> Dict[str, Any]:
         first_name = self.first_name
-
         last_name = self.last_name
-
         alias = self.alias
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class AssetToAssetMaintenancePlanResponseAssignedEmployee:
             field_dict["LastName"] = last_name
         if alias is not None:
             field_dict["Alias"] = alias
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         alias = d.pop("Alias", None)
-
         qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee = cls(
             first_name=first_name,
             last_name=last_name,
             alias=alias,
         )
-
         qualer_api_models_asset_to_asset_maintenance_plan_response_assigned_employee.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_manage_response_model.py
@@ -202,249 +202,92 @@ class AssetToAssetManageResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_maker = self.asset_maker
-
-        record_type: Optional[int] = None
-        if self.record_type:
-            record_type = self.record_type.value
-
+        record_type = self.record_type.value if self.record_type else None
         parent_asset_id = self.parent_asset_id
-
         children_count = self.children_count
-
         site_id = self.site_id
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         legacy_identifier = self.legacy_identifier
-
         criticality = self.criticality
-
         condition = self.condition
-
         asset_class = self.asset_class
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
-        retirment_date: Optional[str]
-        if not self.retirment_date:
-            retirment_date = None
-        elif isinstance(self.retirment_date, datetime.datetime):
-            retirment_date = self.retirment_date.isoformat()
-        else:
-            retirment_date = self.retirment_date
-
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
+        retirment_date = self.retirment_date.isoformat() if self.retirment_date else None
         client_vendor_id = self.client_vendor_id
-
         company_name = self.company_name
-
         site_name = self.site_name
-
         asset_has_image = self.asset_has_image
-
         has_image = self.has_image
-
         parent_has_image = self.parent_has_image
-
         pool_id = self.pool_id
-
         pool = self.pool
-
         product_id = self.product_id
-
         parent_product_id = self.parent_product_id
-
         product_name = self.product_name
-
         parent_product_name = self.parent_product_name
-
         category_id = self.category_id
-
         root_category_id = self.root_category_id
-
         category_name = self.category_name
-
         root_category_name = self.root_category_name
-
         manufacturer_id = self.manufacturer_id
-
         manufacturer = self.manufacturer
-
         display_part_number = self.display_part_number
-
         display_name = self.display_name
-
         manufacturer_part_number = self.manufacturer_part_number
-
         asset_room = self.asset_room
-
         location = self.location
-
         station = self.station
-
-        tool_role: Optional[int] = None
-        if self.tool_role:
-            tool_role = self.tool_role.value
-
+        tool_role = self.tool_role.value if self.tool_role else None
         tool_id = self.tool_id
-
         department_id = self.department_id
-
         department_name = self.department_name
-
         custodian_name = self.custodian_name
-
         warranty = self.warranty
-
-        warranty_end: Optional[str]
-        if not self.warranty_end:
-            warranty_end = None
-        elif isinstance(self.warranty_end, datetime.datetime):
-            warranty_end = self.warranty_end.isoformat()
-        else:
-            warranty_end = self.warranty_end
-
+        warranty_end = self.warranty_end.isoformat() if self.warranty_end else None
         is_warranty_expired = self.is_warranty_expired
-
         depreciation_method = self.depreciation_method
-
         depreciation_basis = self.depreciation_basis
-
         salvage_value = self.salvage_value
-
         total_service_cost = self.total_service_cost
-
         life_span_months = self.life_span_months
-
-        due_for_replacement_date: Optional[str]
-        if not self.due_for_replacement_date:
-            due_for_replacement_date = None
-        elif isinstance(self.due_for_replacement_date, datetime.datetime):
-            due_for_replacement_date = self.due_for_replacement_date.isoformat()
-        else:
-            due_for_replacement_date = self.due_for_replacement_date
-
+        due_for_replacement_date = self.due_for_replacement_date.isoformat() if self.due_for_replacement_date else None
         depreciation_proc = self.depreciation_proc
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
         purchase_cost = self.purchase_cost
-
         time_in_service = self.time_in_service
-
         retirement_reason = self.retirement_reason
-
         residual_cost = self.residual_cost
-
         employee_id = self.employee_id
-
         asset_service_record_id = self.asset_service_record_id
-
-        result_status: Optional[int] = None
-        if self.result_status:
-            result_status = self.result_status.value
-
-        as_found_result: Optional[int] = None
-        if self.as_found_result:
-            as_found_result = self.as_found_result.value
-
-        as_left_result: Optional[int] = None
-        if self.as_left_result:
-            as_left_result = self.as_left_result.value
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        last_service: Optional[str]
-        if not self.last_service:
-            last_service = None
-        else:
-            last_service = self.last_service
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        result_status = self.result_status.value if self.result_status else None
+        as_found_result = self.as_found_result.value if self.as_found_result else None
+        as_left_result = self.as_left_result.value if self.as_left_result else None
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        last_service = self.last_service
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         next_service = self.next_service
-
         service_schedule_segment_id = self.service_schedule_segment_id
-
         service_schedule_id = self.service_schedule_id
-
         service_schedule = self.service_schedule
-
         service_order_id = self.service_order_id
-
         service_order_status: Optional[str] = (
             self.service_order_status.value if self.service_order_status else None
         )
-
         custom_order_number = self.custom_order_number
-
         service_order_item_id = self.service_order_item_id
-
         vendor = self.vendor
-
         technician = self.technician
-
         certificate_number = self.certificate_number
-
-        due_trigger_date: Optional[str]
-        if not self.due_trigger_date:
-            due_trigger_date = None
-        elif isinstance(self.due_trigger_date, datetime.datetime):
-            due_trigger_date = self.due_trigger_date.isoformat()
-        else:
-            due_trigger_date = self.due_trigger_date
-
-        past_due_trigger_date: Optional[str]
-        if not self.past_due_trigger_date:
-            past_due_trigger_date = None
-        elif isinstance(self.past_due_trigger_date, datetime.datetime):
-            past_due_trigger_date = self.past_due_trigger_date.isoformat()
-        else:
-            past_due_trigger_date = self.past_due_trigger_date
-
-        due_status: Optional[int] = None
-        if self.due_status:
-            due_status = self.due_status.value
-
-        work_status: Optional[int] = None
-        if self.work_status:
-            work_status = self.work_status.value
-
+        due_trigger_date = self.due_trigger_date.isoformat() if self.due_trigger_date else None
+        past_due_trigger_date = self.past_due_trigger_date.isoformat() if self.past_due_trigger_date else None
+        due_status = self.due_status.value if self.due_status else None
+        work_status = self.work_status.value if self.work_status else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -618,20 +461,15 @@ class AssetToAssetManageResponseModel:
             field_dict["DueStatus"] = due_status
         if work_status is not None:
             field_dict["WorkStatus"] = work_status
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         _record_type = d.pop("RecordType", None)
         record_type: Optional[AssetToAssetManageResponseModelRecordType]
         if not _record_type:
@@ -640,29 +478,17 @@ class AssetToAssetManageResponseModel:
             record_type = None
         else:
             record_type = AssetToAssetManageResponseModelRecordType(_record_type)
-
         parent_asset_id = d.pop("ParentAssetId", None)
-
         children_count = d.pop("ChildrenCount", None)
-
         site_id = d.pop("SiteId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         criticality = d.pop("Criticality", None)
-
         condition = d.pop("Condition", None)
-
         asset_class = d.pop("AssetClass", None)
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -672,14 +498,11 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         def _parse_retirment_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -689,62 +512,35 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 retirment_date_type_0 = isoparse(data)
-
                 return retirment_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirment_date = _parse_retirment_date(d.pop("RetirmentDate", None))
-
         client_vendor_id = d.pop("ClientVendorId", None)
-
         company_name = d.pop("CompanyName", None)
-
         site_name = d.pop("SiteName", None)
-
         asset_has_image = d.pop("AssetHasImage", None)
-
         has_image = d.pop("HasImage", None)
-
         parent_has_image = d.pop("ParentHasImage", None)
-
         pool_id = d.pop("PoolId", None)
-
         pool = d.pop("Pool", None)
-
         product_id = d.pop("ProductId", None)
-
         parent_product_id = d.pop("ParentProductId", None)
-
         product_name = d.pop("ProductName", None)
-
         parent_product_name = d.pop("ParentProductName", None)
-
         category_id = d.pop("CategoryId", None)
-
         root_category_id = d.pop("RootCategoryId", None)
-
         category_name = d.pop("CategoryName", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         manufacturer_id = d.pop("ManufacturerId", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         display_part_number = d.pop("DisplayPartNumber", None)
-
         display_name = d.pop("DisplayName", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         asset_room = d.pop("AssetRoom", None)
-
         location = d.pop("Location", None)
-
         station = d.pop("Station", None)
-
         _tool_role = d.pop("ToolRole", None)
         tool_role: Optional[AssetToAssetManageResponseModelToolRole]
         if not _tool_role:
@@ -753,17 +549,11 @@ class AssetToAssetManageResponseModel:
             tool_role = None
         else:
             tool_role = AssetToAssetManageResponseModelToolRole(_tool_role)
-
         tool_id = d.pop("ToolId", None)
-
         department_id = d.pop("DepartmentId", None)
-
         department_name = d.pop("DepartmentName", None)
-
         custodian_name = d.pop("CustodianName", None)
-
         warranty = d.pop("Warranty", None)
-
         def _parse_warranty_end(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -771,26 +561,17 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 warranty_end_type_0 = isoparse(data)
-
                 return warranty_end_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         warranty_end = _parse_warranty_end(d.pop("WarrantyEnd", None))
-
         is_warranty_expired = d.pop("IsWarrantyExpired", None)
-
         depreciation_method = d.pop("DepreciationMethod", None)
-
         depreciation_basis = d.pop("DepreciationBasis", None)
-
         salvage_value = d.pop("SalvageValue", None)
-
         total_service_cost = d.pop("TotalServiceCost", None)
-
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_due_for_replacement_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -800,18 +581,14 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_for_replacement_date_type_0 = isoparse(data)
-
                 return due_for_replacement_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_for_replacement_date = _parse_due_for_replacement_date(
             d.pop("DueForReplacementDate", None)
         )
-
         depreciation_proc = d.pop("DepreciationProc", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -819,26 +596,17 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         purchase_cost = d.pop("PurchaseCost", None)
-
         time_in_service = d.pop("TimeInService", None)
-
         retirement_reason = d.pop("RetirementReason", None)
-
         residual_cost = d.pop("ResidualCost", None)
-
         employee_id = d.pop("EmployeeId", None)
-
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         _result_status = d.pop("ResultStatus", None)
         result_status: Optional[ServiceResultStatus]
         if not _result_status:
@@ -847,7 +615,6 @@ class AssetToAssetManageResponseModel:
             result_status = None
         else:
             result_status = ServiceResultStatus(_result_status)
-
         _as_found_result = d.pop("AsFoundResult", None)
         as_found_result: Optional[ServiceResultStatus]
         if not _as_found_result:
@@ -856,7 +623,6 @@ class AssetToAssetManageResponseModel:
             as_found_result = None
         else:
             as_found_result = ServiceResultStatus(_as_found_result)
-
         _as_left_result = d.pop("AsLeftResult", None)
         as_left_result: Optional[ServiceResultStatus]
         if not _as_left_result:
@@ -865,7 +631,6 @@ class AssetToAssetManageResponseModel:
             as_left_result = None
         else:
             as_left_result = ServiceResultStatus(_as_left_result)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -875,21 +640,16 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_last_service(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         last_service = _parse_last_service(d.pop("LastService", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -899,37 +659,23 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         next_service = d.pop("NextService", None)
-
         service_schedule_segment_id = d.pop("ServiceScheduleSegmentId", None)
-
         service_schedule_id = d.pop("ServiceScheduleId", None)
-
         service_schedule = d.pop("ServiceSchedule", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         _service_order_status = d.pop("ServiceOrderStatus", None)
         service_order_status = ServiceOrderStatus.from_api_value(_service_order_status)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         vendor = d.pop("Vendor", None)
-
         technician = d.pop("Technician", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_due_trigger_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -939,14 +685,11 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_trigger_date_type_0 = isoparse(data)
-
                 return due_trigger_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_trigger_date = _parse_due_trigger_date(d.pop("DueTriggerDate", None))
-
         def _parse_past_due_trigger_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -956,14 +699,11 @@ class AssetToAssetManageResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 past_due_trigger_date_type_0 = isoparse(data)
-
                 return past_due_trigger_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         past_due_trigger_date = _parse_past_due_trigger_date(d.pop("PastDueTriggerDate", None))
-
         _due_status = d.pop("DueStatus", None)
         due_status: Optional[AssetToAssetManageResponseModelDueStatus]
         if not _due_status:
@@ -972,7 +712,6 @@ class AssetToAssetManageResponseModel:
             due_status = None
         else:
             due_status = AssetToAssetManageResponseModelDueStatus(_due_status)
-
         _work_status = d.pop("WorkStatus", None)
         work_status: Optional[WorkStatus]
         if not _work_status:
@@ -981,7 +720,6 @@ class AssetToAssetManageResponseModel:
             work_status = None
         else:
             work_status = WorkStatus(_work_status)
-
         qualer_api_models_asset_to_asset_manage_response_model = cls(
             asset_id=asset_id,
             asset_name=asset_name,
@@ -1069,7 +807,6 @@ class AssetToAssetManageResponseModel:
             due_status=due_status,
             work_status=work_status,
         )
-
         qualer_api_models_asset_to_asset_manage_response_model.additional_properties = d
         return qualer_api_models_asset_to_asset_manage_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_response_model.py
@@ -119,121 +119,53 @@ class AssetToAssetResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         company_id = self.company_id
-
         asset_id = self.asset_id
-
         serial_number = self.serial_number
-
         asset_user = self.asset_user
-
         asset_tag = self.asset_tag
-
         equipment_id = self.equipment_id
-
-        asset_status: Optional[str] = None
-        if self.asset_status:
-            asset_status = self.asset_status.value
-
+        asset_status = self.asset_status.value if self.asset_status else None
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_maker = self.asset_maker
-
         location = self.location
-
         room_number = self.room_number
-
         barcode = self.barcode
-
         legacy_identifier = self.legacy_identifier
-
         root_category_name = self.root_category_name
-
         category_name = self.category_name
-
         class_ = self.class_
-
         custodian_email = self.custodian_email
-
         custodian_first_name = self.custodian_first_name
-
         custodian_last_name = self.custodian_last_name
-
         custodian_name = self.custodian_name
-
         department = self.department
-
         station = self.station
-
         notes = self.notes
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         cumulative_service_cost = self.cumulative_service_cost
-
         product_id = self.product_id
-
         manufacturer_part_number = self.manufacturer_part_number
-
         product_name = self.product_name
-
         product_description = self.product_description
-
         product_manufacturer = self.product_manufacturer
-
         site_name = self.site_name
-
         site_id = self.site_id
-
         condition = self.condition
-
         criticality = self.criticality
-
         pool = self.pool
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
         purchase_cost = self.purchase_cost
-
         life_span_months = self.life_span_months
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
         depreciation_basis = self.depreciation_basis
-
         depreciation_method = self.depreciation_method
-
-        retirement_date: Optional[str]
-        if not self.retirement_date:
-            retirement_date = None
-        elif isinstance(self.retirement_date, datetime.datetime):
-            retirement_date = self.retirement_date.isoformat()
-        else:
-            retirement_date = self.retirement_date
-
+        retirement_date = self.retirement_date.isoformat() if self.retirement_date else None
         salvage_value = self.salvage_value
-
         retirment_reason = self.retirment_reason
-
         composite_parent_id = self.composite_parent_id
-
         composite_child_count = self.composite_child_count
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -333,91 +265,53 @@ class AssetToAssetResponseModel:
             field_dict["CompositeParentId"] = composite_parent_id
         if composite_child_count is not None:
             field_dict["CompositeChildCount"] = composite_child_count
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         company_id = d.pop("CompanyId", None)
-
         asset_id = d.pop("AssetId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         _asset_status = d.pop("AssetStatus", None)
         asset_status: Optional[AssetToAssetResponseModelAssetStatus]
         if not _asset_status:
             asset_status = None
         else:
             asset_status = AssetToAssetResponseModelAssetStatus(_asset_status)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         location = d.pop("Location", None)
-
         room_number = d.pop("RoomNumber", None)
-
         barcode = d.pop("Barcode", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         category_name = d.pop("CategoryName", None)
-
         class_ = d.pop("Class", None)
-
         custodian_email = d.pop("CustodianEmail", None)
-
         custodian_first_name = d.pop("CustodianFirstName", None)
-
         custodian_last_name = d.pop("CustodianLastName", None)
-
         custodian_name = d.pop("CustodianName", None)
-
         department = d.pop("Department", None)
-
         station = d.pop("Station", None)
-
         notes = d.pop("Notes", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         cumulative_service_cost = d.pop("CumulativeServiceCost", None)
-
         product_id = d.pop("ProductId", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         product_name = d.pop("ProductName", None)
-
         product_description = d.pop("ProductDescription", None)
-
         product_manufacturer = d.pop("ProductManufacturer", None)
-
         site_name = d.pop("SiteName", None)
-
         site_id = d.pop("SiteId", None)
-
         condition = d.pop("Condition", None)
-
         criticality = d.pop("Criticality", None)
-
         pool = d.pop("Pool", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -425,18 +319,13 @@ class AssetToAssetResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         purchase_cost = d.pop("PurchaseCost", None)
-
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -446,18 +335,13 @@ class AssetToAssetResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         depreciation_basis = d.pop("DepreciationBasis", None)
-
         depreciation_method = d.pop("DepreciationMethod", None)
-
         def _parse_retirement_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -467,22 +351,15 @@ class AssetToAssetResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 retirement_date_type_0 = isoparse(data)
-
                 return retirement_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirement_date = _parse_retirement_date(d.pop("RetirementDate", None))
-
         salvage_value = d.pop("SalvageValue", None)
-
         retirment_reason = d.pop("RetirmentReason", None)
-
         composite_parent_id = d.pop("CompositeParentId", None)
-
         composite_child_count = d.pop("CompositeChildCount", None)
-
         qualer_api_models_asset_to_asset_response_model = cls(
             company_id=company_id,
             asset_id=asset_id,
@@ -533,7 +410,6 @@ class AssetToAssetResponseModel:
             composite_parent_id=composite_parent_id,
             composite_child_count=composite_child_count,
         )
-
         qualer_api_models_asset_to_asset_response_model.additional_properties = d
         return qualer_api_models_asset_to_asset_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_asset_service_forecast_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_asset_service_forecast_model.py
@@ -9,6 +9,10 @@ from dateutil.parser import isoparse
 T = TypeVar("T", bound="AssetToAssetServiceForecastModel")
 
 
+def _isoformat_if_datetime(value: Any) -> Any:
+    return value.isoformat() if isinstance(value, datetime.datetime) else value
+
+
 @_attrs_define
 class AssetToAssetServiceForecastModel:
     """
@@ -80,195 +84,93 @@ class AssetToAssetServiceForecastModel:
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        company_id = self.company_id
-
-        asset_id = self.asset_id
-
-        site_id = self.site_id
-
-        asset_service_record_id = self.asset_service_record_id
-
-        serial_number = self.serial_number
-
-        asset_user = self.asset_user
-
-        asset_tag = self.asset_tag
-
-        equipment_id = self.equipment_id
-
-        asset_name = self.asset_name
-
-        category_name = self.category_name
-
-        manufacturer_name = self.manufacturer_name
-
-        site_name = self.site_name
-
-        maintenance_plan_id = self.maintenance_plan_id
-
-        maintenance_plan_name = self.maintenance_plan_name
-
-        maintenance_task_id = self.maintenance_task_id
-
-        maintenance_task_name = self.maintenance_task_name
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        advance_recall_date: Optional[str]
-        if not self.advance_recall_date:
-            advance_recall_date = None
-        elif isinstance(self.advance_recall_date, datetime.datetime):
-            advance_recall_date = self.advance_recall_date.isoformat()
-        else:
-            advance_recall_date = self.advance_recall_date
-
-        grace_period_date: Optional[str]
-        if not self.grace_period_date:
-            grace_period_date = None
-        elif isinstance(self.grace_period_date, datetime.datetime):
-            grace_period_date = self.grace_period_date.isoformat()
-        else:
-            grace_period_date = self.grace_period_date
-
-        certificate_next_service_date: Optional[str]
-        if not self.certificate_next_service_date:
-            certificate_next_service_date = None
-        elif isinstance(self.certificate_next_service_date, datetime.datetime):
-            certificate_next_service_date = self.certificate_next_service_date.isoformat()
-        else:
-            certificate_next_service_date = self.certificate_next_service_date
-
-        service_interval = self.service_interval
-
-        interval_cycle = self.interval_cycle
-
-        interval_length = self.interval_length
-
-        on_day = self.on_day
-
-        on_month = self.on_month
-
-        on_week_days = self.on_week_days
-
-        weekday_of_month = self.weekday_of_month
-
-        advance_recall_period = self.advance_recall_period
-
-        days_before_due = self.days_before_due
-
-        past_due_grace_period = self.past_due_grace_period
-
-        days_after_due = self.days_after_due
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-        field_dict.update({})
-        if company_id is not None:
-            field_dict["CompanyId"] = company_id
-        if asset_id is not None:
-            field_dict["AssetId"] = asset_id
-        if site_id is not None:
-            field_dict["SiteId"] = site_id
-        if asset_service_record_id is not None:
-            field_dict["AssetServiceRecordId"] = asset_service_record_id
-        if serial_number is not None:
-            field_dict["SerialNumber"] = serial_number
-        if asset_user is not None:
-            field_dict["AssetUser"] = asset_user
-        if asset_tag is not None:
-            field_dict["AssetTag"] = asset_tag
-        if equipment_id is not None:
-            field_dict["EquipmentId"] = equipment_id
-        if asset_name is not None:
-            field_dict["AssetName"] = asset_name
-        if category_name is not None:
-            field_dict["CategoryName"] = category_name
-        if manufacturer_name is not None:
-            field_dict["ManufacturerName"] = manufacturer_name
-        if site_name is not None:
-            field_dict["SiteName"] = site_name
-        if maintenance_plan_id is not None:
-            field_dict["MaintenancePlanId"] = maintenance_plan_id
-        if maintenance_plan_name is not None:
-            field_dict["MaintenancePlanName"] = maintenance_plan_name
-        if maintenance_task_id is not None:
-            field_dict["MaintenanceTaskId"] = maintenance_task_id
-        if maintenance_task_name is not None:
-            field_dict["MaintenanceTaskName"] = maintenance_task_name
-        if next_service_date is not None:
-            field_dict["NextServiceDate"] = next_service_date
-        if advance_recall_date is not None:
-            field_dict["AdvanceRecallDate"] = advance_recall_date
-        if grace_period_date is not None:
-            field_dict["GracePeriodDate"] = grace_period_date
-        if certificate_next_service_date is not None:
-            field_dict["CertificateNextServiceDate"] = certificate_next_service_date
-        if service_interval is not None:
-            field_dict["ServiceInterval"] = service_interval
-        if interval_cycle is not None:
-            field_dict["IntervalCycle"] = interval_cycle
-        if interval_length is not None:
-            field_dict["IntervalLength"] = interval_length
-        if on_day is not None:
-            field_dict["OnDay"] = on_day
-        if on_month is not None:
-            field_dict["OnMonth"] = on_month
-        if on_week_days is not None:
-            field_dict["OnWeekDays"] = on_week_days
-        if weekday_of_month is not None:
-            field_dict["WeekdayOfMonth"] = weekday_of_month
-        if advance_recall_period is not None:
-            field_dict["AdvanceRecallPeriod"] = advance_recall_period
-        if days_before_due is not None:
-            field_dict["DaysBeforeDue"] = days_before_due
-        if past_due_grace_period is not None:
-            field_dict["PastDueGracePeriod"] = past_due_grace_period
-        if days_after_due is not None:
-            field_dict["DaysAfterDue"] = days_after_due
-
+        if self.company_id is not None:
+            field_dict["CompanyId"] = self.company_id
+        if self.asset_id is not None:
+            field_dict["AssetId"] = self.asset_id
+        if self.site_id is not None:
+            field_dict["SiteId"] = self.site_id
+        if self.asset_service_record_id is not None:
+            field_dict["AssetServiceRecordId"] = self.asset_service_record_id
+        if self.serial_number is not None:
+            field_dict["SerialNumber"] = self.serial_number
+        if self.asset_user is not None:
+            field_dict["AssetUser"] = self.asset_user
+        if self.asset_tag is not None:
+            field_dict["AssetTag"] = self.asset_tag
+        if self.equipment_id is not None:
+            field_dict["EquipmentId"] = self.equipment_id
+        if self.asset_name is not None:
+            field_dict["AssetName"] = self.asset_name
+        if self.category_name is not None:
+            field_dict["CategoryName"] = self.category_name
+        if self.manufacturer_name is not None:
+            field_dict["ManufacturerName"] = self.manufacturer_name
+        if self.site_name is not None:
+            field_dict["SiteName"] = self.site_name
+        if self.maintenance_plan_id is not None:
+            field_dict["MaintenancePlanId"] = self.maintenance_plan_id
+        if self.maintenance_plan_name is not None:
+            field_dict["MaintenancePlanName"] = self.maintenance_plan_name
+        if self.maintenance_task_id is not None:
+            field_dict["MaintenanceTaskId"] = self.maintenance_task_id
+        if self.maintenance_task_name is not None:
+            field_dict["MaintenanceTaskName"] = self.maintenance_task_name
+        if self.next_service_date is not None:
+            field_dict["NextServiceDate"] = _isoformat_if_datetime(self.next_service_date)
+        if self.advance_recall_date is not None:
+            field_dict["AdvanceRecallDate"] = _isoformat_if_datetime(self.advance_recall_date)
+        if self.grace_period_date is not None:
+            field_dict["GracePeriodDate"] = _isoformat_if_datetime(self.grace_period_date)
+        if self.certificate_next_service_date is not None:
+            field_dict["CertificateNextServiceDate"] = _isoformat_if_datetime(
+                self.certificate_next_service_date
+            )
+        if self.service_interval is not None:
+            field_dict["ServiceInterval"] = self.service_interval
+        if self.interval_cycle is not None:
+            field_dict["IntervalCycle"] = self.interval_cycle
+        if self.interval_length is not None:
+            field_dict["IntervalLength"] = self.interval_length
+        if self.on_day is not None:
+            field_dict["OnDay"] = self.on_day
+        if self.on_month is not None:
+            field_dict["OnMonth"] = self.on_month
+        if self.on_week_days is not None:
+            field_dict["OnWeekDays"] = self.on_week_days
+        if self.weekday_of_month is not None:
+            field_dict["WeekdayOfMonth"] = self.weekday_of_month
+        if self.advance_recall_period is not None:
+            field_dict["AdvanceRecallPeriod"] = self.advance_recall_period
+        if self.days_before_due is not None:
+            field_dict["DaysBeforeDue"] = self.days_before_due
+        if self.past_due_grace_period is not None:
+            field_dict["PastDueGracePeriod"] = self.past_due_grace_period
+        if self.days_after_due is not None:
+            field_dict["DaysAfterDue"] = self.days_after_due
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         company_id = d.pop("CompanyId", None)
-
         asset_id = d.pop("AssetId", None)
-
         site_id = d.pop("SiteId", None)
-
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         asset_name = d.pop("AssetName", None)
-
         category_name = d.pop("CategoryName", None)
-
         manufacturer_name = d.pop("ManufacturerName", None)
-
         site_name = d.pop("SiteName", None)
-
         maintenance_plan_id = d.pop("MaintenancePlanId", None)
-
         maintenance_plan_name = d.pop("MaintenancePlanName", None)
-
         maintenance_task_id = d.pop("MaintenanceTaskId", None)
-
         maintenance_task_name = d.pop("MaintenanceTaskName", None)
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -278,14 +180,11 @@ class AssetToAssetServiceForecastModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_advance_recall_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -295,14 +194,11 @@ class AssetToAssetServiceForecastModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 advance_recall_date_type_0 = isoparse(data)
-
                 return advance_recall_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         advance_recall_date = _parse_advance_recall_date(d.pop("AdvanceRecallDate", None))
-
         def _parse_grace_period_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -312,14 +208,11 @@ class AssetToAssetServiceForecastModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 grace_period_date_type_0 = isoparse(data)
-
                 return grace_period_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         grace_period_date = _parse_grace_period_date(d.pop("GracePeriodDate", None))
-
         def _parse_certificate_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -329,38 +222,24 @@ class AssetToAssetServiceForecastModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 certificate_next_service_date_type_0 = isoparse(data)
-
                 return certificate_next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         certificate_next_service_date = _parse_certificate_next_service_date(
             d.pop("CertificateNextServiceDate", None)
         )
-
         service_interval = d.pop("ServiceInterval", None)
-
         interval_cycle = d.pop("IntervalCycle", None)
-
         interval_length = d.pop("IntervalLength", None)
-
         on_day = d.pop("OnDay", None)
-
         on_month = d.pop("OnMonth", None)
-
         on_week_days = d.pop("OnWeekDays", None)
-
         weekday_of_month = d.pop("WeekdayOfMonth", None)
-
         advance_recall_period = d.pop("AdvanceRecallPeriod", None)
-
         days_before_due = d.pop("DaysBeforeDue", None)
-
         past_due_grace_period = d.pop("PastDueGracePeriod", None)
-
         days_after_due = d.pop("DaysAfterDue", None)
-
         qualer_api_models_asset_to_asset_service_forecast_model = cls(
             company_id=company_id,
             asset_id=asset_id,
@@ -394,7 +273,6 @@ class AssetToAssetServiceForecastModel:
             past_due_grace_period=past_due_grace_period,
             days_after_due=days_after_due,
         )
-
         qualer_api_models_asset_to_asset_service_forecast_model.additional_properties = d
         return qualer_api_models_asset_to_asset_service_forecast_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_assets_count_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_assets_count_response_model.py
@@ -57,45 +57,25 @@ class AssetToAssetsCountResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         assets_all = self.assets_all
-
         assets_collected = self.assets_collected
-
         assets_recently_serviced = self.assets_recently_serviced
-
         assets_due = self.assets_due
-
         assets_past_due = self.assets_past_due
-
         assets_service_pending = self.assets_service_pending
-
         assets_recently_purchased = self.assets_recently_purchased
-
         assets_warranty_expires = self.assets_warranty_expires
-
         assets_due_for_replacement = self.assets_due_for_replacement
-
         assets_out_of_service = self.assets_out_of_service
-
         assets_not_serviced = self.assets_not_serviced
-
         assets_without_schedule = self.assets_without_schedule
-
         assets_without_vendor = self.assets_without_vendor
-
         assets_without_product = self.assets_without_product
-
         assets_added = self.assets_added
-
         assets_updated = self.assets_updated
-
         assets_deleted = self.assets_deleted
-
         assets_no_agreement = self.assets_no_agreement
-
         assets_expired_agreement = self.assets_expired_agreement
-
         assets_expiring_soon_agreement = self.assets_expiring_soon_agreement
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -139,52 +119,31 @@ class AssetToAssetsCountResponseModel:
             field_dict["AssetsExpiredAgreement"] = assets_expired_agreement
         if assets_expiring_soon_agreement is not None:
             field_dict["AssetsExpiringSoonAgreement"] = assets_expiring_soon_agreement
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         assets_all = d.pop("AssetsAll", None)
-
         assets_collected = d.pop("AssetsCollected", None)
-
         assets_recently_serviced = d.pop("AssetsRecentlyServiced", None)
-
         assets_due = d.pop("AssetsDue", None)
-
         assets_past_due = d.pop("AssetsPastDue", None)
-
         assets_service_pending = d.pop("AssetsServicePending", None)
-
         assets_recently_purchased = d.pop("AssetsRecentlyPurchased", None)
-
         assets_warranty_expires = d.pop("AssetsWarrantyExpires", None)
-
         assets_due_for_replacement = d.pop("AssetsDueForReplacement", None)
-
         assets_out_of_service = d.pop("AssetsOutOfService", None)
-
         assets_not_serviced = d.pop("AssetsNotServiced", None)
-
         assets_without_schedule = d.pop("AssetsWithoutSchedule", None)
-
         assets_without_vendor = d.pop("AssetsWithoutVendor", None)
-
         assets_without_product = d.pop("AssetsWithoutProduct", None)
-
         assets_added = d.pop("AssetsAdded", None)
-
         assets_updated = d.pop("AssetsUpdated", None)
-
         assets_deleted = d.pop("AssetsDeleted", None)
-
         assets_no_agreement = d.pop("AssetsNoAgreement", None)
-
         assets_expired_agreement = d.pop("AssetsExpiredAgreement", None)
-
         assets_expiring_soon_agreement = d.pop("AssetsExpiringSoonAgreement", None)
-
         qualer_api_models_asset_to_assets_count_response_model = cls(
             assets_all=assets_all,
             assets_collected=assets_collected,
@@ -207,7 +166,6 @@ class AssetToAssetsCountResponseModel:
             assets_expired_agreement=assets_expired_agreement,
             assets_expiring_soon_agreement=assets_expiring_soon_agreement,
         )
-
         qualer_api_models_asset_to_assets_count_response_model.additional_properties = d
         return qualer_api_models_asset_to_assets_count_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_counters_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_counters_response_model.py
@@ -29,17 +29,11 @@ class AssetToClientAssetCountersResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         client_assets_collected = self.client_assets_collected
-
         client_unset = self.client_unset
-
         client_due_for_service = self.client_due_for_service
-
         client_past_due = self.client_past_due
-
         client_out_of_service = self.client_out_of_service
-
         client_without_schedule = self.client_without_schedule
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -55,24 +49,17 @@ class AssetToClientAssetCountersResponseModel:
             field_dict["ClientOutOfService"] = client_out_of_service
         if client_without_schedule is not None:
             field_dict["ClientWithoutSchedule"] = client_without_schedule
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         client_assets_collected = d.pop("ClientAssetsCollected", None)
-
         client_unset = d.pop("ClientUnset", None)
-
         client_due_for_service = d.pop("ClientDueForService", None)
-
         client_past_due = d.pop("ClientPastDue", None)
-
         client_out_of_service = d.pop("ClientOutOfService", None)
-
         client_without_schedule = d.pop("ClientWithoutSchedule", None)
-
         qualer_api_models_asset_to_client_asset_counters_response_model = cls(
             client_assets_collected=client_assets_collected,
             client_unset=client_unset,
@@ -81,7 +68,6 @@ class AssetToClientAssetCountersResponseModel:
             client_out_of_service=client_out_of_service,
             client_without_schedule=client_without_schedule,
         )
-
         qualer_api_models_asset_to_client_asset_counters_response_model.additional_properties = d
         return qualer_api_models_asset_to_client_asset_counters_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_client_asset_manager_response_model.py
@@ -218,265 +218,100 @@ class AssetToClientAssetManagerResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_maker = self.asset_maker
-
-        record_type: Optional[int] = None
-        if self.record_type:
-            record_type = self.record_type.value
-
+        record_type = self.record_type.value if self.record_type else None
         parent_asset_id = self.parent_asset_id
-
         children_count = self.children_count
-
         site_id = self.site_id
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         legacy_identifier = self.legacy_identifier
-
         criticality = self.criticality
-
         condition = self.condition
-
         asset_class = self.asset_class
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
-        retirment_date: Optional[str]
-        if not self.retirment_date:
-            retirment_date = None
-        elif isinstance(self.retirment_date, datetime.datetime):
-            retirment_date = self.retirment_date.isoformat()
-        else:
-            retirment_date = self.retirment_date
-
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
+        retirment_date = self.retirment_date.isoformat() if self.retirment_date else None
         client_vendor_id = self.client_vendor_id
-
         company_name = self.company_name
-
         site_name = self.site_name
-
         asset_has_image = self.asset_has_image
-
         has_image = self.has_image
-
         parent_has_image = self.parent_has_image
-
         pool_id = self.pool_id
-
         pool = self.pool
-
         product_id = self.product_id
-
         parent_product_id = self.parent_product_id
-
         product_name = self.product_name
-
         parent_product_name = self.parent_product_name
-
         category_id = self.category_id
-
         root_category_id = self.root_category_id
-
         category_name = self.category_name
-
         root_category_name = self.root_category_name
-
         manufacturer_id = self.manufacturer_id
-
         manufacturer = self.manufacturer
-
         display_part_number = self.display_part_number
-
         display_name = self.display_name
-
         manufacturer_part_number = self.manufacturer_part_number
-
         asset_room = self.asset_room
-
         location = self.location
-
         station = self.station
-
-        tool_role: Optional[int] = None
-        if self.tool_role:
-            tool_role = self.tool_role.value
-
+        tool_role = self.tool_role.value if self.tool_role else None
         tool_id = self.tool_id
-
         department_id = self.department_id
-
         department_name = self.department_name
-
         custodian_name = self.custodian_name
-
         warranty = self.warranty
-
-        warranty_end: Optional[str]
-        if not self.warranty_end:
-            warranty_end = None
-        elif isinstance(self.warranty_end, datetime.datetime):
-            warranty_end = self.warranty_end.isoformat()
-        else:
-            warranty_end = self.warranty_end
-
+        warranty_end = self.warranty_end.isoformat() if self.warranty_end else None
         is_warranty_expired = self.is_warranty_expired
-
         depreciation_method = self.depreciation_method
-
         depreciation_basis = self.depreciation_basis
-
         salvage_value = self.salvage_value
-
         total_service_cost = self.total_service_cost
-
         life_span_months = self.life_span_months
-
-        due_for_replacement_date: Optional[str]
-        if not self.due_for_replacement_date:
-            due_for_replacement_date = None
-        elif isinstance(self.due_for_replacement_date, datetime.datetime):
-            due_for_replacement_date = self.due_for_replacement_date.isoformat()
-        else:
-            due_for_replacement_date = self.due_for_replacement_date
-
+        due_for_replacement_date = self.due_for_replacement_date.isoformat() if self.due_for_replacement_date else None
         depreciation_proc = self.depreciation_proc
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
         purchase_cost = self.purchase_cost
-
         time_in_service = self.time_in_service
-
         retirement_reason = self.retirement_reason
-
         residual_cost = self.residual_cost
-
         employee_id = self.employee_id
-
         asset_collection_id = self.asset_collection_id
-
         asset_service_record_id = self.asset_service_record_id
-
-        result_status: Optional[int] = None
-        if self.result_status:
-            result_status = self.result_status.value
-
-        as_found_result: Optional[int] = None
-        if self.as_found_result:
-            as_found_result = self.as_found_result.value
-
-        as_left_result: Optional[int] = None
-        if self.as_left_result:
-            as_left_result = self.as_left_result.value
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        last_service: Optional[str]
-        if not self.last_service:
-            last_service = None
-        else:
-            last_service = self.last_service
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        result_status = self.result_status.value if self.result_status else None
+        as_found_result = self.as_found_result.value if self.as_found_result else None
+        as_left_result = self.as_left_result.value if self.as_left_result else None
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        last_service = self.last_service
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         next_service = self.next_service
-
         service_schedule_segment_id = self.service_schedule_segment_id
-
         service_schedule_id = self.service_schedule_id
-
         service_schedule = self.service_schedule
-
         in_service = self.in_service
-
         in_last_service = self.in_last_service
-
         service_order_id = self.service_order_id
-
         service_order_status: Optional[str] = (
             self.service_order_status.value if self.service_order_status else None
         )
-
         custom_order_number = self.custom_order_number
-
         service_order_item_id = self.service_order_item_id
-
         vendor = self.vendor
-
         technician = self.technician
-
         certificate_number = self.certificate_number
-
-        due_trigger_date: Optional[str]
-        if not self.due_trigger_date:
-            due_trigger_date = None
-        elif isinstance(self.due_trigger_date, datetime.datetime):
-            due_trigger_date = self.due_trigger_date.isoformat()
-        else:
-            due_trigger_date = self.due_trigger_date
-
-        past_due_trigger_date: Optional[str]
-        if not self.past_due_trigger_date:
-            past_due_trigger_date = None
-        elif isinstance(self.past_due_trigger_date, datetime.datetime):
-            past_due_trigger_date = self.past_due_trigger_date.isoformat()
-        else:
-            past_due_trigger_date = self.past_due_trigger_date
-
-        due_status: Optional[int] = None
-        if self.due_status:
-            due_status = self.due_status.value
-
-        work_status: Optional[int] = None
-        if self.work_status:
-            work_status = self.work_status.value
-
+        due_trigger_date = self.due_trigger_date.isoformat() if self.due_trigger_date else None
+        past_due_trigger_date = self.past_due_trigger_date.isoformat() if self.past_due_trigger_date else None
+        due_status = self.due_status.value if self.due_status else None
+        work_status = self.work_status.value if self.work_status else None
         service_tag = self.service_tag
-
         service_site_name = self.service_site_name
-
         service_site_id = self.service_site_id
-
         standard_title = self.standard_title
-
         schedules = self.schedules
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -666,20 +501,15 @@ class AssetToClientAssetManagerResponseModel:
             field_dict["StandardTitle"] = standard_title
         if schedules is not None:
             field_dict["Schedules"] = schedules
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         _record_type = d.pop("RecordType", None)
         record_type: Optional[AssetToClientAssetManagerResponseModelRecordType]
         if not _record_type:
@@ -688,29 +518,17 @@ class AssetToClientAssetManagerResponseModel:
             record_type = None
         else:
             record_type = AssetToClientAssetManagerResponseModelRecordType(_record_type)
-
         parent_asset_id = d.pop("ParentAssetId", None)
-
         children_count = d.pop("ChildrenCount", None)
-
         site_id = d.pop("SiteId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         criticality = d.pop("Criticality", None)
-
         condition = d.pop("Condition", None)
-
         asset_class = d.pop("AssetClass", None)
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -720,14 +538,11 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         def _parse_retirment_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -737,62 +552,35 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 retirment_date_type_0 = isoparse(data)
-
                 return retirment_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirment_date = _parse_retirment_date(d.pop("RetirmentDate", None))
-
         client_vendor_id = d.pop("ClientVendorId", None)
-
         company_name = d.pop("CompanyName", None)
-
         site_name = d.pop("SiteName", None)
-
         asset_has_image = d.pop("AssetHasImage", None)
-
         has_image = d.pop("HasImage", None)
-
         parent_has_image = d.pop("ParentHasImage", None)
-
         pool_id = d.pop("PoolId", None)
-
         pool = d.pop("Pool", None)
-
         product_id = d.pop("ProductId", None)
-
         parent_product_id = d.pop("ParentProductId", None)
-
         product_name = d.pop("ProductName", None)
-
         parent_product_name = d.pop("ParentProductName", None)
-
         category_id = d.pop("CategoryId", None)
-
         root_category_id = d.pop("RootCategoryId", None)
-
         category_name = d.pop("CategoryName", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         manufacturer_id = d.pop("ManufacturerId", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         display_part_number = d.pop("DisplayPartNumber", None)
-
         display_name = d.pop("DisplayName", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         asset_room = d.pop("AssetRoom", None)
-
         location = d.pop("Location", None)
-
         station = d.pop("Station", None)
-
         _tool_role = d.pop("ToolRole", None)
         tool_role: Optional[AssetToClientAssetManagerResponseModelToolRole]
         if not _tool_role:
@@ -801,17 +589,11 @@ class AssetToClientAssetManagerResponseModel:
             tool_role = None
         else:
             tool_role = AssetToClientAssetManagerResponseModelToolRole(_tool_role)
-
         tool_id = d.pop("ToolId", None)
-
         department_id = d.pop("DepartmentId", None)
-
         department_name = d.pop("DepartmentName", None)
-
         custodian_name = d.pop("CustodianName", None)
-
         warranty = d.pop("Warranty", None)
-
         def _parse_warranty_end(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -819,26 +601,17 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 warranty_end_type_0 = isoparse(data)
-
                 return warranty_end_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         warranty_end = _parse_warranty_end(d.pop("WarrantyEnd", None))
-
         is_warranty_expired = d.pop("IsWarrantyExpired", None)
-
         depreciation_method = d.pop("DepreciationMethod", None)
-
         depreciation_basis = d.pop("DepreciationBasis", None)
-
         salvage_value = d.pop("SalvageValue", None)
-
         total_service_cost = d.pop("TotalServiceCost", None)
-
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_due_for_replacement_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -848,18 +621,14 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_for_replacement_date_type_0 = isoparse(data)
-
                 return due_for_replacement_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_for_replacement_date = _parse_due_for_replacement_date(
             d.pop("DueForReplacementDate", None)
         )
-
         depreciation_proc = d.pop("DepreciationProc", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -867,28 +636,18 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         purchase_cost = d.pop("PurchaseCost", None)
-
         time_in_service = d.pop("TimeInService", None)
-
         retirement_reason = d.pop("RetirementReason", None)
-
         residual_cost = d.pop("ResidualCost", None)
-
         employee_id = d.pop("EmployeeId", None)
-
         asset_collection_id = d.pop("QuickCollectionId", None)
-
         asset_service_record_id = d.pop("AssetServiceRecordId", None)
-
         _result_status = d.pop("ResultStatus", None)
         result_status: Optional[ServiceResultStatus]
         if not _result_status:
@@ -897,7 +656,6 @@ class AssetToClientAssetManagerResponseModel:
             result_status = None
         else:
             result_status = ServiceResultStatus(_result_status)
-
         _as_found_result = d.pop("AsFoundResult", None)
         as_found_result: Optional[ServiceResultStatus]
         if not _as_found_result:
@@ -906,7 +664,6 @@ class AssetToClientAssetManagerResponseModel:
             as_found_result = None
         else:
             as_found_result = ServiceResultStatus(_as_found_result)
-
         _as_left_result = d.pop("AsLeftResult", None)
         as_left_result: Optional[ServiceResultStatus]
         if not _as_left_result:
@@ -915,7 +672,6 @@ class AssetToClientAssetManagerResponseModel:
             as_left_result = None
         else:
             as_left_result = ServiceResultStatus(_as_left_result)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -925,21 +681,16 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_last_service(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         last_service = _parse_last_service(d.pop("LastService", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -949,41 +700,25 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         next_service = d.pop("NextService", None)
-
         service_schedule_segment_id = d.pop("ServiceScheduleSegmentId", None)
-
         service_schedule_id = d.pop("ServiceScheduleId", None)
-
         service_schedule = d.pop("ServiceSchedule", None)
-
         in_service = d.pop("InService", None)
-
         in_last_service = d.pop("InLastService", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         _service_order_status = d.pop("ServiceOrderStatus", None)
         service_order_status = ServiceOrderStatus.from_api_value(_service_order_status)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         vendor = d.pop("Vendor", None)
-
         technician = d.pop("Technician", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_due_trigger_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -993,14 +728,11 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_trigger_date_type_0 = isoparse(data)
-
                 return due_trigger_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_trigger_date = _parse_due_trigger_date(d.pop("DueTriggerDate", None))
-
         def _parse_past_due_trigger_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1010,14 +742,11 @@ class AssetToClientAssetManagerResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 past_due_trigger_date_type_0 = isoparse(data)
-
                 return past_due_trigger_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         past_due_trigger_date = _parse_past_due_trigger_date(d.pop("PastDueTriggerDate", None))
-
         _due_status = d.pop("DueStatus", None)
         due_status: Optional[AssetToClientAssetManagerResponseModelDueStatus]
         if not _due_status:
@@ -1026,7 +755,6 @@ class AssetToClientAssetManagerResponseModel:
             due_status = None
         else:
             due_status = AssetToClientAssetManagerResponseModelDueStatus(_due_status)
-
         _work_status = d.pop("WorkStatus", None)
         work_status: Optional[WorkStatus]
         if not _work_status:
@@ -1035,17 +763,11 @@ class AssetToClientAssetManagerResponseModel:
             work_status = None
         else:
             work_status = WorkStatus(_work_status)
-
         service_tag = d.pop("ServiceTag", None)
-
         service_site_name = d.pop("ServiceSiteName", None)
-
         service_site_id = d.pop("ServiceSiteId", None)
-
         standard_title = d.pop("StandardTitle", None)
-
         schedules = d.pop("Schedules", None)
-
         qualer_api_models_asset_to_client_asset_manager_response_model = cls(
             asset_id=asset_id,
             asset_name=asset_name,
@@ -1141,7 +863,6 @@ class AssetToClientAssetManagerResponseModel:
             standard_title=standard_title,
             schedules=schedules,
         )
-
         qualer_api_models_asset_to_client_asset_manager_response_model.additional_properties = d
         return qualer_api_models_asset_to_client_asset_manager_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_employee_filter_preference_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_employee_filter_preference_response_model.py
@@ -29,27 +29,10 @@ class AssetToEmployeeFilterPreferenceResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         filter_type = self.filter_type
-
         within_days = self.within_days
-
         use_date_range = self.use_date_range
-
-        start_date: Optional[str]
-        if not self.start_date:
-            start_date = None
-        elif isinstance(self.start_date, datetime.datetime):
-            start_date = self.start_date.isoformat()
-        else:
-            start_date = self.start_date
-
-        end_date: Optional[str]
-        if not self.end_date:
-            end_date = None
-        elif isinstance(self.end_date, datetime.datetime):
-            end_date = self.end_date.isoformat()
-        else:
-            end_date = self.end_date
-
+        start_date = self.start_date.isoformat() if self.start_date else None
+        end_date = self.end_date.isoformat() if self.end_date else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -63,18 +46,14 @@ class AssetToEmployeeFilterPreferenceResponseModel:
             field_dict["StartDate"] = start_date
         if end_date is not None:
             field_dict["EndDate"] = end_date
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         filter_type = d.pop("FilterType", None)
-
         within_days = d.pop("WithinDays", None)
-
         use_date_range = d.pop("UseDateRange", None)
-
         def _parse_start_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -82,14 +61,11 @@ class AssetToEmployeeFilterPreferenceResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 start_date_type_0 = isoparse(data)
-
                 return start_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         start_date = _parse_start_date(d.pop("StartDate", None))
-
         def _parse_end_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -97,14 +73,11 @@ class AssetToEmployeeFilterPreferenceResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 end_date_type_0 = isoparse(data)
-
                 return end_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         end_date = _parse_end_date(d.pop("EndDate", None))
-
         qualer_api_models_asset_to_employee_filter_preference_response_model = cls(
             filter_type=filter_type,
             within_days=within_days,
@@ -112,7 +85,6 @@ class AssetToEmployeeFilterPreferenceResponseModel:
             start_date=start_date,
             end_date=end_date,
         )
-
         qualer_api_models_asset_to_employee_filter_preference_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_asset_to_employee_preference_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_asset_to_employee_preference_response_model.py
@@ -27,17 +27,12 @@ class AssetToEmployeePreferenceResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         element_type = self.element_type
-
         element_page = self.element_page
-
         element_id = self.element_id
-
         preference: Optional[List[str]] = None
         if self.preference:
             preference = self.preference
-
         is_pinned = self.is_pinned
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -51,22 +46,16 @@ class AssetToEmployeePreferenceResponseModel:
             field_dict["Preference"] = preference
         if is_pinned is not None:
             field_dict["IsPinned"] = is_pinned
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         element_type = d.pop("ElementType", None)
-
         element_page = d.pop("ElementPage", None)
-
         element_id = d.pop("ElementId", None)
-
         preference = cast(List[str], d.pop("Preference", None))
-
         is_pinned = d.pop("IsPinned", None)
-
         qualer_api_models_asset_to_employee_preference_response_model = cls(
             element_type=element_type,
             element_page=element_page,
@@ -74,7 +63,6 @@ class AssetToEmployeePreferenceResponseModel:
             preference=preference,
             is_pinned=is_pinned,
         )
-
         qualer_api_models_asset_to_employee_preference_response_model.additional_properties = d
         return qualer_api_models_asset_to_employee_preference_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_attributes_to_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_attributes_to_attribute_response.py
@@ -21,9 +21,7 @@ class AttributesToAttributeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class AttributesToAttributeResponse:
             field_dict["Name"] = name
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_attributes_to_attribute_response = cls(
             name=name,
             value=value,
         )
-
         qualer_api_models_attributes_to_attribute_response.additional_properties = d
         return qualer_api_models_attributes_to_attribute_response
 

--- a/src/qualer_sdk/models/qualer_api_models_client_attributes_from_client_attribute_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_client_attributes_from_client_attribute_model.py
@@ -23,11 +23,8 @@ class ClientAttributesFromClientAttributeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         client_site_id = self.client_site_id
-
         name = self.name
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ClientAttributesFromClientAttributeModel:
             field_dict["Name"] = name
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         client_site_id = d.pop("ClientSiteId", None)
-
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_client_attributes_from_client_attribute_model = cls(
             client_site_id=client_site_id,
             name=name,
             value=value,
         )
-
         qualer_api_models_client_attributes_from_client_attribute_model.additional_properties = d
         return qualer_api_models_client_attributes_from_client_attribute_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_asset_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_asset_model.py
@@ -83,7 +83,6 @@ class ClientsFromAssetModel:
         serial_number = self.serial_number
         asset_tag = self.asset_tag
         asset_user = self.asset_user
-
         # Enum and optional string fields
         asset_status: Optional[str] = (
             self.asset_status.value if self.asset_status is not None else None
@@ -97,7 +96,6 @@ class ClientsFromAssetModel:
         legacy_identifier = self.legacy_identifier
         condition = self.condition
         criticality = self.criticality
-
         # Datetime fields to ISO8601 strings
         purchase_date: Optional[str]
         if self.purchase_date is None:
@@ -106,10 +104,8 @@ class ClientsFromAssetModel:
             purchase_date = self.purchase_date.isoformat()
         else:
             purchase_date = self.purchase_date
-
         purchase_cost = self.purchase_cost
         life_span_months = self.life_span_months
-
         activation_date: Optional[str]
         if self.activation_date is None:
             activation_date = None
@@ -117,10 +113,8 @@ class ClientsFromAssetModel:
             activation_date = self.activation_date.isoformat()
         else:
             activation_date = self.activation_date
-
         depreciation_basis = self.depreciation_basis
         depreciation_method = self.depreciation_method
-
         retirement_date: Optional[str]
         if self.retirement_date is None:
             retirement_date = None
@@ -128,9 +122,7 @@ class ClientsFromAssetModel:
             retirement_date = self.retirement_date.isoformat()
         else:
             retirement_date = self.retirement_date
-
         salvage_value = self.salvage_value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -186,7 +178,6 @@ class ClientsFromAssetModel:
             field_dict["RetirementDate"] = retirement_date
         if salvage_value is not None:
             field_dict["SalvageValue"] = salvage_value
-
         return field_dict
 
     @classmethod
@@ -200,14 +191,12 @@ class ClientsFromAssetModel:
         serial_number = d.pop("SerialNumber", None)
         asset_tag = d.pop("AssetTag", None)
         asset_user = d.pop("AssetUser", None)
-
         _asset_status = d.pop("AssetStatus", None)
         asset_status: Optional[ClientsFromAssetModelAssetStatus]
         if _asset_status is None:
             asset_status = None
         else:
             asset_status = ClientsFromAssetModelAssetStatus(_asset_status)
-
         asset_name = d.pop("AssetName", None)
         asset_description = d.pop("AssetDescription", None)
         asset_maker = d.pop("AssetMaker", None)
@@ -217,7 +206,6 @@ class ClientsFromAssetModel:
         legacy_identifier = d.pop("LegacyIdentifier", None)
         condition = d.pop("Condition", None)
         criticality = d.pop("Criticality", None)
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if data is None:
                 return data
@@ -229,11 +217,9 @@ class ClientsFromAssetModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
         purchase_cost = d.pop("PurchaseCost", None)
         life_span_months = d.pop("LifeSpanMonths", None)
-
         def _parse_activation_date(data: object) -> Optional[datetime.datetime]:
             if data is None:
                 return data
@@ -245,11 +231,9 @@ class ClientsFromAssetModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
         depreciation_basis = d.pop("DepreciationBasis", None)
         depreciation_method = d.pop("DepreciationMethod", None)
-
         def _parse_retirement_date(data: object) -> Optional[datetime.datetime]:
             if data is None:
                 return data
@@ -261,10 +245,8 @@ class ClientsFromAssetModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         retirement_date = _parse_retirement_date(d.pop("RetirementDate", None))
         salvage_value = d.pop("SalvageValue", None)
-
         qualer_api_models_clients_from_asset_model = cls(
             site_id=site_id,
             product_id=product_id,
@@ -293,7 +275,6 @@ class ClientsFromAssetModel:
             retirement_date=retirement_date,
             salvage_value=salvage_value,
         )
-
         qualer_api_models_clients_from_asset_model.additional_properties = d
         return qualer_api_models_clients_from_asset_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_model.py
@@ -19,24 +19,20 @@ class ClientsFromClientAssetModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if asset_id is not None:
             field_dict["AssetId"] = asset_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         qualer_api_models_clients_from_client_asset_model = cls(
             asset_id=asset_id,
         )
-
         qualer_api_models_clients_from_client_asset_model.additional_properties = d
         return qualer_api_models_clients_from_client_asset_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_query.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_asset_query.py
@@ -27,15 +27,10 @@ class ClientsFromClientAssetQuery:
 
     def to_dict(self) -> Dict[str, Any]:
         equipment_id = self.equipment_id
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         barcode = self.barcode
-
         legacy_id = self.legacy_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class ClientsFromClientAssetQuery:
             field_dict["Barcode"] = barcode
         if legacy_id is not None:
             field_dict["LegacyId"] = legacy_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         equipment_id = d.pop("EquipmentId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         barcode = d.pop("Barcode", None)
-
         legacy_id = d.pop("LegacyId", None)
-
         qualer_api_models_clients_from_client_asset_query = cls(
             equipment_id=equipment_id,
             serial_number=serial_number,
@@ -72,7 +61,6 @@ class ClientsFromClientAssetQuery:
             barcode=barcode,
             legacy_id=legacy_id,
         )
-
         qualer_api_models_clients_from_client_asset_query.additional_properties = d
         return qualer_api_models_clients_from_client_asset_query
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_company_search_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_company_search_model.py
@@ -29,17 +29,12 @@ class ClientsFromClientCompanySearchModel:
 
     def to_dict(self) -> Dict[str, Any]:
         legacy_id = self.legacy_id
-
         account_number_text = self.account_number_text
-
         company_name = self.company_name
-
         take = self.take
-
         modified_after: Optional[str] = None
         if self.modified_after:
             modified_after = self.modified_after.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -53,27 +48,21 @@ class ClientsFromClientCompanySearchModel:
             field_dict["Take"] = take
         if modified_after is not None:
             field_dict["ModifiedAfter"] = modified_after
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         legacy_id = d.pop("LegacyId", None)
-
         account_number_text = d.pop("AccountNumberText", None)
-
         company_name = d.pop("CompanyName", None)
-
         take = d.pop("Take", None)
-
         _modified_after = d.pop("ModifiedAfter", None)
         modified_after: Optional[datetime.datetime]
         if not _modified_after:
             modified_after = None
         else:
             modified_after = isoparse(_modified_after)
-
         qualer_api_models_clients_from_client_company_search_model = cls(
             legacy_id=legacy_id,
             account_number_text=account_number_text,
@@ -81,7 +70,6 @@ class ClientsFromClientCompanySearchModel:
             take=take,
             modified_after=modified_after,
         )
-
         qualer_api_models_clients_from_client_company_search_model.additional_properties = d
         return qualer_api_models_clients_from_client_company_search_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_client_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_client_employee_model.py
@@ -19,24 +19,20 @@ class ClientsFromClientEmployeeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         employee_id = self.employee_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if employee_id is not None:
             field_dict["EmployeeId"] = employee_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         employee_id = d.pop("EmployeeId", None)
-
         qualer_api_models_clients_from_client_employee_model = cls(
             employee_id=employee_id,
         )
-
         qualer_api_models_clients_from_client_employee_model.additional_properties = d
         return qualer_api_models_clients_from_client_employee_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_send_employee_email_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_send_employee_email_model.py
@@ -21,9 +21,7 @@ class ClientsFromSendEmployeeEmailModel:
 
     def to_dict(self) -> Dict[str, Any]:
         subject = self.subject
-
         body = self.body
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ClientsFromSendEmployeeEmailModel:
             field_dict["Subject"] = subject
         if body is not None:
             field_dict["Body"] = body
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         subject = d.pop("Subject", None)
-
         body = d.pop("Body", None)
-
         qualer_api_models_clients_from_send_employee_email_model = cls(
             subject=subject,
             body=body,
         )
-
         qualer_api_models_clients_from_send_employee_email_model.additional_properties = d
         return qualer_api_models_clients_from_send_employee_email_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_create_model.py
@@ -49,35 +49,21 @@ class ClientsFromSponsoredClientCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         account_number_text = self.account_number_text
-
-        client_status: Optional[str] = None
-        if self.client_status:
-            client_status = self.client_status.value
-
+        client_status = self.client_status.value if self.client_status else None
         domain_name = self.domain_name
-
         custom_client_name = self.custom_client_name
-
         legacy_id = self.legacy_id
-
         currency_id = self.currency_id
-
         account_representative_employee_id = self.account_representative_employee_id
-
         account_representative_site_id = self.account_representative_site_id
-
         account_manager_employee_id = self.account_manager_employee_id
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -105,7 +91,6 @@ class ClientsFromSponsoredClientCreateModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -113,47 +98,34 @@ class ClientsFromSponsoredClientCreateModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         account_number_text = d.pop("AccountNumberText", None)
-
         _client_status = d.pop("ClientStatus", None)
         client_status: Optional[ClientsFromSponsoredClientCreateModelClientStatus]
         if not _client_status:
             client_status = None
         else:
             client_status = ClientsFromSponsoredClientCreateModelClientStatus(_client_status)
-
         domain_name = d.pop("DomainName", None)
-
         custom_client_name = d.pop("CustomClientName", None)
-
         legacy_id = d.pop("LegacyId", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         account_representative_employee_id = d.pop("AccountRepresentativeEmployeeId", None)
-
         account_representative_site_id = d.pop("AccountRepresentativeSiteId", None)
-
         account_manager_employee_id = d.pop("AccountManagerEmployeeId", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_clients_from_sponsored_client_create_model = cls(
             account_number_text=account_number_text,
             client_status=client_status,
@@ -168,7 +140,6 @@ class ClientsFromSponsoredClientCreateModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_clients_from_sponsored_client_create_model.additional_properties = d
         return qualer_api_models_clients_from_sponsored_client_create_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_edit_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_client_edit_model.py
@@ -51,37 +51,22 @@ class ClientsFromSponsoredClientEditModel:
 
     def to_dict(self) -> Dict[str, Any]:
         company_id = self.company_id
-
         account_number_text = self.account_number_text
-
-        client_status: Optional[str] = None
-        if self.client_status:
-            client_status = self.client_status.value
-
+        client_status = self.client_status.value if self.client_status else None
         domain_name = self.domain_name
-
         custom_client_name = self.custom_client_name
-
         legacy_id = self.legacy_id
-
         currency_id = self.currency_id
-
         account_representative_employee_id = self.account_representative_employee_id
-
         account_representative_site_id = self.account_representative_site_id
-
         account_manager_employee_id = self.account_manager_employee_id
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -111,7 +96,6 @@ class ClientsFromSponsoredClientEditModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -119,49 +103,35 @@ class ClientsFromSponsoredClientEditModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         company_id = d.pop("CompanyId", None)
-
         account_number_text = d.pop("AccountNumberText", None)
-
         _client_status = d.pop("ClientStatus", None)
         client_status: Optional[ClientsFromSponsoredClientEditModelClientStatus]
         if not _client_status:
             client_status = None
         else:
             client_status = ClientsFromSponsoredClientEditModelClientStatus(_client_status)
-
         domain_name = d.pop("DomainName", None)
-
         custom_client_name = d.pop("CustomClientName", None)
-
         legacy_id = d.pop("LegacyId", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         account_representative_employee_id = d.pop("AccountRepresentativeEmployeeId", None)
-
         account_representative_site_id = d.pop("AccountRepresentativeSiteId", None)
-
         account_manager_employee_id = d.pop("AccountManagerEmployeeId", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_clients_from_sponsored_client_edit_model = cls(
             company_id=company_id,
             account_number_text=account_number_text,
@@ -177,7 +147,6 @@ class ClientsFromSponsoredClientEditModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_clients_from_sponsored_client_edit_model.additional_properties = d
         return qualer_api_models_clients_from_sponsored_client_edit_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_from_sponsored_employee_model.py
@@ -33,21 +33,13 @@ class ClientsFromSponsoredEmployeeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         client_company_id = self.client_company_id
-
         first_name = self.first_name
-
         last_name = self.last_name
-
         login_email = self.login_email
-
         password = self.password
-
         subscription_email = self.subscription_email
-
         mobile_phone = self.mobile_phone
-
         office_phone = self.office_phone
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class ClientsFromSponsoredEmployeeModel:
             field_dict["MobilePhone"] = mobile_phone
         if office_phone is not None:
             field_dict["OfficePhone"] = office_phone
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         client_company_id = d.pop("ClientCompanyId", None)
-
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         login_email = d.pop("LoginEmail", None)
-
         password = d.pop("Password", None)
-
         subscription_email = d.pop("SubscriptionEmail", None)
-
         mobile_phone = d.pop("MobilePhone", None)
-
         office_phone = d.pop("OfficePhone", None)
-
         qualer_api_models_clients_from_sponsored_employee_model = cls(
             client_company_id=client_company_id,
             first_name=first_name,
@@ -99,7 +82,6 @@ class ClientsFromSponsoredEmployeeModel:
             mobile_phone=mobile_phone,
             office_phone=office_phone,
         )
-
         qualer_api_models_clients_from_sponsored_employee_model.additional_properties = d
         return qualer_api_models_clients_from_sponsored_employee_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model.py
@@ -70,37 +70,22 @@ class ClientsToClientCompanyResponseModel:
         from ..models.qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0 import (
             ClientsToClientCompanyResponseModelShippingAddressType0,
         )
-
         company_id = self.company_id
-
         account_number_text = self.account_number_text
-
         account_number = self.account_number
-
         currency_id = self.currency_id
-
         client_status = self.client_status
-
         company_name = self.company_name
-
         company_description = self.company_description
-
         domain_name = self.domain_name
-
         custom_client_name = self.custom_client_name
-
         legacy_id = self.legacy_id
-
         updated_on_utc: Optional[str] = None
         if self.updated_on_utc:
             updated_on_utc = self.updated_on_utc.isoformat()
-
         account_representative_employee_id = self.account_representative_employee_id
-
         account_representative_site_id = self.account_representative_site_id
-
         account_manager_employee_id = self.account_manager_employee_id
-
         billing_address: Optional[Dict[str, Any]]
         if not self.billing_address:
             billing_address = None
@@ -111,7 +96,6 @@ class ClientsToClientCompanyResponseModel:
             billing_address = self.billing_address.to_dict()
         else:
             billing_address = self.billing_address
-
         shipping_address: Optional[Dict[str, Any]]
         if not self.shipping_address:
             shipping_address = None
@@ -122,14 +106,12 @@ class ClientsToClientCompanyResponseModel:
             shipping_address = self.shipping_address.to_dict()
         else:
             shipping_address = self.shipping_address
-
         attributes: Optional[List[Dict[str, Any]]] = None
         if self.attributes:
             attributes = []
             for attributes_item_data in self.attributes:
                 attributes_item = attributes_item_data.to_dict()
                 attributes.append(attributes_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -167,7 +149,6 @@ class ClientsToClientCompanyResponseModel:
             field_dict["ShippingAddress"] = shipping_address
         if attributes is not None:
             field_dict["Attributes"] = attributes
-
         return field_dict
 
     @classmethod
@@ -181,41 +162,26 @@ class ClientsToClientCompanyResponseModel:
         from ..models.qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0 import (
             ClientsToClientCompanyResponseModelShippingAddressType0,
         )
-
         d = dict(src_dict)
         company_id = d.pop("CompanyId", None)
-
         account_number_text = d.pop("AccountNumberText", None)
-
         account_number = d.pop("AccountNumber", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         client_status = d.pop("ClientStatus", None)
-
         company_name = d.pop("CompanyName", None)
-
         company_description = d.pop("CompanyDescription", None)
-
         domain_name = d.pop("DomainName", None)
-
         custom_client_name = d.pop("CustomClientName", None)
-
         legacy_id = d.pop("LegacyId", None)
-
         _updated_on_utc = d.pop("UpdatedOnUtc", None)
         updated_on_utc: Optional[datetime.datetime]
         if not _updated_on_utc:
             updated_on_utc = None
         else:
             updated_on_utc = isoparse(_updated_on_utc)
-
         account_representative_employee_id = d.pop("AccountRepresentativeEmployeeId", None)
-
         account_representative_site_id = d.pop("AccountRepresentativeSiteId", None)
-
         account_manager_employee_id = d.pop("AccountManagerEmployeeId", None)
-
         def _parse_billing_address(
             data: object,
         ) -> Optional["ClientsToClientCompanyResponseModelBillingAddressType0"]:
@@ -227,7 +193,6 @@ class ClientsToClientCompanyResponseModel:
                 billing_address_type_0 = (
                     ClientsToClientCompanyResponseModelBillingAddressType0.from_dict(data)
                 )
-
                 return billing_address_type_0
             except Exception:
                 pass
@@ -235,9 +200,7 @@ class ClientsToClientCompanyResponseModel:
                 Optional["ClientsToClientCompanyResponseModelBillingAddressType0"],
                 data,
             )
-
         billing_address = _parse_billing_address(d.pop("BillingAddress", None))
-
         def _parse_shipping_address(
             data: object,
         ) -> Optional["ClientsToClientCompanyResponseModelShippingAddressType0"]:
@@ -249,7 +212,6 @@ class ClientsToClientCompanyResponseModel:
                 shipping_address_type_0 = (
                     ClientsToClientCompanyResponseModelShippingAddressType0.from_dict(data)
                 )
-
                 return shipping_address_type_0
             except Exception:
                 pass
@@ -257,16 +219,12 @@ class ClientsToClientCompanyResponseModel:
                 Optional["ClientsToClientCompanyResponseModelShippingAddressType0"],
                 data,
             )
-
         shipping_address = _parse_shipping_address(d.pop("ShippingAddress", None))
-
         attributes = []
         _attributes = d.pop("Attributes", None)
         for attributes_item_data in _attributes or []:
             attributes_item = AttributesToAttributeResponse.from_dict(attributes_item_data)
-
             attributes.append(attributes_item)
-
         qualer_api_models_clients_to_client_company_response_model = cls(
             company_id=company_id,
             account_number_text=account_number_text,
@@ -286,7 +244,6 @@ class ClientsToClientCompanyResponseModel:
             shipping_address=shipping_address,
             attributes=attributes,
         )
-
         qualer_api_models_clients_to_client_company_response_model.additional_properties = d
         return qualer_api_models_clients_to_client_company_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model_billing_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model_billing_address_type_0.py
@@ -16,14 +16,12 @@ class ClientsToClientCompanyResponseModelBillingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_clients_to_client_company_response_model_billing_address_type_0 = cls()
-
         qualer_api_models_clients_to_client_company_response_model_billing_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0.py
@@ -16,14 +16,12 @@ class ClientsToClientCompanyResponseModelShippingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0 = cls()
-
         qualer_api_models_clients_to_client_company_response_model_shipping_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_asset_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_asset_response.py
@@ -19,24 +19,20 @@ class ClientsToCreatedClientAssetResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_clients_to_created_client_asset_response = cls(
             id=id,
         )
-
         qualer_api_models_clients_to_created_client_asset_response.additional_properties = d
         return qualer_api_models_clients_to_created_client_asset_response
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_company_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_company_response.py
@@ -19,24 +19,20 @@ class ClientsToCreatedClientCompanyResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_clients_to_created_client_company_response = cls(
             id=id,
         )
-
         qualer_api_models_clients_to_created_client_company_response.additional_properties = d
         return qualer_api_models_clients_to_created_client_company_response
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_employee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_created_client_employee_response.py
@@ -19,24 +19,20 @@ class ClientsToCreatedClientEmployeeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_clients_to_created_client_employee_response = cls(
             id=id,
         )
-
         qualer_api_models_clients_to_created_client_employee_response.additional_properties = d
         return qualer_api_models_clients_to_created_client_employee_response
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_employee_employee_department_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_employee_employee_department_response.py
@@ -23,11 +23,8 @@ class ClientsToEmployeeEmployeeDepartmentResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         name = self.name
-
         position = self.position
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ClientsToEmployeeEmployeeDepartmentResponse:
             field_dict["Name"] = name
         if position is not None:
             field_dict["Position"] = position
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         name = d.pop("Name", None)
-
         position = d.pop("Position", None)
-
         qualer_api_models_clients_to_employee_employee_department_response = cls(
             id=id,
             name=name,
             position=position,
         )
-
         qualer_api_models_clients_to_employee_employee_department_response.additional_properties = d
         return qualer_api_models_clients_to_employee_employee_department_response
 

--- a/src/qualer_sdk/models/qualer_api_models_clients_to_employee_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_clients_to_employee_response_model.py
@@ -59,50 +59,27 @@ class ClientsToEmployeeResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         employee_id = self.employee_id
-
         first_name = self.first_name
-
         last_name = self.last_name
-
         company_id = self.company_id
-
         login_email = self.login_email
-
         departments: Optional[List[Dict[str, Any]]] = None
         if self.departments:
             departments = []
             for departments_item_data in self.departments:
                 departments_item = departments_item_data.to_dict()
                 departments.append(departments_item)
-
         subscription_email = self.subscription_email
-
         subscription_phone = self.subscription_phone
-
         office_phone = self.office_phone
-
         is_locked = self.is_locked
-
         image_url = self.image_url
-
         alias = self.alias
-
         title = self.title
-
         is_deleted = self.is_deleted
-
-        last_seen_date_utc: Optional[str]
-        if not self.last_seen_date_utc:
-            last_seen_date_utc = None
-        elif isinstance(self.last_seen_date_utc, datetime.datetime):
-            last_seen_date_utc = self.last_seen_date_utc.isoformat()
-        else:
-            last_seen_date_utc = self.last_seen_date_utc
-
+        last_seen_date_utc = self.last_seen_date_utc.isoformat() if self.last_seen_date_utc else None
         culture_name = self.culture_name
-
         culture_ui_name = self.culture_ui_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -140,7 +117,6 @@ class ClientsToEmployeeResponseModel:
             field_dict["CultureName"] = culture_name
         if culture_ui_name is not None:
             field_dict["CultureUiName"] = culture_ui_name
-
         return field_dict
 
     @classmethod
@@ -148,43 +124,27 @@ class ClientsToEmployeeResponseModel:
         from ..models.qualer_api_models_clients_to_employee_employee_department_response import (
             ClientsToEmployeeEmployeeDepartmentResponse,
         )
-
         d = dict(src_dict)
         employee_id = d.pop("EmployeeId", None)
-
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         company_id = d.pop("CompanyId", None)
-
         login_email = d.pop("LoginEmail", None)
-
         departments = []
         _departments = d.pop("Departments", None)
         for departments_item_data in _departments or []:
             departments_item = ClientsToEmployeeEmployeeDepartmentResponse.from_dict(
                 departments_item_data
             )
-
             departments.append(departments_item)
-
         subscription_email = d.pop("SubscriptionEmail", None)
-
         subscription_phone = d.pop("SubscriptionPhone", None)
-
         office_phone = d.pop("OfficePhone", None)
-
         is_locked = d.pop("IsLocked", None)
-
         image_url = d.pop("ImageUrl", None)
-
         alias = d.pop("Alias", None)
-
         title = d.pop("Title", None)
-
         is_deleted = d.pop("IsDeleted", None)
-
         def _parse_last_seen_date_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -194,18 +154,13 @@ class ClientsToEmployeeResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_seen_date_utc_type_0 = isoparse(data)
-
                 return last_seen_date_utc_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_seen_date_utc = _parse_last_seen_date_utc(d.pop("LastSeenDateUtc", None))
-
         culture_name = d.pop("CultureName", None)
-
         culture_ui_name = d.pop("CultureUiName", None)
-
         qualer_api_models_clients_to_employee_response_model = cls(
             employee_id=employee_id,
             first_name=first_name,
@@ -225,7 +180,6 @@ class ClientsToEmployeeResponseModel:
             culture_name=culture_name,
             culture_ui_name=culture_ui_name,
         )
-
         qualer_api_models_clients_to_employee_response_model.additional_properties = d
         return qualer_api_models_clients_to_employee_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_common_from_attribute_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_from_attribute_model.py
@@ -21,9 +21,7 @@ class CommonFromAttributeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class CommonFromAttributeModel:
             field_dict["Name"] = name
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_common_from_attribute_model = cls(
             name=name,
             value=value,
         )
-
         qualer_api_models_common_from_attribute_model.additional_properties = d
         return qualer_api_models_common_from_attribute_model
 

--- a/src/qualer_sdk/models/qualer_api_models_common_to_culture_list_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_to_culture_list_response_model.py
@@ -21,24 +21,20 @@ class CommonToCultureListResponseModel:
         culture_list: Optional[List[str]] = None
         if self.culture_list:
             culture_list = self.culture_list
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if culture_list is not None:
             field_dict["CultureList"] = culture_list
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         culture_list = cast(List[str], d.pop("CultureList", None))
-
         qualer_api_models_common_to_culture_list_response_model = cls(
             culture_list=culture_list,
         )
-
         qualer_api_models_common_to_culture_list_response_model.additional_properties = d
         return qualer_api_models_common_to_culture_list_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_common_to_setting_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_common_to_setting_response_model.py
@@ -19,24 +19,20 @@ class CommonToSettingResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         value = d.pop("Value", None)
-
         qualer_api_models_common_to_setting_response_model = cls(
             value=value,
         )
-
         qualer_api_models_common_to_setting_response_model.additional_properties = d
         return qualer_api_models_common_to_setting_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_company_to_departments_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_departments_response_model.py
@@ -21,9 +21,7 @@ class CompanyToDepartmentsResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         name = self.name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class CompanyToDepartmentsResponseModel:
             field_dict["Id"] = id
         if name is not None:
             field_dict["Name"] = name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         name = d.pop("Name", None)
-
         qualer_api_models_company_to_departments_response_model = cls(
             id=id,
             name=name,
         )
-
         qualer_api_models_company_to_departments_response_model.additional_properties = d
         return qualer_api_models_company_to_departments_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_company_to_environment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_environment_response_model.py
@@ -21,9 +21,7 @@ class CompanyToEnvironmentResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         name = self.name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class CompanyToEnvironmentResponseModel:
             field_dict["Id"] = id
         if name is not None:
             field_dict["Name"] = name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         name = d.pop("Name", None)
-
         qualer_api_models_company_to_environment_response_model = cls(
             id=id,
             name=name,
         )
-
         qualer_api_models_company_to_environment_response_model.additional_properties = d
         return qualer_api_models_company_to_environment_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_company_to_sites_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_company_to_sites_response_model.py
@@ -21,9 +21,7 @@ class CompanyToSitesResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         name = self.name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class CompanyToSitesResponseModel:
             field_dict["Id"] = id
         if name is not None:
             field_dict["Name"] = name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         name = d.pop("Name", None)
-
         qualer_api_models_company_to_sites_response_model = cls(
             id=id,
             name=name,
         )
-
         qualer_api_models_company_to_sites_response_model.additional_properties = d
         return qualer_api_models_company_to_sites_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_create_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_create_employee_model.py
@@ -41,29 +41,17 @@ class EmployeesFromCreateEmployeeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         login_email = self.login_email
-
         password = self.password
-
         first_name = self.first_name
-
         last_name = self.last_name
-
         subscription_email = self.subscription_email
-
         mobile_phone = self.mobile_phone
-
         office_phone = self.office_phone
-
         alias = self.alias
-
         title = self.title
-
         culture_name = self.culture_name
-
         culture_ui_name = self.culture_ui_name
-
         image_url = self.image_url
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -91,36 +79,23 @@ class EmployeesFromCreateEmployeeModel:
             field_dict["CultureUiName"] = culture_ui_name
         if image_url is not None:
             field_dict["ImageUrl"] = image_url
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         login_email = d.pop("LoginEmail", None)
-
         password = d.pop("Password", None)
-
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         subscription_email = d.pop("SubscriptionEmail", None)
-
         mobile_phone = d.pop("MobilePhone", None)
-
         office_phone = d.pop("OfficePhone", None)
-
         alias = d.pop("Alias", None)
-
         title = d.pop("Title", None)
-
         culture_name = d.pop("CultureName", None)
-
         culture_ui_name = d.pop("CultureUiName", None)
-
         image_url = d.pop("ImageUrl", None)
-
         qualer_api_models_employees_from_create_employee_model = cls(
             login_email=login_email,
             password=password,
@@ -135,7 +110,6 @@ class EmployeesFromCreateEmployeeModel:
             culture_ui_name=culture_ui_name,
             image_url=image_url,
         )
-
         qualer_api_models_employees_from_create_employee_model.additional_properties = d
         return qualer_api_models_employees_from_create_employee_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_employee_department_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_employee_department_model.py
@@ -21,9 +21,7 @@ class EmployeesFromEmployeeDepartmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         department_id = self.department_id
-
         position = self.position
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class EmployeesFromEmployeeDepartmentModel:
             field_dict["DepartmentId"] = department_id
         if position is not None:
             field_dict["Position"] = position
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         department_id = d.pop("DepartmentId", None)
-
         position = d.pop("Position", None)
-
         qualer_api_models_employees_from_employee_department_model = cls(
             department_id=department_id,
             position=position,
         )
-
         qualer_api_models_employees_from_employee_department_model.additional_properties = d
         return qualer_api_models_employees_from_employee_department_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_employee_location_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_employee_location_model.py
@@ -33,21 +33,13 @@ class EmployeesFromEmployeeLocationModel:
 
     def to_dict(self) -> Dict[str, Any]:
         latitude = self.latitude
-
         longitude = self.longitude
-
         accuracy = self.accuracy
-
         altitude = self.altitude
-
         altitude_accuracy = self.altitude_accuracy
-
         heading = self.heading
-
         speed = self.speed
-
         timestamp = self.timestamp
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class EmployeesFromEmployeeLocationModel:
             field_dict["Speed"] = speed
         if timestamp is not None:
             field_dict["Timestamp"] = timestamp
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         latitude = d.pop("Latitude", None)
-
         longitude = d.pop("Longitude", None)
-
         accuracy = d.pop("Accuracy", None)
-
         altitude = d.pop("Altitude", None)
-
         altitude_accuracy = d.pop("AltitudeAccuracy", None)
-
         heading = d.pop("Heading", None)
-
         speed = d.pop("Speed", None)
-
         timestamp = d.pop("Timestamp", None)
-
         qualer_api_models_employees_from_employee_location_model = cls(
             latitude=latitude,
             longitude=longitude,
@@ -99,7 +82,6 @@ class EmployeesFromEmployeeLocationModel:
             speed=speed,
             timestamp=timestamp,
         )
-
         qualer_api_models_employees_from_employee_location_model.additional_properties = d
         return qualer_api_models_employees_from_employee_location_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_search_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_search_employee_model.py
@@ -19,24 +19,20 @@ class EmployeesFromSearchEmployeeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         search_string = self.search_string
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if search_string is not None:
             field_dict["SearchString"] = search_string
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         search_string = d.pop("SearchString", None)
-
         qualer_api_models_employees_from_search_employee_model = cls(
             search_string=search_string,
         )
-
         qualer_api_models_employees_from_search_employee_model.additional_properties = d
         return qualer_api_models_employees_from_search_employee_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_from_update_employee_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_from_update_employee_model.py
@@ -37,25 +37,15 @@ class EmployeesFromUpdateEmployeeModel:
 
     def to_dict(self) -> Dict[str, Any]:
         first_name = self.first_name
-
         last_name = self.last_name
-
         subscription_email = self.subscription_email
-
         mobile_phone = self.mobile_phone
-
         office_phone = self.office_phone
-
         alias = self.alias
-
         title = self.title
-
         culture_name = self.culture_name
-
         culture_ui_name = self.culture_ui_name
-
         image_url = self.image_url
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -79,32 +69,21 @@ class EmployeesFromUpdateEmployeeModel:
             field_dict["CultureUiName"] = culture_ui_name
         if image_url is not None:
             field_dict["ImageUrl"] = image_url
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         subscription_email = d.pop("SubscriptionEmail", None)
-
         mobile_phone = d.pop("MobilePhone", None)
-
         office_phone = d.pop("OfficePhone", None)
-
         alias = d.pop("Alias", None)
-
         title = d.pop("Title", None)
-
         culture_name = d.pop("CultureName", None)
-
         culture_ui_name = d.pop("CultureUiName", None)
-
         image_url = d.pop("ImageUrl", None)
-
         qualer_api_models_employees_from_update_employee_model = cls(
             first_name=first_name,
             last_name=last_name,
@@ -117,7 +96,6 @@ class EmployeesFromUpdateEmployeeModel:
             culture_ui_name=culture_ui_name,
             image_url=image_url,
         )
-
         qualer_api_models_employees_from_update_employee_model.additional_properties = d
         return qualer_api_models_employees_from_update_employee_model
 

--- a/src/qualer_sdk/models/qualer_api_models_employees_to_created_employee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_employees_to_created_employee_response.py
@@ -19,24 +19,20 @@ class EmployeesToCreatedEmployeeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_employees_to_created_employee_response = cls(
             id=id,
         )
-
         qualer_api_models_employees_to_created_employee_response.additional_properties = d
         return qualer_api_models_employees_to_created_employee_response
 

--- a/src/qualer_sdk/models/qualer_api_models_environment_from_environment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_environment_from_environment_model.py
@@ -31,17 +31,10 @@ class EnvironmentFromEnvironmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         station_id = self.station_id
-
-        factor_id: Optional[str] = None
-        if self.factor_id:
-            factor_id = self.factor_id.value
-
+        factor_id = self.factor_id.value if self.factor_id else None
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         unit_of_measure = self.unit_of_measure
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -55,27 +48,21 @@ class EnvironmentFromEnvironmentModel:
             field_dict["FactorValue"] = factor_value
         if unit_of_measure is not None:
             field_dict["UnitOfMeasure"] = unit_of_measure
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         station_id = d.pop("StationId", None)
-
         _factor_id = d.pop("FactorId", None)
         factor_id: Optional[EnvironmentFromEnvironmentModelFactorId]
         if not _factor_id:
             factor_id = None
         else:
             factor_id = EnvironmentFromEnvironmentModelFactorId(_factor_id)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         qualer_api_models_environment_from_environment_model = cls(
             station_id=station_id,
             factor_id=factor_id,
@@ -83,7 +70,6 @@ class EnvironmentFromEnvironmentModel:
             factor_value=factor_value,
             unit_of_measure=unit_of_measure,
         )
-
         qualer_api_models_environment_from_environment_model.additional_properties = d
         return qualer_api_models_environment_from_environment_model
 

--- a/src/qualer_sdk/models/qualer_api_models_environment_to_environment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_environment_to_environment_model.py
@@ -37,23 +37,13 @@ class EnvironmentToEnvironmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         room_name = self.room_name
-
-        factor_id: Optional[str] = None
-        if self.factor_id:
-            factor_id = self.factor_id.value
-
+        factor_id = self.factor_id.value if self.factor_id else None
         station_id = self.station_id
-
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         valid_range_min = self.valid_range_min
-
         valid_range_max = self.valid_range_max
-
         unit_of_measure = self.unit_of_measure
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -73,33 +63,24 @@ class EnvironmentToEnvironmentModel:
             field_dict["ValidRangeMax"] = valid_range_max
         if unit_of_measure is not None:
             field_dict["UnitOfMeasure"] = unit_of_measure
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         room_name = d.pop("RoomName", None)
-
         _factor_id = d.pop("FactorId", None)
         factor_id: Optional[EnvironmentToEnvironmentModelFactorId]
         if not _factor_id:
             factor_id = None
         else:
             factor_id = EnvironmentToEnvironmentModelFactorId(_factor_id)
-
         station_id = d.pop("StationId", None)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         valid_range_min = d.pop("ValidRangeMin", None)
-
         valid_range_max = d.pop("ValidRangeMax", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         qualer_api_models_environment_to_environment_model = cls(
             room_name=room_name,
             factor_id=factor_id,
@@ -110,7 +91,6 @@ class EnvironmentToEnvironmentModel:
             valid_range_max=valid_range_max,
             unit_of_measure=unit_of_measure,
         )
-
         qualer_api_models_environment_to_environment_model.additional_properties = d
         return qualer_api_models_environment_to_environment_model
 

--- a/src/qualer_sdk/models/qualer_api_models_inventory_from_inventory_count_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_inventory_from_inventory_count_model.py
@@ -27,15 +27,10 @@ class InventoryFromInventoryCountModel:
 
     def to_dict(self) -> Dict[str, Any]:
         product_id = self.product_id
-
         manufacturer = self.manufacturer
-
         part_number = self.part_number
-
         is_stock_item = self.is_stock_item
-
         quantity_on_hand = self.quantity_on_hand
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class InventoryFromInventoryCountModel:
             field_dict["IsStockItem"] = is_stock_item
         if quantity_on_hand is not None:
             field_dict["QuantityOnHand"] = quantity_on_hand
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         product_id = d.pop("ProductId", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         part_number = d.pop("PartNumber", None)
-
         is_stock_item = d.pop("IsStockItem", None)
-
         quantity_on_hand = d.pop("QuantityOnHand", None)
-
         qualer_api_models_inventory_from_inventory_count_model = cls(
             product_id=product_id,
             manufacturer=manufacturer,
@@ -72,7 +61,6 @@ class InventoryFromInventoryCountModel:
             is_stock_item=is_stock_item,
             quantity_on_hand=quantity_on_hand,
         )
-
         qualer_api_models_inventory_from_inventory_count_model.additional_properties = d
         return qualer_api_models_inventory_from_inventory_count_model
 

--- a/src/qualer_sdk/models/qualer_api_models_inventory_to_inventory_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_inventory_to_inventory_response_model.py
@@ -27,15 +27,10 @@ class InventoryToInventoryResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         product_id = self.product_id
-
         manufacturer = self.manufacturer
-
         part_number = self.part_number
-
         is_stock_item = self.is_stock_item
-
         quantity_on_hand = self.quantity_on_hand
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class InventoryToInventoryResponseModel:
             field_dict["IsStockItem"] = is_stock_item
         if quantity_on_hand is not None:
             field_dict["QuantityOnHand"] = quantity_on_hand
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         product_id = d.pop("ProductId", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         part_number = d.pop("PartNumber", None)
-
         is_stock_item = d.pop("IsStockItem", None)
-
         quantity_on_hand = d.pop("QuantityOnHand", None)
-
         qualer_api_models_inventory_to_inventory_response_model = cls(
             product_id=product_id,
             manufacturer=manufacturer,
@@ -72,7 +61,6 @@ class InventoryToInventoryResponseModel:
             is_stock_item=is_stock_item,
             quantity_on_hand=quantity_on_hand,
         )
-
         qualer_api_models_inventory_to_inventory_response_model.additional_properties = d
         return qualer_api_models_inventory_to_inventory_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_plan_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_plan_response.py
@@ -33,20 +33,15 @@ class MaintenancePlansToMaintenancePlanResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         maintenance_plan_id = self.maintenance_plan_id
-
         maintenance_plan_name = self.maintenance_plan_name
-
         is_template = self.is_template
-
         company_name = self.company_name
-
         maintenance_tasks: Optional[List[Dict[str, Any]]] = None
         if self.maintenance_tasks:
             maintenance_tasks = []
             for maintenance_tasks_item_data in self.maintenance_tasks:
                 maintenance_tasks_item = maintenance_tasks_item_data.to_dict()
                 maintenance_tasks.append(maintenance_tasks_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -60,7 +55,6 @@ class MaintenancePlansToMaintenancePlanResponse:
             field_dict["CompanyName"] = company_name
         if maintenance_tasks is not None:
             field_dict["MaintenanceTasks"] = maintenance_tasks
-
         return field_dict
 
     @classmethod
@@ -68,25 +62,18 @@ class MaintenancePlansToMaintenancePlanResponse:
         from ..models.qualer_api_models_maintenance_plans_to_maintenance_task_response import (
             MaintenancePlansToMaintenanceTaskResponse,
         )
-
         d = dict(src_dict)
         maintenance_plan_id = d.pop("MaintenancePlanId", None)
-
         maintenance_plan_name = d.pop("MaintenancePlanName", None)
-
         is_template = d.pop("IsTemplate", None)
-
         company_name = d.pop("CompanyName", None)
-
         maintenance_tasks = []
         _maintenance_tasks = d.pop("MaintenanceTasks", None)
         for maintenance_tasks_item_data in _maintenance_tasks or []:
             maintenance_tasks_item = MaintenancePlansToMaintenanceTaskResponse.from_dict(
                 maintenance_tasks_item_data
             )
-
             maintenance_tasks.append(maintenance_tasks_item)
-
         qualer_api_models_maintenance_plans_to_maintenance_plan_response = cls(
             maintenance_plan_id=maintenance_plan_id,
             maintenance_plan_name=maintenance_plan_name,
@@ -94,7 +81,6 @@ class MaintenancePlansToMaintenancePlanResponse:
             company_name=company_name,
             maintenance_tasks=maintenance_tasks,
         )
-
         qualer_api_models_maintenance_plans_to_maintenance_plan_response.additional_properties = d
         return qualer_api_models_maintenance_plans_to_maintenance_plan_response
 

--- a/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_maintenance_plans_to_maintenance_task_response.py
@@ -69,57 +69,31 @@ class MaintenancePlansToMaintenanceTaskResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         segment_name = self.segment_name
-
         service_level_id = self.service_level_id
-
         display_order = self.display_order
-
         service_notes = self.service_notes
-
         interval_cycle = self.interval_cycle
-
         interval_length = self.interval_length
-
         on_day = self.on_day
-
         on_month = self.on_month
-
         on_week_days = self.on_week_days
-
         weekday_of_month = self.weekday_of_month
-
         color_code = self.color_code
-
         service_interval = self.service_interval
-
         on_segment_id = self.on_segment_id
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         as_found_standard_group_id = self.as_found_standard_group_id
-
         as_left_standard_group_id = self.as_left_standard_group_id
-
         task_notes = self.task_notes
-
         advance_recall_period = self.advance_recall_period
-
         days_before_due = self.days_before_due
-
         past_due_grace_period = self.past_due_grace_period
-
         days_after_due = self.days_after_due
-
         use_period_in_reports = self.use_period_in_reports
-
         generate_order_automatically = self.generate_order_automatically
-
         approve_upon_generation = self.approve_upon_generation
-
         generate_separate = self.generate_separate
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -175,64 +149,37 @@ class MaintenancePlansToMaintenanceTaskResponse:
             field_dict["ApproveUponGeneration"] = approve_upon_generation
         if generate_separate is not None:
             field_dict["GenerateSeparate"] = generate_separate
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         segment_name = d.pop("SegmentName", None)
-
         service_level_id = d.pop("ServiceLevelId", None)
-
         display_order = d.pop("DisplayOrder", None)
-
         service_notes = d.pop("ServiceNotes", None)
-
         interval_cycle = d.pop("IntervalCycle", None)
-
         interval_length = d.pop("IntervalLength", None)
-
         on_day = d.pop("OnDay", None)
-
         on_month = d.pop("OnMonth", None)
-
         on_week_days = d.pop("OnWeekDays", None)
-
         weekday_of_month = d.pop("WeekdayOfMonth", None)
-
         color_code = d.pop("ColorCode", None)
-
         service_interval = d.pop("ServiceInterval", None)
-
         on_segment_id = d.pop("OnSegmentId", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         as_found_standard_group_id = d.pop("AsFoundStandardGroupId", None)
-
         as_left_standard_group_id = d.pop("AsLeftStandardGroupId", None)
-
         task_notes = d.pop("TaskNotes", None)
-
         advance_recall_period = d.pop("AdvanceRecallPeriod", None)
-
         days_before_due = d.pop("DaysBeforeDue", None)
-
         past_due_grace_period = d.pop("PastDueGracePeriod", None)
-
         days_after_due = d.pop("DaysAfterDue", None)
-
         use_period_in_reports = d.pop("UsePeriodInReports", None)
-
         generate_order_automatically = d.pop("GenerateOrderAutomatically", None)
-
         approve_upon_generation = d.pop("ApproveUponGeneration", None)
-
         generate_separate = d.pop("GenerateSeparate", None)
-
         qualer_api_models_maintenance_plans_to_maintenance_task_response = cls(
             segment_name=segment_name,
             service_level_id=service_level_id,
@@ -261,7 +208,6 @@ class MaintenancePlansToMaintenanceTaskResponse:
             approve_upon_generation=approve_upon_generation,
             generate_separate=generate_separate,
         )
-
         qualer_api_models_maintenance_plans_to_maintenance_task_response.additional_properties = d
         return qualer_api_models_maintenance_plans_to_maintenance_task_response
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_condition_factor_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_condition_factor_model.py
@@ -29,21 +29,10 @@ class MeasurementsFromCreateMeasurementConditionFactorModel:
 
     def to_dict(self) -> Dict[str, Any]:
         factor_id = self.factor_id
-
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         factor_uom = self.factor_uom
-
-        last_modified_on_utc: Optional[str]
-        if not self.last_modified_on_utc:
-            last_modified_on_utc = None
-        elif isinstance(self.last_modified_on_utc, datetime.datetime):
-            last_modified_on_utc = self.last_modified_on_utc.isoformat()
-        else:
-            last_modified_on_utc = self.last_modified_on_utc
-
+        last_modified_on_utc = self.last_modified_on_utc.isoformat() if self.last_modified_on_utc else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -57,20 +46,15 @@ class MeasurementsFromCreateMeasurementConditionFactorModel:
             field_dict["FactorUom"] = factor_uom
         if last_modified_on_utc is not None:
             field_dict["LastModifiedOnUtc"] = last_modified_on_utc
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         factor_id = d.pop("FactorId", None)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         factor_uom = d.pop("FactorUom", None)
-
         def _parse_last_modified_on_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -80,14 +64,11 @@ class MeasurementsFromCreateMeasurementConditionFactorModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_modified_on_utc_type_0 = isoparse(data)
-
                 return last_modified_on_utc_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_modified_on_utc = _parse_last_modified_on_utc(d.pop("LastModifiedOnUtc", None))
-
         qualer_api_models_measurements_from_create_measurement_condition_factor_model = cls(
             factor_id=factor_id,
             factor_name=factor_name,
@@ -95,7 +76,6 @@ class MeasurementsFromCreateMeasurementConditionFactorModel:
             factor_uom=factor_uom,
             last_modified_on_utc=last_modified_on_utc,
         )
-
         qualer_api_models_measurements_from_create_measurement_condition_factor_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_field_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_field_model.py
@@ -27,15 +27,10 @@ class MeasurementsFromCreateMeasurementFieldModel:
 
     def to_dict(self) -> Dict[str, Any]:
         field_id = self.field_id
-
         valid_values = self.valid_values
-
         name = self.name
-
         type_ = self.type_
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class MeasurementsFromCreateMeasurementFieldModel:
             field_dict["Type"] = type_
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         field_id = d.pop("FieldId", None)
-
         valid_values = d.pop("ValidValues", None)
-
         name = d.pop("Name", None)
-
         type_ = d.pop("Type", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_measurements_from_create_measurement_field_model = cls(
             field_id=field_id,
             valid_values=valid_values,
@@ -72,7 +61,6 @@ class MeasurementsFromCreateMeasurementFieldModel:
             type_=type_,
             value=value,
         )
-
         qualer_api_models_measurements_from_create_measurement_field_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_field_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_form_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_form_model.py
@@ -35,18 +35,15 @@ class MeasurementsFromCreateMeasurementFormModel:
     def to_dict(self) -> Dict[str, Any]:
         batch_type = self.batch_type
         batch_result = self.batch_result
-
         specification: Optional[Dict[str, Any]] = None
         if self.specification is not None:
             specification = self.specification.to_dict()
-
         measurement_sets: Optional[List[Dict[str, Any]]] = None
         if self.measurement_sets is not None:
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
                 measurement_sets_item = measurement_sets_item_data.to_dict()
                 measurement_sets.append(measurement_sets_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -58,7 +55,6 @@ class MeasurementsFromCreateMeasurementFormModel:
             field_dict["Specification"] = specification
         if measurement_sets is not None:
             field_dict["MeasurementSets"] = measurement_sets
-
         return field_dict
 
     @classmethod
@@ -69,18 +65,15 @@ class MeasurementsFromCreateMeasurementFormModel:
         from ..models.qualer_api_models_measurements_from_specification import (
             MeasurementsFromSpecification,
         )
-
         d = dict(src_dict)
         batch_type = d.pop("BatchType", None)
         batch_result = d.pop("BatchResult", None)
-
         _specification = d.pop("Specification", None)
         specification: Optional[MeasurementsFromSpecification]
         if _specification is None:
             specification = None
         else:
             specification = MeasurementsFromSpecification.from_dict(_specification)
-
         measurement_sets: List[MeasurementsFromCreateMeasurementSetModel] = []
         _measurement_sets = d.pop("MeasurementSets", None)
         for measurement_sets_item_data in _measurement_sets or []:
@@ -88,14 +81,12 @@ class MeasurementsFromCreateMeasurementFormModel:
                 measurement_sets_item_data
             )
             measurement_sets.append(measurement_sets_item)
-
         qualer_api_models_measurements_from_create_measurement_form_model = cls(
             batch_type=batch_type,
             batch_result=batch_result,
             specification=specification,
             measurement_sets=measurement_sets,
         )
-
         qualer_api_models_measurements_from_create_measurement_form_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_form_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_model.py
@@ -51,39 +51,23 @@ class MeasurementsFromCreateMeasurementModel:
 
     def to_dict(self) -> Dict[str, Any]:
         values = self.values
-
         mean = self.mean
-
         sd = self.sd
-
         range_ = self.range_
-
         delta = self.delta
-
         cv = self.cv
-
         cmc = self.cmc
-
         mu = self.mu
-
         tur = self.tur
-
         tar = self.tar
-
         max_value = self.max_value
-
         min_value = self.min_value
-
         error = self.error
-
         result = self.result
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
         updated_by = self.updated_by
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -119,49 +103,32 @@ class MeasurementsFromCreateMeasurementModel:
             field_dict["UpdatedOn"] = updated_on
         if updated_by is not None:
             field_dict["UpdatedBy"] = updated_by
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         values = d.pop("Values", None)
-
         mean = d.pop("Mean", None)
-
         sd = d.pop("SD", None)
-
         range_ = d.pop("Range", None)
-
         delta = d.pop("Delta", None)
-
         cv = d.pop("CV", None)
-
         cmc = d.pop("CMC", None)
-
         mu = d.pop("MU", None)
-
         tur = d.pop("TUR", None)
-
         tar = d.pop("TAR", None)
-
         max_value = d.pop("MaxValue", None)
-
         min_value = d.pop("MinValue", None)
-
         error = d.pop("Error", None)
-
         result = d.pop("Result", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         updated_by = d.pop("UpdatedBy", None)
-
         qualer_api_models_measurements_from_create_measurement_model = cls(
             values=values,
             mean=mean,
@@ -180,7 +147,6 @@ class MeasurementsFromCreateMeasurementModel:
             updated_on=updated_on,
             updated_by=updated_by,
         )
-
         qualer_api_models_measurements_from_create_measurement_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_point_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_point_model.py
@@ -94,79 +94,47 @@ class MeasurementsFromCreateMeasurementPointModel:
 
     def to_dict(self) -> Dict[str, Any]:
         specification_name = self.specification_name
-
         measurement_quantity = self.measurement_quantity
-
         unit_of_measure_id = self.unit_of_measure_id
-
         unit_of_measure = self.unit_of_measure
-
         range_min = self.range_min
-
         range_max = self.range_max
-
         specification_mode = self.specification_mode
-
         tolerance_type = self.tolerance_type
-
-        tolerance_mode: Optional[int] = None
-        if self.tolerance_mode:
-            tolerance_mode = self.tolerance_mode.value
-
-        tolerance_unit: Optional[int] = None
-        if self.tolerance_unit:
-            tolerance_unit = self.tolerance_unit.value
-
+        tolerance_mode = self.tolerance_mode.value if self.tolerance_mode else None
+        tolerance_unit = self.tolerance_unit.value if self.tolerance_unit else None
         precision_type = self.precision_type
-
         readings = self.readings
-
         channels_type = self.channels_type
-
         channel_count = self.channel_count
-
         precision = self.precision
-
         tolerance_minimum = self.tolerance_minimum
-
         tolerance_maximum = self.tolerance_maximum
-
         resolution = self.resolution
-
         resolution_count = self.resolution_count
-
         nominal = self.nominal
-
         expected_value = self.expected_value
-
         base_value = self.base_value
-
         test_value = self.test_value
-
         is_accredited = self.is_accredited
-
         measurements: Optional[List[Dict[str, Any]]] = None
         if self.measurements:
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
-
         condition_factors: Optional[List[Dict[str, Any]]] = None
         if self.condition_factors:
             condition_factors = []
             for condition_factors_item_data in self.condition_factors:
                 condition_factors_item = condition_factors_item_data.to_dict()
                 condition_factors.append(condition_factors_item)
-
         primary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.primary_measurement_tool:
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
-
         secondary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.secondary_measurement_tool:
             secondary_measurement_tool = self.secondary_measurement_tool.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -226,7 +194,6 @@ class MeasurementsFromCreateMeasurementPointModel:
             field_dict["PrimaryMeasurementTool"] = primary_measurement_tool
         if secondary_measurement_tool is not None:
             field_dict["SecondaryMeasurementTool"] = secondary_measurement_tool
-
         return field_dict
 
     @classmethod
@@ -240,24 +207,15 @@ class MeasurementsFromCreateMeasurementPointModel:
         from ..models.qualer_api_models_measurements_from_create_measurement_tool_model import (
             MeasurementsFromCreateMeasurementToolModel,
         )
-
         d = dict(src_dict)
         specification_name = d.pop("SpecificationName", None)
-
         measurement_quantity = d.pop("MeasurementQuantity", None)
-
         unit_of_measure_id = d.pop("UnitOfMeasureId", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         range_min = d.pop("RangeMin", None)
-
         range_max = d.pop("RangeMax", None)
-
         specification_mode = d.pop("SpecificationMode", None)
-
         tolerance_type = d.pop("ToleranceType", None)
-
         _tolerance_mode = d.pop("ToleranceMode", None)
         tolerance_mode: Optional[MeasurementsFromCreateMeasurementPointModelToleranceMode]
         if not _tolerance_mode:
@@ -266,7 +224,6 @@ class MeasurementsFromCreateMeasurementPointModel:
             tolerance_mode = MeasurementsFromCreateMeasurementPointModelToleranceMode(
                 _tolerance_mode
             )
-
         _tolerance_unit = d.pop("ToleranceUnit", None)
         tolerance_unit: Optional[MeasurementsFromCreateMeasurementPointModelToleranceUnit]
         if not _tolerance_unit:
@@ -275,44 +232,27 @@ class MeasurementsFromCreateMeasurementPointModel:
             tolerance_unit = MeasurementsFromCreateMeasurementPointModelToleranceUnit(
                 _tolerance_unit
             )
-
         precision_type = d.pop("PrecisionType", None)
-
         readings = d.pop("Readings", None)
-
         channels_type = d.pop("ChannelsType", None)
-
         channel_count = d.pop("ChannelCount", None)
-
         precision = d.pop("Precision", None)
-
         tolerance_minimum = d.pop("ToleranceMinimum", None)
-
         tolerance_maximum = d.pop("ToleranceMaximum", None)
-
         resolution = d.pop("Resolution", None)
-
         resolution_count = d.pop("ResolutionCount", None)
-
         nominal = d.pop("Nominal", None)
-
         expected_value = d.pop("ExpectedValue", None)
-
         base_value = d.pop("BaseValue", None)
-
         test_value = d.pop("TestValue", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         measurements = []
         _measurements = d.pop("Measurements", None)
         for measurements_item_data in _measurements or []:
             measurements_item = MeasurementsFromCreateMeasurementModel.from_dict(
                 measurements_item_data
             )
-
             measurements.append(measurements_item)
-
         condition_factors = []
         _condition_factors = d.pop("ConditionFactors", None)
         for condition_factors_item_data in _condition_factors or []:
@@ -321,9 +261,7 @@ class MeasurementsFromCreateMeasurementPointModel:
                     condition_factors_item_data
                 )
             )
-
             condition_factors.append(condition_factors_item)
-
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", None)
         primary_measurement_tool: Optional[MeasurementsFromCreateMeasurementToolModel]
         if not _primary_measurement_tool:
@@ -332,7 +270,6 @@ class MeasurementsFromCreateMeasurementPointModel:
             primary_measurement_tool = MeasurementsFromCreateMeasurementToolModel.from_dict(
                 _primary_measurement_tool
             )
-
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", None)
         secondary_measurement_tool: Optional[MeasurementsFromCreateMeasurementToolModel]
         if not _secondary_measurement_tool:
@@ -341,7 +278,6 @@ class MeasurementsFromCreateMeasurementPointModel:
             secondary_measurement_tool = MeasurementsFromCreateMeasurementToolModel.from_dict(
                 _secondary_measurement_tool
             )
-
         qualer_api_models_measurements_from_create_measurement_point_model = cls(
             specification_name=specification_name,
             measurement_quantity=measurement_quantity,
@@ -372,7 +308,6 @@ class MeasurementsFromCreateMeasurementPointModel:
             primary_measurement_tool=primary_measurement_tool,
             secondary_measurement_tool=secondary_measurement_tool,
         )
-
         qualer_api_models_measurements_from_create_measurement_point_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_point_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_set_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_set_model.py
@@ -47,32 +47,23 @@ class MeasurementsFromCreateMeasurementSetModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_name = self.measurement_name
-
         is_accredited = self.is_accredited
-
         measurement_quantity_id = self.measurement_quantity_id
-
         default_unit_of_measure_id = self.default_unit_of_measure_id
-
         decimal_places = self.decimal_places
-
         significant_figures = self.significant_figures
-
         display_options: Optional[Dict[str, Any]] = None
         if self.display_options:
             display_options = self.display_options.to_dict()
-
         custom_fields: Optional[Dict[str, Any]] = None
         if self.custom_fields:
             custom_fields = self.custom_fields.to_dict()
-
         measurement_points: Optional[List[Dict[str, Any]]] = None
         if self.measurement_points:
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -94,7 +85,6 @@ class MeasurementsFromCreateMeasurementSetModel:
             field_dict["CustomFields"] = custom_fields
         if measurement_points is not None:
             field_dict["MeasurementPoints"] = measurement_points
-
         return field_dict
 
     @classmethod
@@ -108,43 +98,32 @@ class MeasurementsFromCreateMeasurementSetModel:
         from ..models.qualer_api_models_measurements_from_display_options import (
             MeasurementsFromDisplayOptions,
         )
-
         d = dict(src_dict)
         measurement_name = d.pop("MeasurementName", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         measurement_quantity_id = d.pop("MeasurementQuantityId", None)
-
         default_unit_of_measure_id = d.pop("DefaultUnitOfMeasureId", None)
-
         decimal_places = d.pop("DecimalPlaces", None)
-
         significant_figures = d.pop("SignificantFigures", None)
-
         _display_options = d.pop("DisplayOptions", None)
         display_options: Optional[MeasurementsFromDisplayOptions]
         if not _display_options:
             display_options = None
         else:
             display_options = MeasurementsFromDisplayOptions.from_dict(_display_options)
-
         _custom_fields = d.pop("CustomFields", None)
         custom_fields: Optional[MeasurementsFromCustomFields]
         if not _custom_fields:
             custom_fields = None
         else:
             custom_fields = MeasurementsFromCustomFields.from_dict(_custom_fields)
-
         measurement_points = []
         _measurement_points = d.pop("MeasurementPoints", None)
         for measurement_points_item_data in _measurement_points or []:
             measurement_points_item = MeasurementsFromCreateMeasurementPointModel.from_dict(
                 measurement_points_item_data
             )
-
             measurement_points.append(measurement_points_item)
-
         qualer_api_models_measurements_from_create_measurement_set_model = cls(
             measurement_name=measurement_name,
             is_accredited=is_accredited,
@@ -156,7 +135,6 @@ class MeasurementsFromCreateMeasurementSetModel:
             custom_fields=custom_fields,
             measurement_points=measurement_points,
         )
-
         qualer_api_models_measurements_from_create_measurement_set_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_set_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_tool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_create_measurement_tool_model.py
@@ -47,45 +47,19 @@ class MeasurementsFromCreateMeasurementToolModel:
 
     def to_dict(self) -> Dict[str, Any]:
         tool_id = self.tool_id
-
         tool_type_name = self.tool_type_name
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         calibrated_by = self.calibrated_by
-
         certificate_number = self.certificate_number
-
         tool_name = self.tool_name
-
         tool_description = self.tool_description
-
         manufacturer = self.manufacturer
-
         manufacturer_part_number = self.manufacturer_part_number
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -117,16 +91,13 @@ class MeasurementsFromCreateMeasurementToolModel:
             field_dict["AssetUser"] = asset_user
         if equipment_id is not None:
             field_dict["EquipmentId"] = equipment_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         tool_id = d.pop("ToolId", None)
-
         tool_type_name = d.pop("ToolTypeName", None)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -136,14 +107,11 @@ class MeasurementsFromCreateMeasurementToolModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -153,34 +121,21 @@ class MeasurementsFromCreateMeasurementToolModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         calibrated_by = d.pop("CalibratedBy", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         tool_name = d.pop("ToolName", None)
-
         tool_description = d.pop("ToolDescription", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         qualer_api_models_measurements_from_create_measurement_tool_model = cls(
             tool_id=tool_id,
             tool_type_name=tool_type_name,
@@ -197,7 +152,6 @@ class MeasurementsFromCreateMeasurementToolModel:
             asset_user=asset_user,
             equipment_id=equipment_id,
         )
-
         qualer_api_models_measurements_from_create_measurement_tool_model.additional_properties = d
         return qualer_api_models_measurements_from_create_measurement_tool_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_custom_fields.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_custom_fields.py
@@ -29,16 +29,13 @@ class MeasurementsFromCustomFields:
 
     def to_dict(self) -> Dict[str, Any]:
         description = self.description
-
         result = self.result
-
         items: Optional[List[Dict[str, Any]]] = None
         if self.items:
             items = []
             for items_item_data in self.items:
                 items_item = items_item_data.to_dict()
                 items.append(items_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -48,7 +45,6 @@ class MeasurementsFromCustomFields:
             field_dict["Result"] = result
         if items is not None:
             field_dict["Items"] = items
-
         return field_dict
 
     @classmethod
@@ -56,25 +52,19 @@ class MeasurementsFromCustomFields:
         from ..models.qualer_api_models_measurements_from_create_measurement_field_model import (
             MeasurementsFromCreateMeasurementFieldModel,
         )
-
         d = dict(src_dict)
         description = d.pop("Description", None)
-
         result = d.pop("Result", None)
-
         items = []
         _items = d.pop("Items", None)
         for items_item_data in _items or []:
             items_item = MeasurementsFromCreateMeasurementFieldModel.from_dict(items_item_data)
-
             items.append(items_item)
-
         qualer_api_models_measurements_from_custom_fields = cls(
             description=description,
             result=result,
             items=items,
         )
-
         qualer_api_models_measurements_from_custom_fields.additional_properties = d
         return qualer_api_models_measurements_from_custom_fields
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_display_options.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_display_options.py
@@ -43,31 +43,18 @@ class MeasurementsFromDisplayOptions:
 
     def to_dict(self) -> Dict[str, Any]:
         err = self.err
-
         mean = self.mean
-
         max_ = self.max_
-
         min_ = self.min_
-
         sd = self.sd
-
         cv = self.cv
-
         tar = self.tar
-
         tur = self.tur
-
         mu = self.mu
-
         cmc = self.cmc
-
         tol = self.tol
-
         delta = self.delta
-
         range_ = self.range_
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -97,38 +84,24 @@ class MeasurementsFromDisplayOptions:
             field_dict["Delta"] = delta
         if range_ is not None:
             field_dict["Range"] = range_
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         err = d.pop("Err", None)
-
         mean = d.pop("Mean", None)
-
         max_ = d.pop("Max", None)
-
         min_ = d.pop("Min", None)
-
         sd = d.pop("Sd", None)
-
         cv = d.pop("Cv", None)
-
         tar = d.pop("Tar", None)
-
         tur = d.pop("Tur", None)
-
         mu = d.pop("Mu", None)
-
         cmc = d.pop("Cmc", None)
-
         tol = d.pop("Tol", None)
-
         delta = d.pop("Delta", None)
-
         range_ = d.pop("Range", None)
-
         qualer_api_models_measurements_from_display_options = cls(
             err=err,
             mean=mean,
@@ -144,7 +117,6 @@ class MeasurementsFromDisplayOptions:
             delta=delta,
             range_=range_,
         )
-
         qualer_api_models_measurements_from_display_options.additional_properties = d
         return qualer_api_models_measurements_from_display_options
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_specification.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_specification.py
@@ -23,11 +23,8 @@ class MeasurementsFromSpecification:
 
     def to_dict(self) -> Dict[str, Any]:
         title = self.title
-
         subtitle = self.subtitle
-
         group = self.group
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class MeasurementsFromSpecification:
             field_dict["Subtitle"] = subtitle
         if group is not None:
             field_dict["Group"] = group
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         title = d.pop("Title", None)
-
         subtitle = d.pop("Subtitle", None)
-
         group = d.pop("Group", None)
-
         qualer_api_models_measurements_from_specification = cls(
             title=title,
             subtitle=subtitle,
             group=group,
         )
-
         qualer_api_models_measurements_from_specification.additional_properties = d
         return qualer_api_models_measurements_from_specification
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_batch_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_batch_model.py
@@ -31,18 +31,14 @@ class MeasurementsFromUpdateMeasurementBatchModel:
 
     def to_dict(self) -> Dict[str, Any]:
         batch_id = self.batch_id
-
         batch_type = self.batch_type
-
         save_and_delete_empty = self.save_and_delete_empty
-
         measurement_sets: Optional[List[Dict[str, Any]]] = None
         if self.measurement_sets:
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
                 measurement_sets_item = measurement_sets_item_data.to_dict()
                 measurement_sets.append(measurement_sets_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -54,7 +50,6 @@ class MeasurementsFromUpdateMeasurementBatchModel:
             field_dict["SaveAndDeleteEmpty"] = save_and_delete_empty
         if measurement_sets is not None:
             field_dict["MeasurementSets"] = measurement_sets
-
         return field_dict
 
     @classmethod
@@ -62,30 +57,23 @@ class MeasurementsFromUpdateMeasurementBatchModel:
         from ..models.qualer_api_models_measurements_from_update_measurement_set_model import (
             MeasurementsFromUpdateMeasurementSetModel,
         )
-
         d = dict(src_dict)
         batch_id = d.pop("BatchId", None)
-
         batch_type = d.pop("BatchType", None)
-
         save_and_delete_empty = d.pop("SaveAndDeleteEmpty", None)
-
         measurement_sets = []
         _measurement_sets = d.pop("MeasurementSets", None)
         for measurement_sets_item_data in _measurement_sets or []:
             measurement_sets_item = MeasurementsFromUpdateMeasurementSetModel.from_dict(
                 measurement_sets_item_data
             )
-
             measurement_sets.append(measurement_sets_item)
-
         qualer_api_models_measurements_from_update_measurement_batch_model = cls(
             batch_id=batch_id,
             batch_type=batch_type,
             save_and_delete_empty=save_and_delete_empty,
             measurement_sets=measurement_sets,
         )
-
         qualer_api_models_measurements_from_update_measurement_batch_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_batch_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_condition_factor_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_condition_factor_model.py
@@ -27,15 +27,10 @@ class MeasurementsFromUpdateMeasurementConditionFactorModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_condition_factor_id = self.measurement_condition_factor_id
-
         factor_id = self.factor_id
-
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         factor_uom = self.factor_uom
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class MeasurementsFromUpdateMeasurementConditionFactorModel:
             field_dict["FactorValue"] = factor_value
         if factor_uom is not None:
             field_dict["FactorUom"] = factor_uom
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_condition_factor_id = d.pop("MeasurementConditionFactorId", None)
-
         factor_id = d.pop("FactorId", None)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         factor_uom = d.pop("FactorUom", None)
-
         qualer_api_models_measurements_from_update_measurement_condition_factor_model = cls(
             measurement_condition_factor_id=measurement_condition_factor_id,
             factor_id=factor_id,
@@ -72,7 +61,6 @@ class MeasurementsFromUpdateMeasurementConditionFactorModel:
             factor_value=factor_value,
             factor_uom=factor_uom,
         )
-
         qualer_api_models_measurements_from_update_measurement_condition_factor_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_field_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_field_model.py
@@ -25,13 +25,9 @@ class MeasurementsFromUpdateMeasurementFieldModel:
 
     def to_dict(self) -> Dict[str, Any]:
         field_id = self.field_id
-
         name = self.name
-
         type_ = self.type_
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class MeasurementsFromUpdateMeasurementFieldModel:
             field_dict["Type"] = type_
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         field_id = d.pop("FieldId", None)
-
         name = d.pop("Name", None)
-
         type_ = d.pop("Type", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_measurements_from_update_measurement_field_model = cls(
             field_id=field_id,
             name=name,
             type_=type_,
             value=value,
         )
-
         qualer_api_models_measurements_from_update_measurement_field_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_field_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_form_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_form_model.py
@@ -30,13 +30,11 @@ class MeasurementsFromUpdateMeasurementFormModel:
             for measurement_batches_item_data in self.measurement_batches:
                 measurement_batches_item = measurement_batches_item_data.to_dict()
                 measurement_batches.append(measurement_batches_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if measurement_batches is not None:
             field_dict["MeasurementBatches"] = measurement_batches
-
         return field_dict
 
     @classmethod
@@ -44,7 +42,6 @@ class MeasurementsFromUpdateMeasurementFormModel:
         from ..models.qualer_api_models_measurements_from_update_measurement_batch_model import (
             MeasurementsFromUpdateMeasurementBatchModel,
         )
-
         d = dict(src_dict)
         measurement_batches = []
         _measurement_batches = d.pop("MeasurementBatches", None)
@@ -52,13 +49,10 @@ class MeasurementsFromUpdateMeasurementFormModel:
             measurement_batches_item = MeasurementsFromUpdateMeasurementBatchModel.from_dict(
                 measurement_batches_item_data
             )
-
             measurement_batches.append(measurement_batches_item)
-
         qualer_api_models_measurements_from_update_measurement_form_model = cls(
             measurement_batches=measurement_batches,
         )
-
         qualer_api_models_measurements_from_update_measurement_form_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_form_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_model.py
@@ -29,17 +29,12 @@ class MeasurementsFromUpdateMeasurementModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_id = self.measurement_id
-
         values = self.values
-
         channel = self.channel
-
         updated_by = self.updated_by
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -53,27 +48,21 @@ class MeasurementsFromUpdateMeasurementModel:
             field_dict["UpdatedBy"] = updated_by
         if updated_on is not None:
             field_dict["UpdatedOn"] = updated_on
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_id = d.pop("MeasurementId", None)
-
         values = d.pop("Values", None)
-
         channel = d.pop("Channel", None)
-
         updated_by = d.pop("UpdatedBy", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         qualer_api_models_measurements_from_update_measurement_model = cls(
             measurement_id=measurement_id,
             values=values,
@@ -81,7 +70,6 @@ class MeasurementsFromUpdateMeasurementModel:
             updated_by=updated_by,
             updated_on=updated_on,
         )
-
         qualer_api_models_measurements_from_update_measurement_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_point_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_point_model.py
@@ -145,60 +145,32 @@ class MeasurementsFromUpdateMeasurementPointModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_point_id = self.measurement_point_id
-
         specification_name = self.specification_name
-
         unit_of_measure = self.unit_of_measure
-
         expected_value = self.expected_value
-
         expected_value_raw = self.expected_value_raw
-
         base_value = self.base_value
-
         test_value = self.test_value
-
         nominal = self.nominal
-
         range_min = self.range_min
-
         range_max = self.range_max
-
         tolerance_type = self.tolerance_type
-
         precision_type = self.precision_type
-
         precision = self.precision
-
         tolerance_minimum = self.tolerance_minimum
-
         tolerance_maximum = self.tolerance_maximum
-
         resolution = self.resolution
-
         resolution_count = self.resolution_count
-
         is_accredited = self.is_accredited
-
-        specification_mode: Optional[int] = None
-        if self.specification_mode:
-            specification_mode = self.specification_mode.value
-
-        tolerance_mode: Optional[int] = None
-        if self.tolerance_mode:
-            tolerance_mode = self.tolerance_mode.value
-
-        tolerance_unit: Optional[int] = None
-        if self.tolerance_unit:
-            tolerance_unit = self.tolerance_unit.value
-
+        specification_mode = self.specification_mode.value if self.specification_mode else None
+        tolerance_mode = self.tolerance_mode.value if self.tolerance_mode else None
+        tolerance_unit = self.tolerance_unit.value if self.tolerance_unit else None
         measurements: Optional[List[Dict[str, Any]]] = None
         if self.measurements:
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
-
         measurement_condition_factors: Optional[List[Dict[str, Any]]] = None
         if self.measurement_condition_factors:
             measurement_condition_factors = []
@@ -207,63 +179,34 @@ class MeasurementsFromUpdateMeasurementPointModel:
                     measurement_condition_factors_item_data.to_dict()
                 )
                 measurement_condition_factors.append(measurement_condition_factors_item)
-
-        tool_application_mode: Optional[str] = None
-        if self.tool_application_mode:
-            tool_application_mode = self.tool_application_mode.value
-
+        tool_application_mode = self.tool_application_mode.value if self.tool_application_mode else None
         primary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.primary_measurement_tool:
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
-
         secondary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.secondary_measurement_tool:
             secondary_measurement_tool = self.secondary_measurement_tool.to_dict()
-
         linked_measurement_point_id = self.linked_measurement_point_id
-
-        hysteresis_point: Optional[str] = None
-        if self.hysteresis_point:
-            hysteresis_point = self.hysteresis_point.value
-
+        hysteresis_point = self.hysteresis_point.value if self.hysteresis_point else None
         influence_parameter_1_parameter_id = self.influence_parameter_1_parameter_id
-
         influence_parameter_1_value = self.influence_parameter_1_value
-
         influence_parameter_2_parameter_id = self.influence_parameter_2_parameter_id
-
         influence_parameter_2_value = self.influence_parameter_2_value
-
         measurement_not_taken_reason = self.measurement_not_taken_reason
-
         hide_from_certificate = self.hide_from_certificate
-
         measurement_not_taken_result = self.measurement_not_taken_result
-
         is_measurement_not_taken = self.is_measurement_not_taken
-
         column_mean = self.column_mean
-
         column_mean_result = self.column_mean_result
-
         column_sd = self.column_sd
-
         column_sd_result = self.column_sd_result
-
         column_cv = self.column_cv
-
         column_cv_result = self.column_cv_result
-
         column_range = self.column_range
-
         column_range_result = self.column_range_result
-
         column_delta = self.column_delta
-
         column_delta_result = self.column_delta_result
-
         column_result = self.column_result
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -361,7 +304,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             field_dict["ColumnDeltaResult"] = column_delta_result
         if column_result is not None:
             field_dict["ColumnResult"] = column_result
-
         return field_dict
 
     @classmethod
@@ -375,44 +317,25 @@ class MeasurementsFromUpdateMeasurementPointModel:
         from ..models.qualer_api_models_measurements_from_update_measurement_tool_model import (
             MeasurementsFromUpdateMeasurementToolModel,
         )
-
         d = dict(src_dict)
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         specification_name = d.pop("SpecificationName", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         expected_value = d.pop("ExpectedValue", None)
-
         expected_value_raw = d.pop("ExpectedValueRaw", None)
-
         base_value = d.pop("BaseValue", None)
-
         test_value = d.pop("TestValue", None)
-
         nominal = d.pop("Nominal", None)
-
         range_min = d.pop("RangeMin", None)
-
         range_max = d.pop("RangeMax", None)
-
         tolerance_type = d.pop("ToleranceType", None)
-
         precision_type = d.pop("PrecisionType", None)
-
         precision = d.pop("Precision", None)
-
         tolerance_minimum = d.pop("ToleranceMinimum", None)
-
         tolerance_maximum = d.pop("ToleranceMaximum", None)
-
         resolution = d.pop("Resolution", None)
-
         resolution_count = d.pop("ResolutionCount", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         _specification_mode = d.pop("SpecificationMode", None)
         specification_mode: Optional[MeasurementsFromUpdateMeasurementPointModelSpecificationMode]
         if not _specification_mode:
@@ -421,7 +344,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             specification_mode = MeasurementsFromUpdateMeasurementPointModelSpecificationMode(
                 _specification_mode
             )
-
         _tolerance_mode = d.pop("ToleranceMode", None)
         tolerance_mode: Optional[MeasurementsFromUpdateMeasurementPointModelToleranceMode]
         if not _tolerance_mode:
@@ -430,7 +352,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             tolerance_mode = MeasurementsFromUpdateMeasurementPointModelToleranceMode(
                 _tolerance_mode
             )
-
         _tolerance_unit = d.pop("ToleranceUnit", None)
         tolerance_unit: Optional[MeasurementsFromUpdateMeasurementPointModelToleranceUnit]
         if not _tolerance_unit:
@@ -439,16 +360,13 @@ class MeasurementsFromUpdateMeasurementPointModel:
             tolerance_unit = MeasurementsFromUpdateMeasurementPointModelToleranceUnit(
                 _tolerance_unit
             )
-
         measurements = []
         _measurements = d.pop("Measurements", None)
         for measurements_item_data in _measurements or []:
             measurements_item = MeasurementsFromUpdateMeasurementModel.from_dict(
                 measurements_item_data
             )
-
             measurements.append(measurements_item)
-
         measurement_condition_factors = []
         _measurement_condition_factors = d.pop("MeasurementConditionFactors", None)
         for measurement_condition_factors_item_data in _measurement_condition_factors or []:
@@ -457,9 +375,7 @@ class MeasurementsFromUpdateMeasurementPointModel:
                     measurement_condition_factors_item_data
                 )
             )
-
             measurement_condition_factors.append(measurement_condition_factors_item)
-
         _tool_application_mode = d.pop("ToolApplicationMode", None)
         tool_application_mode: Optional[
             MeasurementsFromUpdateMeasurementPointModelToolApplicationMode
@@ -470,7 +386,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             tool_application_mode = MeasurementsFromUpdateMeasurementPointModelToolApplicationMode(
                 _tool_application_mode
             )
-
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", None)
         primary_measurement_tool: Optional[MeasurementsFromUpdateMeasurementToolModel]
         if not _primary_measurement_tool:
@@ -479,7 +394,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             primary_measurement_tool = MeasurementsFromUpdateMeasurementToolModel.from_dict(
                 _primary_measurement_tool
             )
-
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", None)
         secondary_measurement_tool: Optional[MeasurementsFromUpdateMeasurementToolModel]
         if not _secondary_measurement_tool:
@@ -488,9 +402,7 @@ class MeasurementsFromUpdateMeasurementPointModel:
             secondary_measurement_tool = MeasurementsFromUpdateMeasurementToolModel.from_dict(
                 _secondary_measurement_tool
             )
-
         linked_measurement_point_id = d.pop("LinkedMeasurementPointId", None)
-
         _hysteresis_point = d.pop("HysteresisPoint", None)
         hysteresis_point: Optional[MeasurementsFromUpdateMeasurementPointModelHysteresisPoint]
         if not _hysteresis_point:
@@ -499,45 +411,25 @@ class MeasurementsFromUpdateMeasurementPointModel:
             hysteresis_point = MeasurementsFromUpdateMeasurementPointModelHysteresisPoint(
                 _hysteresis_point
             )
-
         influence_parameter_1_parameter_id = d.pop("InfluenceParameter1ParameterId", None)
-
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", None)
-
         influence_parameter_2_parameter_id = d.pop("InfluenceParameter2ParameterId", None)
-
         influence_parameter_2_value = d.pop("InfluenceParameter2Value", None)
-
         measurement_not_taken_reason = d.pop("MeasurementNotTakenReason", None)
-
         hide_from_certificate = d.pop("HideFromCertificate", None)
-
         measurement_not_taken_result = d.pop("MeasurementNotTakenResult", None)
-
         is_measurement_not_taken = d.pop("IsMeasurementNotTaken", None)
-
         column_mean = d.pop("ColumnMean", None)
-
         column_mean_result = d.pop("ColumnMeanResult", None)
-
         column_sd = d.pop("ColumnSD", None)
-
         column_sd_result = d.pop("ColumnSDResult", None)
-
         column_cv = d.pop("ColumnCV", None)
-
         column_cv_result = d.pop("ColumnCVResult", None)
-
         column_range = d.pop("ColumnRange", None)
-
         column_range_result = d.pop("ColumnRangeResult", None)
-
         column_delta = d.pop("ColumnDelta", None)
-
         column_delta_result = d.pop("ColumnDeltaResult", None)
-
         column_result = d.pop("ColumnResult", None)
-
         qualer_api_models_measurements_from_update_measurement_point_model = cls(
             measurement_point_id=measurement_point_id,
             specification_name=specification_name,
@@ -587,7 +479,6 @@ class MeasurementsFromUpdateMeasurementPointModel:
             column_delta_result=column_delta_result,
             column_result=column_result,
         )
-
         qualer_api_models_measurements_from_update_measurement_point_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_point_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_set_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_set_model.py
@@ -73,55 +73,33 @@ class MeasurementsFromUpdateMeasurementSetModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_set_id = self.measurement_set_id
-
         is_accredited = self.is_accredited
-
         measurement_name = self.measurement_name
-
         use_expected_value = self.use_expected_value
-
         decimal_places = self.decimal_places
-
         significant_figures = self.significant_figures
-
-        influence_parameter_1_type: Optional[str] = None
-        if self.influence_parameter_1_type:
-            influence_parameter_1_type = self.influence_parameter_1_type.value
-
+        influence_parameter_1_type = self.influence_parameter_1_type.value if self.influence_parameter_1_type else None
         influence_parameter_1_tool_type_id = self.influence_parameter_1_tool_type_id
-
         influence_parameter_1_parameter_id = self.influence_parameter_1_parameter_id
-
         influence_parameter_1_source = self.influence_parameter_1_source
-
         influence_parameter_1_value = self.influence_parameter_1_value
-
-        influence_parameter_2_type: Optional[str] = None
-        if self.influence_parameter_2_type:
-            influence_parameter_2_type = self.influence_parameter_2_type.value
-
+        influence_parameter_2_type = self.influence_parameter_2_type.value if self.influence_parameter_2_type else None
         influence_parameter_2_tool_type_id = self.influence_parameter_2_tool_type_id
-
         influence_parameter_2_parameter_id = self.influence_parameter_2_parameter_id
-
         influence_parameter_2_source = self.influence_parameter_2_source
-
         influence_parameter_2_value = self.influence_parameter_2_value
-
         measurement_points: Optional[List[Dict[str, Any]]] = None
         if self.measurement_points:
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
-
         measurement_fields: Optional[List[Dict[str, Any]]] = None
         if self.measurement_fields:
             measurement_fields = []
             for measurement_fields_item_data in self.measurement_fields:
                 measurement_fields_item = measurement_fields_item_data.to_dict()
                 measurement_fields.append(measurement_fields_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -161,7 +139,6 @@ class MeasurementsFromUpdateMeasurementSetModel:
             field_dict["MeasurementPoints"] = measurement_points
         if measurement_fields is not None:
             field_dict["MeasurementFields"] = measurement_fields
-
         return field_dict
 
     @classmethod
@@ -172,20 +149,13 @@ class MeasurementsFromUpdateMeasurementSetModel:
         from ..models.qualer_api_models_measurements_from_update_measurement_point_model import (
             MeasurementsFromUpdateMeasurementPointModel,
         )
-
         d = dict(src_dict)
         measurement_set_id = d.pop("MeasurementSetId", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         measurement_name = d.pop("MeasurementName", None)
-
         use_expected_value = d.pop("UseExpectedValue", None)
-
         decimal_places = d.pop("DecimalPlaces", None)
-
         significant_figures = d.pop("SignificantFigures", None)
-
         _influence_parameter_1_type = d.pop("InfluenceParameter1Type", None)
         influence_parameter_1_type: Optional[
             MeasurementsFromUpdateMeasurementSetModelInfluenceParameter1Type
@@ -198,15 +168,10 @@ class MeasurementsFromUpdateMeasurementSetModel:
                     _influence_parameter_1_type
                 )
             )
-
         influence_parameter_1_tool_type_id = d.pop("InfluenceParameter1ToolTypeId", None)
-
         influence_parameter_1_parameter_id = d.pop("InfluenceParameter1ParameterId", None)
-
         influence_parameter_1_source = d.pop("InfluenceParameter1Source", None)
-
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", None)
-
         _influence_parameter_2_type = d.pop("InfluenceParameter2Type", None)
         influence_parameter_2_type: Optional[
             MeasurementsFromUpdateMeasurementSetModelInfluenceParameter2Type
@@ -219,33 +184,24 @@ class MeasurementsFromUpdateMeasurementSetModel:
                     _influence_parameter_2_type
                 )
             )
-
         influence_parameter_2_tool_type_id = d.pop("InfluenceParameter2ToolTypeId", None)
-
         influence_parameter_2_parameter_id = d.pop("InfluenceParameter2ParameterId", None)
-
         influence_parameter_2_source = d.pop("InfluenceParameter2Source", None)
-
         influence_parameter_2_value = d.pop("InfluenceParameter2Value", None)
-
         measurement_points = []
         _measurement_points = d.pop("MeasurementPoints", None)
         for measurement_points_item_data in _measurement_points or []:
             measurement_points_item = MeasurementsFromUpdateMeasurementPointModel.from_dict(
                 measurement_points_item_data
             )
-
             measurement_points.append(measurement_points_item)
-
         measurement_fields = []
         _measurement_fields = d.pop("MeasurementFields", None)
         for measurement_fields_item_data in _measurement_fields or []:
             measurement_fields_item = MeasurementsFromUpdateMeasurementFieldModel.from_dict(
                 measurement_fields_item_data
             )
-
             measurement_fields.append(measurement_fields_item)
-
         qualer_api_models_measurements_from_update_measurement_set_model = cls(
             measurement_set_id=measurement_set_id,
             is_accredited=is_accredited,
@@ -266,7 +222,6 @@ class MeasurementsFromUpdateMeasurementSetModel:
             measurement_points=measurement_points,
             measurement_fields=measurement_fields,
         )
-
         qualer_api_models_measurements_from_update_measurement_set_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_set_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_tool_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_from_update_measurement_tool_model.py
@@ -49,47 +49,20 @@ class MeasurementsFromUpdateMeasurementToolModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_tool_id = self.measurement_tool_id
-
         tool_id = self.tool_id
-
         tool_type_name = self.tool_type_name
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         calibrated_by = self.calibrated_by
-
         certificate_number = self.certificate_number
-
         tool_name = self.tool_name
-
         tool_description = self.tool_description
-
         manufacturer = self.manufacturer
-
         manufacturer_part_number = self.manufacturer_part_number
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -123,18 +96,14 @@ class MeasurementsFromUpdateMeasurementToolModel:
             field_dict["AssetUser"] = asset_user
         if equipment_id is not None:
             field_dict["EquipmentId"] = equipment_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_tool_id = d.pop("MeasurementToolId", None)
-
         tool_id = d.pop("ToolId", None)
-
         tool_type_name = d.pop("ToolTypeName", None)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -144,14 +113,11 @@ class MeasurementsFromUpdateMeasurementToolModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -161,34 +127,21 @@ class MeasurementsFromUpdateMeasurementToolModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         calibrated_by = d.pop("CalibratedBy", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         tool_name = d.pop("ToolName", None)
-
         tool_description = d.pop("ToolDescription", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         qualer_api_models_measurements_from_update_measurement_tool_model = cls(
             measurement_tool_id=measurement_tool_id,
             tool_id=tool_id,
@@ -206,7 +159,6 @@ class MeasurementsFromUpdateMeasurementToolModel:
             asset_user=asset_user,
             equipment_id=equipment_id,
         )
-
         qualer_api_models_measurements_from_update_measurement_tool_model.additional_properties = d
         return qualer_api_models_measurements_from_update_measurement_tool_model
 

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model.py
@@ -95,121 +95,60 @@ class MeasurementsToMeasurementRecordResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
         order_item_number = self.order_item_number
-
         certificate_number = self.certificate_number
-
         result_status: Optional[str]
         if not self.result_status:
             result_status = None
         else:
             result_status: Optional[str]
-
             if not self.result_status:
-
                 result_status = None
             else:
                 result_status = self.result_status
-        as_found_result: Optional[str]
-
-        if not self.as_found_result:
-
-            as_found_result = None
-
-        else:
-
-            as_found_result = self.as_found_result
+        as_found_result = self.as_found_result
         as_left_result: Optional[str]
         if not self.as_left_result:
             as_left_result = None
         else:
             as_left_result: Optional[str]
-
             if not self.as_left_result:
-
                 as_left_result = None
             else:
                 as_left_result = self.as_left_result
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
+        service_date = self.service_date.isoformat() if self.service_date else None
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         asset_tag_change = self.asset_tag_change
-
         asset_user_change = self.asset_user_change
-
         service_notes = self.service_notes
-
         serial_number_change = self.serial_number_change
-
-        due_date: Optional[str]
-        if not self.due_date:
-            due_date = None
-        elif isinstance(self.due_date, datetime.datetime):
-            due_date = self.due_date.isoformat()
-        else:
-            due_date = self.due_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        due_date = self.due_date.isoformat() if self.due_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         service_level = self.service_level
-
         service_level_code = self.service_level_code
-
         next_service_level = self.next_service_level
-
         next_service_level_code = self.next_service_level_code
-
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         parts_charge = self.parts_charge
-
         parts_charge_before_discount = self.parts_charge_before_discount
-
         service_charge = self.service_charge
-
         repairs_charge = self.repairs_charge
-
         segment_name = self.segment_name
-
         schedule_name = self.schedule_name
-
         service_schedule_segment_id = self.service_schedule_segment_id
-
         forward_next_service = self.forward_next_service
-
         forward_segment_id = self.forward_segment_id
-
         measurement_batches: Optional[List[Dict[str, Any]]] = None
         if self.measurement_batches:
             measurement_batches = []
             for measurement_batches_item_data in self.measurement_batches:
                 measurement_batches_item = measurement_batches_item_data.to_dict()
                 measurement_batches.append(measurement_batches_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -281,7 +220,6 @@ class MeasurementsToMeasurementRecordResponseModel:
             field_dict["ForwardSegmentId"] = forward_segment_id
         if measurement_batches is not None:
             field_dict["MeasurementBatches"] = measurement_batches
-
         return field_dict
 
     @classmethod
@@ -289,34 +227,23 @@ class MeasurementsToMeasurementRecordResponseModel:
         from ..models.qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model import (
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel,
         )
-
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         as_found_result = d.pop("AsFoundResult", None)
-
         def _parse_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -324,28 +251,18 @@ class MeasurementsToMeasurementRecordResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_tag_change = d.pop("AssetTagChange", None)
-
         asset_user_change = d.pop("AssetUserChange", None)
-
         service_notes = d.pop("ServiceNotes", None)
-
         serial_number_change = d.pop("SerialNumberChange", None)
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -353,14 +270,11 @@ class MeasurementsToMeasurementRecordResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_date_type_0 = isoparse(data)
-
                 return due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -370,44 +284,26 @@ class MeasurementsToMeasurementRecordResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         service_level = d.pop("ServiceLevel", None)
-
         service_level_code = d.pop("ServiceLevelCode", None)
-
         next_service_level = d.pop("NextServiceLevel", None)
-
         next_service_level_code = d.pop("NextServiceLevelCode", None)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         parts_charge = d.pop("PartsCharge", None)
-
         parts_charge_before_discount = d.pop("PartsChargeBeforeDiscount", None)
-
         service_charge = d.pop("ServiceCharge", None)
-
         repairs_charge = d.pop("RepairsCharge", None)
-
         segment_name = d.pop("SegmentName", None)
-
         schedule_name = d.pop("ScheduleName", None)
-
         service_schedule_segment_id = d.pop("ServiceScheduleSegmentId", None)
-
         forward_next_service = d.pop("ForwardNextService", None)
-
         forward_segment_id = d.pop("ForwardSegmentId", None)
-
         measurement_batches = []
         _measurement_batches = d.pop("MeasurementBatches", None)
         for measurement_batches_item_data in _measurement_batches or []:
@@ -416,9 +312,7 @@ class MeasurementsToMeasurementRecordResponseModel:
                     measurement_batches_item_data
                 )
             )
-
             measurement_batches.append(measurement_batches_item)
-
         qualer_api_models_measurements_to_measurement_record_response_model = cls(
             service_order_id=service_order_id,
             service_order_number=service_order_number,
@@ -455,7 +349,6 @@ class MeasurementsToMeasurementRecordResponseModel:
             forward_segment_id=forward_segment_id,
             measurement_batches=measurement_batches,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model.py
@@ -44,20 +44,16 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         batch_type = self.batch_type
-
         batch_result = self.batch_result
-
         specification: Optional[Dict[str, Any]] = None
         if self.specification:
             specification = self.specification.to_dict()
-
         measurement_sets: Optional[List[Dict[str, Any]]] = None
         if self.measurement_sets:
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
                 measurement_sets_item = measurement_sets_item_data.to_dict()
                 measurement_sets.append(measurement_sets_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -69,7 +65,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel:
             field_dict["Specification"] = specification
         if measurement_sets is not None:
             field_dict["MeasurementSets"] = measurement_sets
-
         return field_dict
 
     @classmethod
@@ -80,12 +75,9 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel:
         from ..models.qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model import (
             MeasurementsToMeasurementRecordResponseModelSpecificationResponseModel,
         )
-
         d = dict(src_dict)
         batch_type = d.pop("BatchType", None)
-
         batch_result = d.pop("BatchResult", None)
-
         _specification = d.pop("Specification", None)
         specification: Optional[
             MeasurementsToMeasurementRecordResponseModelSpecificationResponseModel
@@ -98,23 +90,19 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModel:
                     _specification
                 )
             )
-
         measurement_sets = []
         _measurement_sets = d.pop("MeasurementSets", None)
         for measurement_sets_item_data in _measurement_sets or []:
             measurement_sets_item = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModel.from_dict(
                 measurement_sets_item_data
             )
-
             measurement_sets.append(measurement_sets_item)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model = cls(
             batch_type=batch_type,
             batch_result=batch_result,
             specification=specification,
             measurement_sets=measurement_sets,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields.py
@@ -37,16 +37,13 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
 
     def to_dict(self) -> Dict[str, Any]:
         description = self.description
-
         result = self.result
-
         items: Optional[List[Dict[str, Any]]] = None
         if self.items:
             items = []
             for items_item_data in self.items:
                 items_item = items_item_data.to_dict()
                 items.append(items_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -56,7 +53,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
             field_dict["Result"] = result
         if items is not None:
             field_dict["Items"] = items
-
         return field_dict
 
     @classmethod
@@ -64,27 +60,21 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
         from ..models.qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model import (
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFieldsCreateMeasurementFieldResponseModel,
         )
-
         d = dict(src_dict)
         description = d.pop("Description", None)
-
         result = d.pop("Result", None)
-
         items = []
         _items = d.pop("Items", None)
         for items_item_data in _items or []:
             items_item = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFieldsCreateMeasurementFieldResponseModel.from_dict(
                 items_item_data
             )
-
             items.append(items_item)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields = cls(
             description=description,
             result=result,
             items=items,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model.py
@@ -30,15 +30,10 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         type_ = self.type_
-
         value = self.value
-
         field_id = self.field_id
-
         valid_values = self.valid_values
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -52,22 +47,16 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
             field_dict["FieldId"] = field_id
         if valid_values is not None:
             field_dict["ValidValues"] = valid_values
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         type_ = d.pop("Type", None)
-
         value = d.pop("Value", None)
-
         field_id = d.pop("FieldId", None)
-
         valid_values = d.pop("ValidValues", None)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model = cls(
             name=name,
             type_=type_,
@@ -75,7 +64,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelC
             field_id=field_id,
             valid_values=valid_values,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_custom_fields_create_measurement_field_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options.py
@@ -46,31 +46,18 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelD
 
     def to_dict(self) -> Dict[str, Any]:
         err = self.err
-
         mean = self.mean
-
         max_ = self.max_
-
         min_ = self.min_
-
         sd = self.sd
-
         cv = self.cv
-
         tar = self.tar
-
         tur = self.tur
-
         mu = self.mu
-
         cmc = self.cmc
-
         tol = self.tol
-
         delta = self.delta
-
         range_ = self.range_
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -100,38 +87,24 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelD
             field_dict["Delta"] = delta
         if range_ is not None:
             field_dict["Range"] = range_
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         err = d.pop("Err", None)
-
         mean = d.pop("Mean", None)
-
         max_ = d.pop("Max", None)
-
         min_ = d.pop("Min", None)
-
         sd = d.pop("Sd", None)
-
         cv = d.pop("Cv", None)
-
         tar = d.pop("Tar", None)
-
         tur = d.pop("Tur", None)
-
         mu = d.pop("Mu", None)
-
         cmc = d.pop("Cmc", None)
-
         tol = d.pop("Tol", None)
-
         delta = d.pop("Delta", None)
-
         range_ = d.pop("Range", None)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options = cls(
             err=err,
             mean=mean,
@@ -147,7 +120,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelD
             delta=delta,
             range_=range_,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_display_options.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model.py
@@ -59,32 +59,23 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_name = self.measurement_name
-
         is_accredited = self.is_accredited
-
         measurement_quantity_id = self.measurement_quantity_id
-
         default_unit_of_measure_id = self.default_unit_of_measure_id
-
         decimal_places = self.decimal_places
-
         significant_figures = self.significant_figures
-
         display_options: Optional[Dict[str, Any]] = None
         if self.display_options:
             display_options = self.display_options.to_dict()
-
         custom_fields: Optional[Dict[str, Any]] = None
         if self.custom_fields:
             custom_fields = self.custom_fields.to_dict()
-
         measurement_points: Optional[List[Dict[str, Any]]] = None
         if self.measurement_points:
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -106,7 +97,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             field_dict["CustomFields"] = custom_fields
         if measurement_points is not None:
             field_dict["MeasurementPoints"] = measurement_points
-
         return field_dict
 
     @classmethod
@@ -120,20 +110,13 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
         from ..models.qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model import (
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModel,
         )
-
         d = dict(src_dict)
         measurement_name = d.pop("MeasurementName", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         measurement_quantity_id = d.pop("MeasurementQuantityId", None)
-
         default_unit_of_measure_id = d.pop("DefaultUnitOfMeasureId", None)
-
         decimal_places = d.pop("DecimalPlaces", None)
-
         significant_figures = d.pop("SignificantFigures", None)
-
         _display_options = d.pop("DisplayOptions", None)
         display_options: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions
@@ -144,7 +127,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             display_options = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelDisplayOptions.from_dict(
                 _display_options
             )
-
         _custom_fields = d.pop("CustomFields", None)
         custom_fields: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields
@@ -155,16 +137,13 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             custom_fields = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelCustomFields.from_dict(
                 _custom_fields
             )
-
         measurement_points = []
         _measurement_points = d.pop("MeasurementPoints", None)
         for measurement_points_item_data in _measurement_points or []:
             measurement_points_item = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModel.from_dict(
                 measurement_points_item_data
             )
-
             measurement_points.append(measurement_points_item)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model = cls(
             measurement_name=measurement_name,
             is_accredited=is_accredited,
@@ -176,7 +155,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             custom_fields=custom_fields,
             measurement_points=measurement_points,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model.py
@@ -124,81 +124,47 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
 
     def to_dict(self) -> Dict[str, Any]:
         specification_name = self.specification_name
-
         measurement_quantity = self.measurement_quantity
-
         unit_of_measure_id = self.unit_of_measure_id
-
         unit_of_measure = self.unit_of_measure
-
         range_min = self.range_min
-
         range_max = self.range_max
-
         tolerance_type = self.tolerance_type
-
-        specification_mode: Optional[int] = None
-        if self.specification_mode:
-            specification_mode = self.specification_mode.value
-
-        tolerance_mode: Optional[int] = None
-        if self.tolerance_mode:
-            tolerance_mode = self.tolerance_mode.value
-
-        tolerance_unit: Optional[int] = None
-        if self.tolerance_unit:
-            tolerance_unit = self.tolerance_unit.value
-
+        specification_mode = self.specification_mode.value if self.specification_mode else None
+        tolerance_mode = self.tolerance_mode.value if self.tolerance_mode else None
+        tolerance_unit = self.tolerance_unit.value if self.tolerance_unit else None
         precision_type = self.precision_type
-
         readings = self.readings
-
         channels_type = self.channels_type
-
         channel_count = self.channel_count
-
         precision = self.precision
-
         tolerance_minimum = self.tolerance_minimum
-
         tolerance_maximum = self.tolerance_maximum
-
         resolution = self.resolution
-
         resolution_count = self.resolution_count
-
         nominal = self.nominal
-
         expected_value = self.expected_value
-
         base_value = self.base_value
-
         test_value = self.test_value
-
         is_accredited = self.is_accredited
-
         measurements: Optional[List[Dict[str, Any]]] = None
         if self.measurements:
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
-
         condition_factors: Optional[List[Dict[str, Any]]] = None
         if self.condition_factors:
             condition_factors = []
             for condition_factors_item_data in self.condition_factors:
                 condition_factors_item = condition_factors_item_data.to_dict()
                 condition_factors.append(condition_factors_item)
-
         primary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.primary_measurement_tool:
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
-
         secondary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.secondary_measurement_tool:
             secondary_measurement_tool = self.secondary_measurement_tool.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -258,7 +224,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             field_dict["PrimaryMeasurementTool"] = primary_measurement_tool
         if secondary_measurement_tool is not None:
             field_dict["SecondaryMeasurementTool"] = secondary_measurement_tool
-
         return field_dict
 
     @classmethod
@@ -272,22 +237,14 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
         from ..models.qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model import (
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel,
         )
-
         d = dict(src_dict)
         specification_name = d.pop("SpecificationName", None)
-
         measurement_quantity = d.pop("MeasurementQuantity", None)
-
         unit_of_measure_id = d.pop("UnitOfMeasureId", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         range_min = d.pop("RangeMin", None)
-
         range_max = d.pop("RangeMax", None)
-
         tolerance_type = d.pop("ToleranceType", None)
-
         _specification_mode = d.pop("SpecificationMode", None)
         specification_mode: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelSpecificationMode
@@ -298,7 +255,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             specification_mode = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelSpecificationMode(
                 _specification_mode
             )
-
         _tolerance_mode = d.pop("ToleranceMode", None)
         tolerance_mode: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceMode
@@ -309,7 +265,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             tolerance_mode = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceMode(
                 _tolerance_mode
             )
-
         _tolerance_unit = d.pop("ToleranceUnit", None)
         tolerance_unit: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceUnit
@@ -320,53 +275,34 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             tolerance_unit = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelToleranceUnit(
                 _tolerance_unit
             )
-
         precision_type = d.pop("PrecisionType", None)
-
         readings = d.pop("Readings", None)
-
         channels_type = d.pop("ChannelsType", None)
-
         channel_count = d.pop("ChannelCount", None)
-
         precision = d.pop("Precision", None)
-
         tolerance_minimum = d.pop("ToleranceMinimum", None)
-
         tolerance_maximum = d.pop("ToleranceMaximum", None)
-
         resolution = d.pop("Resolution", None)
-
         resolution_count = d.pop("ResolutionCount", None)
-
         nominal = d.pop("Nominal", None)
-
         expected_value = d.pop("ExpectedValue", None)
-
         base_value = d.pop("BaseValue", None)
-
         test_value = d.pop("TestValue", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         measurements = []
         _measurements = d.pop("Measurements", None)
         for measurements_item_data in _measurements or []:
             measurements_item = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementResponseModel.from_dict(
                 measurements_item_data
             )
-
             measurements.append(measurements_item)
-
         condition_factors = []
         _condition_factors = d.pop("ConditionFactors", None)
         for condition_factors_item_data in _condition_factors or []:
             condition_factors_item = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementConditionFactorResponseModel.from_dict(
                 condition_factors_item_data
             )
-
             condition_factors.append(condition_factors_item)
-
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", None)
         primary_measurement_tool: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel
@@ -377,7 +313,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             primary_measurement_tool = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel.from_dict(
                 _primary_measurement_tool
             )
-
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", None)
         secondary_measurement_tool: Optional[
             MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel
@@ -388,7 +323,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             secondary_measurement_tool = MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelMeasurementSetResponseModelMeasurementPointResponseModelMeasurementToolResponseModel.from_dict(
                 _secondary_measurement_tool
             )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model = cls(
             specification_name=specification_name,
             measurement_quantity=measurement_quantity,
@@ -419,7 +353,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             primary_measurement_tool=primary_measurement_tool,
             secondary_measurement_tool=secondary_measurement_tool,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model.py
@@ -32,21 +32,10 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
 
     def to_dict(self) -> Dict[str, Any]:
         factor_id = self.factor_id
-
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         factor_uom = self.factor_uom
-
-        last_modified_on_utc: Optional[str]
-        if not self.last_modified_on_utc:
-            last_modified_on_utc = None
-        elif isinstance(self.last_modified_on_utc, datetime.datetime):
-            last_modified_on_utc = self.last_modified_on_utc.isoformat()
-        else:
-            last_modified_on_utc = self.last_modified_on_utc
-
+        last_modified_on_utc = self.last_modified_on_utc.isoformat() if self.last_modified_on_utc else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -60,20 +49,15 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             field_dict["FactorUom"] = factor_uom
         if last_modified_on_utc is not None:
             field_dict["LastModifiedOnUtc"] = last_modified_on_utc
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         factor_id = d.pop("FactorId", None)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         factor_uom = d.pop("FactorUom", None)
-
         def _parse_last_modified_on_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -83,14 +67,11 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
                 if not isinstance(data, str):
                     raise TypeError()
                 last_modified_on_utc_type_0 = isoparse(data)
-
                 return last_modified_on_utc_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_modified_on_utc = _parse_last_modified_on_utc(d.pop("LastModifiedOnUtc", None))
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model = cls(
             factor_id=factor_id,
             factor_name=factor_name,
@@ -98,7 +79,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             factor_uom=factor_uom,
             last_modified_on_utc=last_modified_on_utc,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_condition_factor_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model.py
@@ -54,39 +54,23 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
 
     def to_dict(self) -> Dict[str, Any]:
         values = self.values
-
         mean = self.mean
-
         sd = self.sd
-
         range_ = self.range_
-
         delta = self.delta
-
         cv = self.cv
-
         cmc = self.cmc
-
         mu = self.mu
-
         tur = self.tur
-
         tar = self.tar
-
         max_value = self.max_value
-
         min_value = self.min_value
-
         error = self.error
-
         result = self.result
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
         updated_by = self.updated_by
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -122,49 +106,32 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             field_dict["UpdatedOn"] = updated_on
         if updated_by is not None:
             field_dict["UpdatedBy"] = updated_by
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         values = d.pop("Values", None)
-
         mean = d.pop("Mean", None)
-
         sd = d.pop("SD", None)
-
         range_ = d.pop("Range", None)
-
         delta = d.pop("Delta", None)
-
         cv = d.pop("CV", None)
-
         cmc = d.pop("CMC", None)
-
         mu = d.pop("MU", None)
-
         tur = d.pop("TUR", None)
-
         tar = d.pop("TAR", None)
-
         max_value = d.pop("MaxValue", None)
-
         min_value = d.pop("MinValue", None)
-
         error = d.pop("Error", None)
-
         result = d.pop("Result", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         updated_by = d.pop("UpdatedBy", None)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model = cls(
             values=values,
             mean=mean,
@@ -183,7 +150,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             updated_on=updated_on,
             updated_by=updated_by,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model.py
@@ -45,42 +45,18 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         calibrated_by = self.calibrated_by
-
         certificate_number = self.certificate_number
-
         tool_name = self.tool_name
-
         tool_description = self.tool_description
-
         manufacturer = self.manufacturer
-
         manufacturer_part_number = self.manufacturer_part_number
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -108,13 +84,11 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             field_dict["AssetUser"] = asset_user
         if equipment_id is not None:
             field_dict["EquipmentId"] = equipment_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -124,14 +98,11 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -141,34 +112,21 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         calibrated_by = d.pop("CalibratedBy", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         tool_name = d.pop("ToolName", None)
-
         tool_description = d.pop("ToolDescription", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model = cls(
             last_service_date=last_service_date,
             next_service_date=next_service_date,
@@ -183,7 +141,6 @@ class MeasurementsToMeasurementRecordResponseModelMeasurementBatchResponseModelM
             asset_user=asset_user,
             equipment_id=equipment_id,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_measurement_batch_response_model_measurement_set_response_model_measurement_point_response_model_measurement_tool_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model.py
@@ -26,11 +26,8 @@ class MeasurementsToMeasurementRecordResponseModelSpecificationResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         title = self.title
-
         subtitle = self.subtitle
-
         group = self.group
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -40,24 +37,19 @@ class MeasurementsToMeasurementRecordResponseModelSpecificationResponseModel:
             field_dict["Subtitle"] = subtitle
         if group is not None:
             field_dict["Group"] = group
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         title = d.pop("Title", None)
-
         subtitle = d.pop("Subtitle", None)
-
         group = d.pop("Group", None)
-
         qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model = cls(
             title=title,
             subtitle=subtitle,
             group=group,
         )
-
         qualer_api_models_measurements_to_measurement_record_response_model_specification_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_batch_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_batch_response_model.py
@@ -33,16 +33,13 @@ class MeasurementsToUpdateMeasurementBatchResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         batch_id = self.batch_id
-
         batch_type = self.batch_type
-
         measurement_sets: Optional[List[Dict[str, Any]]] = None
         if self.measurement_sets:
             measurement_sets = []
             for measurement_sets_item_data in self.measurement_sets:
                 measurement_sets_item = measurement_sets_item_data.to_dict()
                 measurement_sets.append(measurement_sets_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -52,7 +49,6 @@ class MeasurementsToUpdateMeasurementBatchResponseModel:
             field_dict["BatchType"] = batch_type
         if measurement_sets is not None:
             field_dict["MeasurementSets"] = measurement_sets
-
         return field_dict
 
     @classmethod
@@ -60,27 +56,21 @@ class MeasurementsToUpdateMeasurementBatchResponseModel:
         from ..models.qualer_api_models_measurements_to_update_measurement_set_response_model import (
             MeasurementsToUpdateMeasurementSetResponseModel,
         )
-
         d = dict(src_dict)
         batch_id = d.pop("BatchId", None)
-
         batch_type = d.pop("BatchType", None)
-
         measurement_sets = []
         _measurement_sets = d.pop("MeasurementSets", None)
         for measurement_sets_item_data in _measurement_sets or []:
             measurement_sets_item = MeasurementsToUpdateMeasurementSetResponseModel.from_dict(
                 measurement_sets_item_data
             )
-
             measurement_sets.append(measurement_sets_item)
-
         qualer_api_models_measurements_to_update_measurement_batch_response_model = cls(
             batch_id=batch_id,
             batch_type=batch_type,
             measurement_sets=measurement_sets,
         )
-
         qualer_api_models_measurements_to_update_measurement_batch_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_condition_factor_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_condition_factor_response.py
@@ -27,15 +27,10 @@ class MeasurementsToUpdateMeasurementConditionFactorResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_condition_factor_id = self.measurement_condition_factor_id
-
         factor_id = self.factor_id
-
         factor_name = self.factor_name
-
         factor_value = self.factor_value
-
         factor_uom = self.factor_uom
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class MeasurementsToUpdateMeasurementConditionFactorResponse:
             field_dict["FactorValue"] = factor_value
         if factor_uom is not None:
             field_dict["FactorUom"] = factor_uom
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_condition_factor_id = d.pop("MeasurementConditionFactorId", None)
-
         factor_id = d.pop("FactorId", None)
-
         factor_name = d.pop("FactorName", None)
-
         factor_value = d.pop("FactorValue", None)
-
         factor_uom = d.pop("FactorUom", None)
-
         qualer_api_models_measurements_to_update_measurement_condition_factor_response = cls(
             measurement_condition_factor_id=measurement_condition_factor_id,
             factor_id=factor_id,
@@ -72,7 +61,6 @@ class MeasurementsToUpdateMeasurementConditionFactorResponse:
             factor_value=factor_value,
             factor_uom=factor_uom,
         )
-
         qualer_api_models_measurements_to_update_measurement_condition_factor_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_field_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_field_response_model.py
@@ -25,13 +25,9 @@ class MeasurementsToUpdateMeasurementFieldResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         field_id = self.field_id
-
         name = self.name
-
         type_ = self.type_
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class MeasurementsToUpdateMeasurementFieldResponseModel:
             field_dict["Type"] = type_
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         field_id = d.pop("FieldId", None)
-
         name = d.pop("Name", None)
-
         type_ = d.pop("Type", None)
-
         value = d.pop("Value", None)
-
         qualer_api_models_measurements_to_update_measurement_field_response_model = cls(
             field_id=field_id,
             name=name,
             type_=type_,
             value=value,
         )
-
         qualer_api_models_measurements_to_update_measurement_field_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_form_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_form_response_model.py
@@ -34,13 +34,11 @@ class MeasurementsToUpdateMeasurementFormResponseModel:
             for measurement_batches_item_data in self.measurement_batches:
                 measurement_batches_item = measurement_batches_item_data.to_dict()
                 measurement_batches.append(measurement_batches_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if measurement_batches is not None:
             field_dict["MeasurementBatches"] = measurement_batches
-
         return field_dict
 
     @classmethod
@@ -48,7 +46,6 @@ class MeasurementsToUpdateMeasurementFormResponseModel:
         from ..models.qualer_api_models_measurements_to_update_measurement_batch_response_model import (
             MeasurementsToUpdateMeasurementBatchResponseModel,
         )
-
         d = dict(src_dict)
         measurement_batches = []
         _measurement_batches = d.pop("MeasurementBatches", None)
@@ -56,13 +53,10 @@ class MeasurementsToUpdateMeasurementFormResponseModel:
             measurement_batches_item = MeasurementsToUpdateMeasurementBatchResponseModel.from_dict(
                 measurement_batches_item_data
             )
-
             measurement_batches.append(measurement_batches_item)
-
         qualer_api_models_measurements_to_update_measurement_form_response_model = cls(
             measurement_batches=measurement_batches,
         )
-
         qualer_api_models_measurements_to_update_measurement_form_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_point_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_point_response_model.py
@@ -104,74 +104,40 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_point_id = self.measurement_point_id
-
         specification_name = self.specification_name
-
         unit_of_measure = self.unit_of_measure
-
         expected_value = self.expected_value
-
         base_value = self.base_value
-
         test_value = self.test_value
-
         nominal = self.nominal
-
         range_min = self.range_min
-
         range_max = self.range_max
-
         tolerance_type = self.tolerance_type
-
-        tolerance_mode: Optional[int] = None
-        if self.tolerance_mode:
-            tolerance_mode = self.tolerance_mode.value
-
-        tolerance_unit: Optional[int] = None
-        if self.tolerance_unit:
-            tolerance_unit = self.tolerance_unit.value
-
+        tolerance_mode = self.tolerance_mode.value if self.tolerance_mode else None
+        tolerance_unit = self.tolerance_unit.value if self.tolerance_unit else None
         precision_type = self.precision_type
-
         precision = self.precision
-
         tolerance_minimum = self.tolerance_minimum
-
         tolerance_maximum = self.tolerance_maximum
-
         resolution = self.resolution
-
         resolution_count = self.resolution_count
-
         is_accredited = self.is_accredited
-
         linked_measurement_point_id = self.linked_measurement_point_id
-
         hysteresis_point = self.hysteresis_point
-
         hide_from_certificate = self.hide_from_certificate
-
         is_measurement_not_taken = self.is_measurement_not_taken
-
         measurement_not_taken_result = self.measurement_not_taken_result
-
         measurement_not_taken_reason = self.measurement_not_taken_reason
-
         influence_parameter_1_parameter_id = self.influence_parameter_1_parameter_id
-
         influence_parameter_1_value = self.influence_parameter_1_value
-
         influence_parameter_2_parameter_id = self.influence_parameter_2_parameter_id
-
         influence_parameter_2_value = self.influence_parameter_2_value
-
         measurements: Optional[List[Dict[str, Any]]] = None
         if self.measurements:
             measurements = []
             for measurements_item_data in self.measurements:
                 measurements_item = measurements_item_data.to_dict()
                 measurements.append(measurements_item)
-
         measurement_condition_factors: Optional[List[Dict[str, Any]]] = None
         if self.measurement_condition_factors:
             measurement_condition_factors = []
@@ -180,15 +146,12 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
                     measurement_condition_factors_item_data.to_dict()
                 )
                 measurement_condition_factors.append(measurement_condition_factors_item)
-
         primary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.primary_measurement_tool:
             primary_measurement_tool = self.primary_measurement_tool.to_dict()
-
         secondary_measurement_tool: Optional[Dict[str, Any]] = None
         if self.secondary_measurement_tool:
             secondary_measurement_tool = self.secondary_measurement_tool.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -258,7 +221,6 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             field_dict["PrimaryMeasurementTool"] = primary_measurement_tool
         if secondary_measurement_tool is not None:
             field_dict["SecondaryMeasurementTool"] = secondary_measurement_tool
-
         return field_dict
 
     @classmethod
@@ -272,28 +234,17 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
         from ..models.qualer_api_models_measurements_to_update_measurement_tool_response_model import (
             MeasurementsToUpdateMeasurementToolResponseModel,
         )
-
         d = dict(src_dict)
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         specification_name = d.pop("SpecificationName", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         expected_value = d.pop("ExpectedValue", None)
-
         base_value = d.pop("BaseValue", None)
-
         test_value = d.pop("TestValue", None)
-
         nominal = d.pop("Nominal", None)
-
         range_min = d.pop("RangeMin", None)
-
         range_max = d.pop("RangeMax", None)
-
         tolerance_type = d.pop("ToleranceType", None)
-
         _tolerance_mode = d.pop("ToleranceMode", None)
         tolerance_mode: Optional[MeasurementsToUpdateMeasurementPointResponseModelToleranceMode]
         if not _tolerance_mode:
@@ -308,7 +259,6 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             tolerance_mode = MeasurementsToUpdateMeasurementPointResponseModelToleranceMode(
                 _tolerance_mode
             )
-
         _tolerance_unit = d.pop("ToleranceUnit", None)
         tolerance_unit: Optional[MeasurementsToUpdateMeasurementPointResponseModelToleranceUnit]
         if not _tolerance_unit:
@@ -327,50 +277,30 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             tolerance_unit = MeasurementsToUpdateMeasurementPointResponseModelToleranceUnit(
                 _tolerance_unit
             )
-
         precision_type = d.pop("PrecisionType", None)
-
         precision = d.pop("Precision", None)
-
         tolerance_minimum = d.pop("ToleranceMinimum", None)
-
         tolerance_maximum = d.pop("ToleranceMaximum", None)
-
         resolution = d.pop("Resolution", None)
-
         resolution_count = d.pop("ResolutionCount", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         linked_measurement_point_id = d.pop("LinkedMeasurementPointId", None)
-
         hysteresis_point = d.pop("HysteresisPoint", None)
-
         hide_from_certificate = d.pop("HideFromCertificate", None)
-
         is_measurement_not_taken = d.pop("IsMeasurementNotTaken", None)
-
         measurement_not_taken_result = d.pop("MeasurementNotTakenResult", None)
-
         measurement_not_taken_reason = d.pop("MeasurementNotTakenReason", None)
-
         influence_parameter_1_parameter_id = d.pop("InfluenceParameter1ParameterId", None)
-
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", None)
-
         influence_parameter_2_parameter_id = d.pop("InfluenceParameter2ParameterId", None)
-
         influence_parameter_2_value = d.pop("InfluenceParameter2Value", None)
-
         measurements = []
         _measurements = d.pop("Measurements", None)
         for measurements_item_data in _measurements or []:
             measurements_item = MeasurementsToUpdateMeasurementResponseModel.from_dict(
                 measurements_item_data
             )
-
             measurements.append(measurements_item)
-
         measurement_condition_factors = []
         _measurement_condition_factors = d.pop("MeasurementConditionFactors", None)
         for measurement_condition_factors_item_data in _measurement_condition_factors or []:
@@ -379,9 +309,7 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
                     measurement_condition_factors_item_data
                 )
             )
-
             measurement_condition_factors.append(measurement_condition_factors_item)
-
         _primary_measurement_tool = d.pop("PrimaryMeasurementTool", None)
         primary_measurement_tool: Optional[MeasurementsToUpdateMeasurementToolResponseModel]
         if not _primary_measurement_tool:
@@ -390,7 +318,6 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             primary_measurement_tool = MeasurementsToUpdateMeasurementToolResponseModel.from_dict(
                 _primary_measurement_tool
             )
-
         _secondary_measurement_tool = d.pop("SecondaryMeasurementTool", None)
         secondary_measurement_tool: Optional[MeasurementsToUpdateMeasurementToolResponseModel]
         if not _secondary_measurement_tool:
@@ -399,7 +326,6 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             secondary_measurement_tool = MeasurementsToUpdateMeasurementToolResponseModel.from_dict(
                 _secondary_measurement_tool
             )
-
         qualer_api_models_measurements_to_update_measurement_point_response_model = cls(
             measurement_point_id=measurement_point_id,
             specification_name=specification_name,
@@ -435,7 +361,6 @@ class MeasurementsToUpdateMeasurementPointResponseModel:
             primary_measurement_tool=primary_measurement_tool,
             secondary_measurement_tool=secondary_measurement_tool,
         )
-
         qualer_api_models_measurements_to_update_measurement_point_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_response_model.py
@@ -29,17 +29,12 @@ class MeasurementsToUpdateMeasurementResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_id = self.measurement_id
-
         values = self.values
-
         channel = self.channel
-
         updated_by = self.updated_by
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -53,27 +48,21 @@ class MeasurementsToUpdateMeasurementResponseModel:
             field_dict["UpdatedBy"] = updated_by
         if updated_on is not None:
             field_dict["UpdatedOn"] = updated_on
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_id = d.pop("MeasurementId", None)
-
         values = d.pop("Values", None)
-
         channel = d.pop("Channel", None)
-
         updated_by = d.pop("UpdatedBy", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         qualer_api_models_measurements_to_update_measurement_response_model = cls(
             measurement_id=measurement_id,
             values=values,
@@ -81,7 +70,6 @@ class MeasurementsToUpdateMeasurementResponseModel:
             updated_by=updated_by,
             updated_on=updated_on,
         )
-
         qualer_api_models_measurements_to_update_measurement_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_set_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_set_response_model.py
@@ -73,55 +73,33 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_set_id = self.measurement_set_id
-
         measurement_name = self.measurement_name
-
         is_accredited = self.is_accredited
-
         use_expected_value = self.use_expected_value
-
         decimal_places = self.decimal_places
-
         significant_figures = self.significant_figures
-
-        influence_parameter_1_type: Optional[str] = None
-        if self.influence_parameter_1_type:
-            influence_parameter_1_type = self.influence_parameter_1_type.value
-
+        influence_parameter_1_type = self.influence_parameter_1_type.value if self.influence_parameter_1_type else None
         influence_parameter_1_tool_type_id = self.influence_parameter_1_tool_type_id
-
         influence_parameter_1_parameter_id = self.influence_parameter_1_parameter_id
-
         influence_parameter_1_source = self.influence_parameter_1_source
-
         influence_parameter_1_value = self.influence_parameter_1_value
-
-        influence_parameter_2_type: Optional[str] = None
-        if self.influence_parameter_2_type:
-            influence_parameter_2_type = self.influence_parameter_2_type.value
-
+        influence_parameter_2_type = self.influence_parameter_2_type.value if self.influence_parameter_2_type else None
         influence_parameter_2_tool_type_id = self.influence_parameter_2_tool_type_id
-
         influence_parameter_2_parameter_id = self.influence_parameter_2_parameter_id
-
         influence_parameter_2_source = self.influence_parameter_2_source
-
         influence_parameter_2_value = self.influence_parameter_2_value
-
         measurement_points: Optional[List[Dict[str, Any]]] = None
         if self.measurement_points:
             measurement_points = []
             for measurement_points_item_data in self.measurement_points:
                 measurement_points_item = measurement_points_item_data.to_dict()
                 measurement_points.append(measurement_points_item)
-
         measurement_fields: Optional[List[Dict[str, Any]]] = None
         if self.measurement_fields:
             measurement_fields = []
             for measurement_fields_item_data in self.measurement_fields:
                 measurement_fields_item = measurement_fields_item_data.to_dict()
                 measurement_fields.append(measurement_fields_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -161,7 +139,6 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
             field_dict["MeasurementPoints"] = measurement_points
         if measurement_fields is not None:
             field_dict["MeasurementFields"] = measurement_fields
-
         return field_dict
 
     @classmethod
@@ -172,20 +149,13 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
         from ..models.qualer_api_models_measurements_to_update_measurement_point_response_model import (
             MeasurementsToUpdateMeasurementPointResponseModel,
         )
-
         d = dict(src_dict)
         measurement_set_id = d.pop("MeasurementSetId", None)
-
         measurement_name = d.pop("MeasurementName", None)
-
         is_accredited = d.pop("IsAccredited", None)
-
         use_expected_value = d.pop("UseExpectedValue", None)
-
         decimal_places = d.pop("DecimalPlaces", None)
-
         significant_figures = d.pop("SignificantFigures", None)
-
         _influence_parameter_1_type = d.pop("InfluenceParameter1Type", None)
         influence_parameter_1_type: Optional[
             MeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter1Type
@@ -200,15 +170,10 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
                     _influence_parameter_1_type
                 )
             )
-
         influence_parameter_1_tool_type_id = d.pop("InfluenceParameter1ToolTypeId", None)
-
         influence_parameter_1_parameter_id = d.pop("InfluenceParameter1ParameterId", None)
-
         influence_parameter_1_source = d.pop("InfluenceParameter1Source", None)
-
         influence_parameter_1_value = d.pop("InfluenceParameter1Value", None)
-
         _influence_parameter_2_type = d.pop("InfluenceParameter2Type", None)
         influence_parameter_2_type: Optional[
             MeasurementsToUpdateMeasurementSetResponseModelInfluenceParameter2Type
@@ -223,33 +188,24 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
                     _influence_parameter_2_type
                 )
             )
-
         influence_parameter_2_tool_type_id = d.pop("InfluenceParameter2ToolTypeId", None)
-
         influence_parameter_2_parameter_id = d.pop("InfluenceParameter2ParameterId", None)
-
         influence_parameter_2_source = d.pop("InfluenceParameter2Source", None)
-
         influence_parameter_2_value = d.pop("InfluenceParameter2Value", None)
-
         measurement_points = []
         _measurement_points = d.pop("MeasurementPoints", None)
         for measurement_points_item_data in _measurement_points or []:
             measurement_points_item = MeasurementsToUpdateMeasurementPointResponseModel.from_dict(
                 measurement_points_item_data
             )
-
             measurement_points.append(measurement_points_item)
-
         measurement_fields = []
         _measurement_fields = d.pop("MeasurementFields", None)
         for measurement_fields_item_data in _measurement_fields or []:
             measurement_fields_item = MeasurementsToUpdateMeasurementFieldResponseModel.from_dict(
                 measurement_fields_item_data
             )
-
             measurement_fields.append(measurement_fields_item)
-
         qualer_api_models_measurements_to_update_measurement_set_response_model = cls(
             measurement_set_id=measurement_set_id,
             measurement_name=measurement_name,
@@ -270,7 +226,6 @@ class MeasurementsToUpdateMeasurementSetResponseModel:
             measurement_points=measurement_points,
             measurement_fields=measurement_fields,
         )
-
         qualer_api_models_measurements_to_update_measurement_set_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_tool_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_measurements_to_update_measurement_tool_response_model.py
@@ -45,43 +45,18 @@ class MeasurementsToUpdateMeasurementToolResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_tool_id = self.measurement_tool_id
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         calibrated_by = self.calibrated_by
-
         certificate_number = self.certificate_number
-
         tool_name = self.tool_name
-
         tool_description = self.tool_description
-
         manufacturer = self.manufacturer
-
         manufacturer_part_number = self.manufacturer_part_number
-
         serial_number = self.serial_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         equipment_id = self.equipment_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -111,14 +86,12 @@ class MeasurementsToUpdateMeasurementToolResponseModel:
             field_dict["AssetUser"] = asset_user
         if equipment_id is not None:
             field_dict["EquipmentId"] = equipment_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_tool_id = d.pop("MeasurementToolId", None)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -128,14 +101,11 @@ class MeasurementsToUpdateMeasurementToolResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -145,34 +115,21 @@ class MeasurementsToUpdateMeasurementToolResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         calibrated_by = d.pop("CalibratedBy", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         tool_name = d.pop("ToolName", None)
-
         tool_description = d.pop("ToolDescription", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         qualer_api_models_measurements_to_update_measurement_tool_response_model = cls(
             measurement_tool_id=measurement_tool_id,
             last_service_date=last_service_date,
@@ -188,7 +145,6 @@ class MeasurementsToUpdateMeasurementToolResponseModel:
             asset_user=asset_user,
             equipment_id=equipment_id,
         )
-
         qualer_api_models_measurements_to_update_measurement_tool_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_product_to_manufacturer_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_product_to_manufacturer_response_model.py
@@ -21,9 +21,7 @@ class ProductToManufacturerResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         manufacturer_id = self.manufacturer_id
-
         manufacturer_name = self.manufacturer_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ProductToManufacturerResponseModel:
             field_dict["ManufacturerId"] = manufacturer_id
         if manufacturer_name is not None:
             field_dict["ManufacturerName"] = manufacturer_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         manufacturer_id = d.pop("ManufacturerId", None)
-
         manufacturer_name = d.pop("ManufacturerName", None)
-
         qualer_api_models_product_to_manufacturer_response_model = cls(
             manufacturer_id=manufacturer_id,
             manufacturer_name=manufacturer_name,
         )
-
         qualer_api_models_product_to_manufacturer_response_model.additional_properties = d
         return qualer_api_models_product_to_manufacturer_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_product_to_product_api_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_product_to_product_api_response_model.py
@@ -53,41 +53,23 @@ class ProductToProductApiResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         product_id = self.product_id
-
         parent_product_id = self.parent_product_id
-
         category_id = self.category_id
-
         manufacturer_id = self.manufacturer_id
-
         manufacturer_name = self.manufacturer_name
-
         product_name = self.product_name
-
         parent_product_name = self.parent_product_name
-
         manufacturer_part_number = self.manufacturer_part_number
-
         product_description = self.product_description
-
         is_family = self.is_family
-
         is_discontinued = self.is_discontinued
-
         is_stock_item = self.is_stock_item
-
         unit_sale_price = self.unit_sale_price
-
         supplier_information = self.supplier_information
-
         quantity_on_hand = self.quantity_on_hand
-
         product_code = self.product_code
-
         category_name = self.category_name
-
         parent_category_name = self.parent_category_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -127,48 +109,29 @@ class ProductToProductApiResponseModel:
             field_dict["CategoryName"] = category_name
         if parent_category_name is not None:
             field_dict["ParentCategoryName"] = parent_category_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         product_id = d.pop("ProductId", None)
-
         parent_product_id = d.pop("ParentProductId", None)
-
         category_id = d.pop("CategoryId", None)
-
         manufacturer_id = d.pop("ManufacturerId", None)
-
         manufacturer_name = d.pop("ManufacturerName", None)
-
         product_name = d.pop("ProductName", None)
-
         parent_product_name = d.pop("ParentProductName", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         product_description = d.pop("ProductDescription", None)
-
         is_family = d.pop("IsFamily", None)
-
         is_discontinued = d.pop("IsDiscontinued", None)
-
         is_stock_item = d.pop("IsStockItem", None)
-
         unit_sale_price = d.pop("UnitSalePrice", None)
-
         supplier_information = d.pop("SupplierInformation", None)
-
         quantity_on_hand = d.pop("QuantityOnHand", None)
-
         product_code = d.pop("ProductCode", None)
-
         category_name = d.pop("CategoryName", None)
-
         parent_category_name = d.pop("ParentCategoryName", None)
-
         qualer_api_models_product_to_product_api_response_model = cls(
             product_id=product_id,
             parent_product_id=parent_product_id,
@@ -189,7 +152,6 @@ class ProductToProductApiResponseModel:
             category_name=category_name,
             parent_category_name=parent_category_name,
         )
-
         qualer_api_models_product_to_product_api_response_model.additional_properties = d
         return qualer_api_models_product_to_product_api_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_reference_to_measurement_quantity_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_reference_to_measurement_quantity_response.py
@@ -21,9 +21,7 @@ class ReferenceToMeasurementQuantityResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_quantity_id = self.measurement_quantity_id
-
         measurement_quantity = self.measurement_quantity
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ReferenceToMeasurementQuantityResponse:
             field_dict["MeasurementQuantityId"] = measurement_quantity_id
         if measurement_quantity is not None:
             field_dict["MeasurementQuantity"] = measurement_quantity
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_quantity_id = d.pop("MeasurementQuantityId", None)
-
         measurement_quantity = d.pop("MeasurementQuantity", None)
-
         qualer_api_models_reference_to_measurement_quantity_response = cls(
             measurement_quantity_id=measurement_quantity_id,
             measurement_quantity=measurement_quantity,
         )
-
         qualer_api_models_reference_to_measurement_quantity_response.additional_properties = d
         return qualer_api_models_reference_to_measurement_quantity_response
 

--- a/src/qualer_sdk/models/qualer_api_models_reference_to_unit_of_measure_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_reference_to_unit_of_measure_response.py
@@ -25,13 +25,9 @@ class ReferenceToUnitOfMeasureResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_quantity_id = self.measurement_quantity_id
-
         measurement_quantity = self.measurement_quantity
-
         unit_of_measure_id = self.unit_of_measure_id
-
         unit_of_measure = self.unit_of_measure
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class ReferenceToUnitOfMeasureResponse:
             field_dict["UnitOfMeasureId"] = unit_of_measure_id
         if unit_of_measure is not None:
             field_dict["UnitOfMeasure"] = unit_of_measure
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_quantity_id = d.pop("MeasurementQuantityId", None)
-
         measurement_quantity = d.pop("MeasurementQuantity", None)
-
         unit_of_measure_id = d.pop("UnitOfMeasureId", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         qualer_api_models_reference_to_unit_of_measure_response = cls(
             measurement_quantity_id=measurement_quantity_id,
             measurement_quantity=measurement_quantity,
             unit_of_measure_id=unit_of_measure_id,
             unit_of_measure=unit_of_measure,
         )
-
         qualer_api_models_reference_to_unit_of_measure_response.additional_properties = d
         return qualer_api_models_reference_to_unit_of_measure_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_attribute_response.py
@@ -25,13 +25,9 @@ class ReportDatasetsToAssetAttributeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_id = self.asset_id
-
         attribute_name = self.attribute_name
-
         attribute_value = self.attribute_value
-
         is_service = self.is_service
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,27 +39,21 @@ class ReportDatasetsToAssetAttributeResponse:
             field_dict["AttributeValue"] = attribute_value
         if is_service is not None:
             field_dict["IsService"] = is_service
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_id = d.pop("AssetId", None)
-
         attribute_name = d.pop("AttributeName", None)
-
         attribute_value = d.pop("AttributeValue", None)
-
         is_service = d.pop("IsService", None)
-
         qualer_api_models_report_datasets_to_asset_attribute_response = cls(
             asset_id=asset_id,
             attribute_name=attribute_name,
             attribute_value=attribute_value,
             is_service=is_service,
         )
-
         qualer_api_models_report_datasets_to_asset_attribute_response.additional_properties = d
         return qualer_api_models_report_datasets_to_asset_attribute_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_summary_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_asset_summary_response.py
@@ -131,156 +131,64 @@ class ReportDatasetsToAssetSummaryResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_number = self.service_order_number
-
         service_order_id = self.service_order_id
-
         service_order_item_id = self.service_order_item_id
-
         custom_order_number = self.custom_order_number
-
         order_item_number = self.order_item_number
-
         is_limited = self.is_limited
-
         certificate_number = self.certificate_number
-
         serial_number = self.serial_number
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        service_date = self.service_date.isoformat() if self.service_date else None
         part_number = self.part_number
-
         display_part_number = self.display_part_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         asset_name = self.asset_name
-
         equipment_id = self.equipment_id
-
         legacy_identifier = self.legacy_identifier
-
         asset_description = self.asset_description
-
         class_ = self.class_
-
         condition = self.condition
-
         criticality = self.criticality
-
         asset_pool = self.asset_pool
-
         room = self.room
-
         station = self.station
-
         service_notes = self.service_notes
-
         service_level = self.service_level
-
         service_level_code = self.service_level_code
-
         next_service_level = self.next_service_level
-
         next_service_level_code = self.next_service_level_code
-
         asset_id = self.asset_id
-
         result_status: Optional[int]
         if not self.result_status:
             result_status = None
         else:
             result_status: Optional[str]
-
             if not self.result_status:
-
                 result_status = None
             else:
                 result_status = self.result_status
-        serial_number_change: Optional[str]
-        if not self.serial_number_change:
-            serial_number_change = None
-        else:
-            serial_number_change = self.serial_number_change
-
-        provider_technician: Optional[str]
-        if not self.provider_technician:
-            provider_technician = None
-        else:
-            provider_technician = self.provider_technician
-
-        provider_technician_alias: Optional[str]
-        if not self.provider_technician_alias:
-            provider_technician_alias = None
-        else:
-            provider_technician_alias = self.provider_technician_alias
-
-        provider_phone: Optional[str]
-        if not self.provider_phone:
-            provider_phone = None
-        else:
-            provider_phone = self.provider_phone
-
-        provider_company: Optional[str]
-        if not self.provider_company:
-            provider_company = None
-        else:
-            provider_company = self.provider_company
-
-        qr_code: Optional[str]
-        if not self.qr_code:
-            qr_code = None
-        else:
-            qr_code = self.qr_code
-
-        bar_code: Optional[str]
-        if not self.bar_code:
-            bar_code = None
-        else:
-            bar_code = self.bar_code
-
-        bar_code_string: Optional[str]
-        if not self.bar_code_string:
-            bar_code_string = None
-        else:
-            bar_code_string = self.bar_code_string
-
+        serial_number_change = self.serial_number_change
+        provider_technician = self.provider_technician
+        provider_technician_alias = self.provider_technician_alias
+        provider_phone = self.provider_phone
+        provider_company = self.provider_company
+        qr_code = self.qr_code
+        bar_code = self.bar_code
+        bar_code_string = self.bar_code_string
         owner_company_id: Optional[int]
         if not self.owner_company_id:
             owner_company_id = None
         else:
             owner_company_id = self.owner_company_id
-
-        owner_company_name: Optional[str]
-        if not self.owner_company_name:
-            owner_company_name = None
-        else:
-            owner_company_name = self.owner_company_name
-
+        owner_company_name = self.owner_company_name
         as_found_result: Optional[int]
         if not self.as_found_result:
             as_found_result = None
         else:
             as_found_result: Optional[str]
-
             if not self.as_found_result:
-
                 as_found_result = None
             else:
                 as_found_result = self.as_found_result
@@ -289,92 +197,47 @@ class ReportDatasetsToAssetSummaryResponse:
             as_left_result = None
         else:
             as_left_result: Optional[str]
-
             if not self.as_left_result:
-
                 as_left_result = None
             else:
                 as_left_result = self.as_left_result
-        asset_tag_change: Optional[str]
-        if not self.asset_tag_change:
-            asset_tag_change = None
-        else:
-            asset_tag_change = self.asset_tag_change
-
-        asset_user_change: Optional[str]
-        if not self.asset_user_change:
-            asset_user_change = None
-        else:
-            asset_user_change = self.asset_user_change
-
-        due_date: Optional[str]
-        if not self.due_date:
-            due_date = None
-        elif isinstance(self.due_date, datetime.datetime):
-            due_date = self.due_date.isoformat()
-        else:
-            due_date = self.due_date
-
+        asset_tag_change = self.asset_tag_change
+        asset_user_change = self.asset_user_change
+        due_date = self.due_date.isoformat() if self.due_date else None
         parts_charge: Optional[float]
         if not self.parts_charge:
             parts_charge = None
         else:
             parts_charge = self.parts_charge
-
         parts_charge_before_discount: Optional[float]
         if not self.parts_charge_before_discount:
             parts_charge_before_discount = None
         else:
             parts_charge_before_discount = self.parts_charge_before_discount
-
         service_charge: Optional[float]
         if not self.service_charge:
             service_charge = None
         else:
             service_charge = self.service_charge
-
         repairs_charge: Optional[float]
         if not self.repairs_charge:
             repairs_charge = None
         else:
             repairs_charge = self.repairs_charge
-
-        segment_name: Optional[str]
-        if not self.segment_name:
-            segment_name = None
-        else:
-            segment_name = self.segment_name
-
-        schedule_name: Optional[str]
-        if not self.schedule_name:
-            schedule_name = None
-        else:
-            schedule_name = self.schedule_name
-
-        next_segment_name: Optional[str]
-        if not self.next_segment_name:
-            next_segment_name = None
-        else:
-            next_segment_name = self.next_segment_name
-
+        segment_name = self.segment_name
+        schedule_name = self.schedule_name
+        next_segment_name = self.next_segment_name
         client_id: Optional[int]
         if not self.client_id:
             client_id = None
         else:
             client_id = self.client_id
-
         interval_length: Optional[int]
         if not self.interval_length:
             interval_length = None
         else:
             interval_length = self.interval_length
-
-        interval_cycle: Optional[str]
-        if not self.interval_cycle:
-            interval_cycle = None
-        else:
-            interval_cycle = self.interval_cycle
-
+        interval_cycle = self.interval_cycle
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -490,28 +353,19 @@ class ReportDatasetsToAssetSummaryResponse:
             field_dict["IntervalLength"] = interval_length
         if interval_cycle is not None:
             field_dict["IntervalCycle"] = interval_cycle
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         is_limited = d.pop("IsLimited", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -521,14 +375,11 @@ class ReportDatasetsToAssetSummaryResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -536,161 +387,108 @@ class ReportDatasetsToAssetSummaryResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         part_number = d.pop("PartNumber", None)
-
         display_part_number = d.pop("DisplayPartNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_name = d.pop("AssetName", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         class_ = d.pop("Class", None)
-
         condition = d.pop("Condition", None)
-
         criticality = d.pop("Criticality", None)
-
         asset_pool = d.pop("AssetPool", None)
-
         room = d.pop("Room", None)
-
         station = d.pop("Station", None)
-
         service_notes = d.pop("ServiceNotes", None)
-
         service_level = d.pop("ServiceLevel", None)
-
         service_level_code = d.pop("ServiceLevelCode", None)
-
         next_service_level = d.pop("NextServiceLevel", None)
-
         next_service_level_code = d.pop("NextServiceLevelCode", None)
-
         asset_id = d.pop("AssetId", None)
-
         def _parse_result_status(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_serial_number_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         serial_number_change = _parse_serial_number_change(d.pop("SerialNumberChange", None))
-
         def _parse_provider_technician(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician = _parse_provider_technician(d.pop("ProviderTechnician", None))
-
         def _parse_provider_technician_alias(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician_alias = _parse_provider_technician_alias(
             d.pop("ProviderTechnicianAlias", None)
         )
-
         def _parse_provider_phone(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_phone = _parse_provider_phone(d.pop("ProviderPhone", None))
-
         def _parse_provider_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_company = _parse_provider_company(d.pop("ProviderCompany", None))
-
         def _parse_qr_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         qr_code = _parse_qr_code(d.pop("QrCode", None))
-
         def _parse_bar_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         bar_code = _parse_bar_code(d.pop("BarCode", None))
-
         def _parse_bar_code_string(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         bar_code_string = _parse_bar_code_string(d.pop("BarCodeString", None))
-
         def _parse_owner_company_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         owner_company_id = _parse_owner_company_id(d.pop("OwnerCompanyId", None))
-
         def _parse_owner_company_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         owner_company_name = _parse_owner_company_name(d.pop("OwnerCompanyName", None))
-
         def _parse_as_found_result(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_asset_tag_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag_change = _parse_asset_tag_change(d.pop("AssetTagChange", None))
-
         def _parse_asset_user_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user_change = _parse_asset_user_change(d.pop("AssetUserChange", None))
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -698,88 +496,65 @@ class ReportDatasetsToAssetSummaryResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_date_type_0 = isoparse(data)
-
                 return due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_parts_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge = _parse_parts_charge(d.pop("PartsCharge", None))
-
         def _parse_parts_charge_before_discount(
             data: object,
         ) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge_before_discount = _parse_parts_charge_before_discount(
             d.pop("PartsChargeBeforeDiscount", None)
         )
-
         def _parse_service_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge = _parse_service_charge(d.pop("ServiceCharge", None))
-
         def _parse_repairs_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_charge = _parse_repairs_charge(d.pop("RepairsCharge", None))
-
         def _parse_segment_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         segment_name = _parse_segment_name(d.pop("SegmentName", None))
-
         def _parse_schedule_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         schedule_name = _parse_schedule_name(d.pop("ScheduleName", None))
-
         def _parse_next_segment_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_segment_name = _parse_next_segment_name(d.pop("NextSegmentName", None))
-
         def _parse_client_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         client_id = _parse_client_id(d.pop("ClientId", None))
-
         def _parse_interval_length(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         interval_length = _parse_interval_length(d.pop("IntervalLength", None))
-
         def _parse_interval_cycle(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         interval_cycle = _parse_interval_cycle(d.pop("IntervalCycle", None))
-
         qualer_api_models_report_datasets_to_asset_summary_response = cls(
             service_order_number=service_order_number,
             service_order_id=service_order_id,
@@ -838,7 +613,6 @@ class ReportDatasetsToAssetSummaryResponse:
             interval_length=interval_length,
             interval_cycle=interval_cycle,
         )
-
         qualer_api_models_report_datasets_to_asset_summary_response.additional_properties = d
         return qualer_api_models_report_datasets_to_asset_summary_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_client_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_client_attribute_response.py
@@ -21,9 +21,7 @@ class ReportDatasetsToClientAttributeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         attribute_name = self.attribute_name
-
         attribute_value = self.attribute_value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ReportDatasetsToClientAttributeResponse:
             field_dict["AttributeName"] = attribute_name
         if attribute_value is not None:
             field_dict["AttributeValue"] = attribute_value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         attribute_name = d.pop("AttributeName", None)
-
         attribute_value = d.pop("AttributeValue", None)
-
         qualer_api_models_report_datasets_to_client_attribute_response = cls(
             attribute_name=attribute_name,
             attribute_value=attribute_value,
         )
-
         qualer_api_models_report_datasets_to_client_attribute_response.additional_properties = d
         return qualer_api_models_report_datasets_to_client_attribute_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_company_certification_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_company_certification_response.py
@@ -35,27 +35,19 @@ class ReportDatasetsToCompanyCertificationResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         logo = self.logo
-
         initial_date: Optional[str] = None
         if self.initial_date:
             initial_date = self.initial_date.isoformat()
-
         certification_date: Optional[str] = None
         if self.certification_date:
             certification_date = self.certification_date.isoformat()
-
         expiration_date: Optional[str] = None
         if self.expiration_date:
             expiration_date = self.expiration_date.isoformat()
-
         certification_name = self.certification_name
-
         certificate_number = self.certificate_number
-
         certification_authority = self.certification_authority
-
         certification_standard = self.certification_standard
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -75,43 +67,34 @@ class ReportDatasetsToCompanyCertificationResponse:
             field_dict["CertificationAuthority"] = certification_authority
         if certification_standard is not None:
             field_dict["CertificationStandard"] = certification_standard
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         logo = d.pop("Logo", None)
-
         _initial_date = d.pop("InitialDate", None)
         initial_date: Optional[datetime.datetime]
         if not _initial_date:
             initial_date = None
         else:
             initial_date = isoparse(_initial_date)
-
         _certification_date = d.pop("CertificationDate", None)
         certification_date: Optional[datetime.datetime]
         if not _certification_date:
             certification_date = None
         else:
             certification_date = isoparse(_certification_date)
-
         _expiration_date = d.pop("ExpirationDate", None)
         expiration_date: Optional[datetime.datetime]
         if not _expiration_date:
             expiration_date = None
         else:
             expiration_date = isoparse(_expiration_date)
-
         certification_name = d.pop("CertificationName", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         certification_authority = d.pop("CertificationAuthority", None)
-
         certification_standard = d.pop("CertificationStandard", None)
-
         qualer_api_models_report_datasets_to_company_certification_response = cls(
             logo=logo,
             initial_date=initial_date,
@@ -122,7 +105,6 @@ class ReportDatasetsToCompanyCertificationResponse:
             certification_authority=certification_authority,
             certification_standard=certification_standard,
         )
-
         qualer_api_models_report_datasets_to_company_certification_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_external_data_report_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_external_data_report_response.py
@@ -82,28 +82,23 @@ class ReportDatasetsToExternalDataReportResponse:
             field_dict["ServiceOrderItemId"] = self.service_order_item_id
         if self.row is not None:
             field_dict["Row"] = self.row
-
         # Map single-letter fields dynamically to avoid E741 on variable names
         for letter in "abcdefghijklmnopqrstuvwxyz":
             value = getattr(self, letter)
             if value is not None:
                 field_dict[letter.upper()] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         data = dict(src_dict)
-
         kwargs: Dict[str, Any] = {}
         kwargs["measurement_set_id"] = data.pop("MeasurementSetId", None)
         kwargs["service_order_item_id"] = data.pop("ServiceOrderItemId", None)
         kwargs["row"] = data.pop("Row", None)
-
         # Extract A..Z into a..z
         for letter in "abcdefghijklmnopqrstuvwxyz":
             kwargs[letter] = data.pop(letter.upper(), None)
-
         obj = cls(**kwargs)
         obj.additional_properties = data
         return obj

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_all_response.py
@@ -1087,11 +1087,7 @@ class ReportDatasetsToMeasurementAllResponse:
         as_found_range = self.as_found_range
         as_found_cv = self.as_found_cv
         as_found_cv_raw = self.as_found_cv_raw
-        as_found_result: Optional[str]
-        if not self.as_found_result:
-            as_found_result = None
-        else:
-            as_found_result = self.as_found_result
+        as_found_result = self.as_found_result
         as_found_range_result = self.as_found_range_result
         as_found_delta_result = self.as_found_delta_result
         as_found_min_result = self.as_found_min_result
@@ -2730,7 +2726,6 @@ class ReportDatasetsToMeasurementAllResponse:
         asset_tag_change = d.pop("AssetTagChange", None)
         asset_user_change = d.pop("AssetUserChange", None)
         serial_number_change = d.pop("SerialNumberChange", None)
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if data is None:
                 return data
@@ -2742,9 +2737,7 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2758,12 +2751,10 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
         service_order_item_id = d.pop("ServiceOrderItemId", None)
         site_name = d.pop("SiteName", None)
         po_number = d.pop("PoNumber", None)
-
         def _parse_shipped_date(data: object) -> Optional[datetime.datetime]:
             if data is None:
                 return data
@@ -2775,7 +2766,6 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         shipped_date = _parse_shipped_date(d.pop("ShippedDate", None))
         tracking_number = d.pop("TrackingNumber", None)
         payment_terms = d.pop("PaymentTerms", None)
@@ -2801,7 +2791,6 @@ class ReportDatasetsToMeasurementAllResponse:
         as_left_min_max_value_extended = d.pop("AsLeftMinMaxValueExtended", None)
         as_left_tool_range_name = d.pop("AsLeftToolRangeName", None)
         as_left_tool_range_uncertainty = d.pop("AsLeftToolRangeUncertainty", None)
-
         def _parse_as_left_primary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2815,11 +2804,9 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_left_primary_tool_last_service_date = _parse_as_left_primary_tool_last_service_date(
             d.pop("AsLeftPrimaryToolLastServiceDate", None)
         )
-
         def _parse_as_left_primary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2833,7 +2820,6 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_left_primary_tool_next_service_date = _parse_as_left_primary_tool_next_service_date(
             d.pop("AsLeftPrimaryToolNextServiceDate", None)
         )
@@ -2865,7 +2851,6 @@ class ReportDatasetsToMeasurementAllResponse:
         as_found_min_max_value_extended = d.pop("AsFoundMinMaxValueExtended", None)
         as_found_tool_range_name = d.pop("AsFoundToolRangeName", None)
         as_found_tool_range_uncertainty = d.pop("AsFoundToolRangeUncertainty", None)
-
         def _parse_as_found_primary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2879,11 +2864,9 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_found_primary_tool_last_service_date = _parse_as_found_primary_tool_last_service_date(
             d.pop("AsFoundPrimaryToolLastServiceDate", None)
         )
-
         def _parse_as_found_primary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2897,7 +2880,6 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_found_primary_tool_next_service_date = _parse_as_found_primary_tool_next_service_date(
             d.pop("AsFoundPrimaryToolNextServiceDate", None)
         )
@@ -2910,7 +2892,6 @@ class ReportDatasetsToMeasurementAllResponse:
             "AsFoundPrimaryToolManufacturerPartNumber", None
         )
         as_found_primary_tool_serial_number = d.pop("AsFoundPrimaryToolSerialNumber", None)
-
         def _parse_as_left_secondary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2924,11 +2905,9 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_left_secondary_tool_last_service_date = _parse_as_left_secondary_tool_last_service_date(
             d.pop("AsLeftSecondaryToolLastServiceDate", None)
         )
-
         def _parse_as_left_secondary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2942,7 +2921,6 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_left_secondary_tool_next_service_date = _parse_as_left_secondary_tool_next_service_date(
             d.pop("AsLeftSecondaryToolNextServiceDate", None)
         )
@@ -2955,7 +2933,6 @@ class ReportDatasetsToMeasurementAllResponse:
             "AsLeftSecondaryToolManufacturerPartNumber", None
         )
         as_left_secondary_tool_serial_number = d.pop("AsLeftSecondaryToolSerialNumber", None)
-
         def _parse_as_found_secondary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2969,13 +2946,11 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_found_secondary_tool_last_service_date = (
             _parse_as_found_secondary_tool_last_service_date(
                 d.pop("AsFoundSecondaryToolLastServiceDate", None)
             )
         )
-
         def _parse_as_found_secondary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2989,7 +2964,6 @@ class ReportDatasetsToMeasurementAllResponse:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         as_found_secondary_tool_next_service_date = (
             _parse_as_found_secondary_tool_next_service_date(
                 d.pop("AsFoundSecondaryToolNextServiceDate", None)
@@ -3069,7 +3043,6 @@ class ReportDatasetsToMeasurementAllResponse:
             as_left_guard_band_logic = ReportDatasetsToMeasurementAllResponseAsLeftGuardBandLogic(
                 _as_left_guard_band_logic
             )
-
         as_found_error = d.pop("AsFoundError", None)
         as_found_error_extended = d.pop("AsFoundErrorExtended", None)
         as_left_error = d.pop("AsLeftError", None)
@@ -3586,12 +3559,10 @@ class ReportDatasetsToMeasurementAllResponse:
         as_left_cv_raw = d.pop("AsLeftCvRaw", None)
         as_left_delta = d.pop("AsLeftDelta", None)
         as_left_range = d.pop("AsLeftRange", None)
-
         def _parse_as_left_result(data: object) -> Optional[int]:
             if data is None:
                 return data
             return cast(Optional[int], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
         as_left_range_result = d.pop("AsLeftRangeResult", None)
         as_left_delta_result = d.pop("AsLeftDeltaResult", None)

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_result_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_result_response.py
@@ -52,39 +52,20 @@ class ReportDatasetsToMeasurementChannelResultResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         measurement_point_id = self.measurement_point_id
-
         column_index = self.column_index
-
-        batch_type: Optional[int] = None
-        if self.batch_type:
-            batch_type = self.batch_type.value
-
-        result: Optional[int] = None
-        if self.result:
-            result = self.result.value
-
+        batch_type = self.batch_type.value if self.batch_type else None
+        result = self.result.value if self.result else None
         mean_result = self.mean_result
-
         range_result = self.range_result
-
         delta_result = self.delta_result
-
         min_result = self.min_result
-
         max_result = self.max_result
-
         tar_result = self.tar_result
-
         tur_result = self.tur_result
-
         error_result = self.error_result
-
         sd_result = self.sd_result
-
         cv_result = self.cv_result
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -118,25 +99,20 @@ class ReportDatasetsToMeasurementChannelResultResponse:
             field_dict["SdResult"] = sd_result
         if cv_result is not None:
             field_dict["CvResult"] = cv_result
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         column_index = d.pop("ColumnIndex", None)
-
         _batch_type = d.pop("BatchType", None)
         batch_type: Optional[ReportDatasetsToMeasurementChannelResultResponseBatchType]
         if not _batch_type:
             batch_type = None
         else:
             batch_type = ReportDatasetsToMeasurementChannelResultResponseBatchType(_batch_type)
-
         _result = d.pop("Result", None)
         result: Optional[ServiceResultStatus]
         if not _result:
@@ -145,27 +121,16 @@ class ReportDatasetsToMeasurementChannelResultResponse:
             result = None
         else:
             result = ServiceResultStatus(_result)
-
         mean_result = d.pop("MeanResult", None)
-
         range_result = d.pop("RangeResult", None)
-
         delta_result = d.pop("DeltaResult", None)
-
         min_result = d.pop("MinResult", None)
-
         max_result = d.pop("MaxResult", None)
-
         tar_result = d.pop("TarResult", None)
-
         tur_result = d.pop("TurResult", None)
-
         error_result = d.pop("ErrorResult", None)
-
         sd_result = d.pop("SdResult", None)
-
         cv_result = d.pop("CvResult", None)
-
         qualer_api_models_report_datasets_to_measurement_channel_result_response = cls(
             service_order_item_id=service_order_item_id,
             measurement_point_id=measurement_point_id,
@@ -183,7 +148,6 @@ class ReportDatasetsToMeasurementChannelResultResponse:
             sd_result=sd_result,
             cv_result=cv_result,
         )
-
         qualer_api_models_report_datasets_to_measurement_channel_result_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_uniformity_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_channel_uniformity_response.py
@@ -52,39 +52,20 @@ class ReportDatasetsToMeasurementChannelUniformityResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         measurement_point_id = self.measurement_point_id
-
-        batch_type: Optional[int] = None
-        if self.batch_type:
-            batch_type = self.batch_type.value
-
+        batch_type = self.batch_type.value if self.batch_type else None
         column_index = self.column_index
-
         mean = self.mean
-
         mean_result = self.mean_result
-
         sd = self.sd
-
         sd_result = self.sd_result
-
         cv = self.cv
-
         cv_result = self.cv_result
-
         range_ = self.range_
-
         range_result = self.range_result
-
         delta = self.delta
-
         delta_result = self.delta_result
-
-        result: Optional[int] = None
-        if self.result:
-            result = self.result.value
-
+        result = self.result.value if self.result else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -118,45 +99,30 @@ class ReportDatasetsToMeasurementChannelUniformityResponse:
             field_dict["DeltaResult"] = delta_result
         if result is not None:
             field_dict["Result"] = result
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         _batch_type = d.pop("BatchType", None)
         batch_type: Optional[ReportDatasetsToMeasurementChannelUniformityResponseBatchType]
         if not _batch_type:
             batch_type = None
         else:
             batch_type = ReportDatasetsToMeasurementChannelUniformityResponseBatchType(_batch_type)
-
         column_index = d.pop("ColumnIndex", None)
-
         mean = d.pop("Mean", None)
-
         mean_result = d.pop("MeanResult", None)
-
         sd = d.pop("SD", None)
-
         sd_result = d.pop("SDResult", None)
-
         cv = d.pop("CV", None)
-
         cv_result = d.pop("CVResult", None)
-
         range_ = d.pop("Range", None)
-
         range_result = d.pop("RangeResult", None)
-
         delta = d.pop("Delta", None)
-
         delta_result = d.pop("DeltaResult", None)
-
         _result = d.pop("Result", None)
         result: Optional[ServiceResultStatus]
         if not _result:
@@ -165,7 +131,6 @@ class ReportDatasetsToMeasurementChannelUniformityResponse:
             result = None
         else:
             result = ServiceResultStatus(_result)
-
         qualer_api_models_report_datasets_to_measurement_channel_uniformity_response = cls(
             service_order_item_id=service_order_item_id,
             measurement_point_id=measurement_point_id,
@@ -183,7 +148,6 @@ class ReportDatasetsToMeasurementChannelUniformityResponse:
             delta_result=delta_result,
             result=result,
         )
-
         qualer_api_models_report_datasets_to_measurement_channel_uniformity_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_chart_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_chart_response.py
@@ -33,21 +33,13 @@ class ReportDatasetsToMeasurementChartResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         measurement_set_id = self.measurement_set_id
-
         chart_type = self.chart_type
-
         chart_image = self.chart_image
-
         nominal = self.nominal
-
         title = self.title
-
         unit_of_measure = self.unit_of_measure
-
         abbreviated_uom = self.abbreviated_uom
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class ReportDatasetsToMeasurementChartResponse:
             field_dict["UnitOfMeasure"] = unit_of_measure
         if abbreviated_uom is not None:
             field_dict["AbbreviatedUOM"] = abbreviated_uom
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         measurement_set_id = d.pop("MeasurementSetId", None)
-
         chart_type = d.pop("ChartType", None)
-
         chart_image = d.pop("ChartImage", None)
-
         nominal = d.pop("Nominal", None)
-
         title = d.pop("Title", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         abbreviated_uom = d.pop("AbbreviatedUOM", None)
-
         qualer_api_models_report_datasets_to_measurement_chart_response = cls(
             service_order_item_id=service_order_item_id,
             measurement_set_id=measurement_set_id,
@@ -99,7 +82,6 @@ class ReportDatasetsToMeasurementChartResponse:
             unit_of_measure=unit_of_measure,
             abbreviated_uom=abbreviated_uom,
         )
-
         qualer_api_models_report_datasets_to_measurement_chart_response.additional_properties = d
         return qualer_api_models_report_datasets_to_measurement_chart_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_field_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_field_response.py
@@ -45,31 +45,17 @@ class ReportDatasetsToMeasurementFieldResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         field_id = self.field_id
-
         name = self.name
-
         value = self.value
-
         measurement_name = self.measurement_name
-
         measurement_set_id = self.measurement_set_id
-
         specification_name = self.specification_name
-
         measurement_point_id = self.measurement_point_id
-
-        batch_type: Optional[int] = None
-        if self.batch_type:
-            batch_type = self.batch_type.value
-
+        batch_type = self.batch_type.value if self.batch_type else None
         service_order_item_id = self.service_order_item_id
-
         service_order_id = self.service_order_id
-
         batch_field_id = self.batch_field_id
-
         point_field_id = self.point_field_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -97,41 +83,28 @@ class ReportDatasetsToMeasurementFieldResponse:
             field_dict["BatchFieldId"] = batch_field_id
         if point_field_id is not None:
             field_dict["PointFieldId"] = point_field_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         field_id = d.pop("FieldId", None)
-
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         measurement_name = d.pop("MeasurementName", None)
-
         measurement_set_id = d.pop("MeasurementSetId", None)
-
         specification_name = d.pop("SpecificationName", None)
-
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         _batch_type = d.pop("BatchType", None)
         batch_type: Optional[ReportDatasetsToMeasurementFieldResponseBatchType]
         if not _batch_type:
             batch_type = None
         else:
             batch_type = ReportDatasetsToMeasurementFieldResponseBatchType(_batch_type)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         batch_field_id = d.pop("BatchFieldId", None)
-
         point_field_id = d.pop("PointFieldId", None)
-
         qualer_api_models_report_datasets_to_measurement_field_response = cls(
             field_id=field_id,
             name=name,
@@ -146,7 +119,6 @@ class ReportDatasetsToMeasurementFieldResponse:
             batch_field_id=batch_field_id,
             point_field_id=point_field_id,
         )
-
         qualer_api_models_report_datasets_to_measurement_field_response.additional_properties = d
         return qualer_api_models_report_datasets_to_measurement_field_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_measurement_response.py
@@ -833,855 +833,399 @@ class ReportDatasetsToMeasurementResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         is_accredited = self.is_accredited
-
         service_total = self.service_total
-
         repairs_total = self.repairs_total
-
         parts_total = self.parts_total
-
         parameter_id = self.parameter_id
-
         tool_range_name = self.tool_range_name
-
         tool_range_uncertainty = self.tool_range_uncertainty
-
-        primary_tool_last_service_date: Optional[str]
-        if not self.primary_tool_last_service_date:
-            primary_tool_last_service_date = None
-        elif isinstance(self.primary_tool_last_service_date, datetime.datetime):
-            primary_tool_last_service_date = self.primary_tool_last_service_date.isoformat()
-        else:
-            primary_tool_last_service_date = self.primary_tool_last_service_date
-
-        primary_tool_next_service_date: Optional[str]
-        if not self.primary_tool_next_service_date:
-            primary_tool_next_service_date = None
-        elif isinstance(self.primary_tool_next_service_date, datetime.datetime):
-            primary_tool_next_service_date = self.primary_tool_next_service_date.isoformat()
-        else:
-            primary_tool_next_service_date = self.primary_tool_next_service_date
-
+        primary_tool_last_service_date = self.primary_tool_last_service_date.isoformat() if self.primary_tool_last_service_date else None
+        primary_tool_next_service_date = self.primary_tool_next_service_date.isoformat() if self.primary_tool_next_service_date else None
         primary_tool_calibrated_by = self.primary_tool_calibrated_by
-
         primary_tool_tool_name = self.primary_tool_tool_name
-
         primary_tool_tool_description = self.primary_tool_tool_description
-
         primary_tool_tool_type_name = self.primary_tool_tool_type_name
-
         primary_tool_manufacturer = self.primary_tool_manufacturer
-
         primary_tool_manufacturer_part_number = self.primary_tool_manufacturer_part_number
-
         primary_tool_serial_number = self.primary_tool_serial_number
-
-        secondary_tool_last_service_date: Optional[str]
-        if not self.secondary_tool_last_service_date:
-            secondary_tool_last_service_date = None
-        elif isinstance(self.secondary_tool_last_service_date, datetime.datetime):
-            secondary_tool_last_service_date = self.secondary_tool_last_service_date.isoformat()
-        else:
-            secondary_tool_last_service_date = self.secondary_tool_last_service_date
-
-        secondary_tool_next_service_date: Optional[str]
-        if not self.secondary_tool_next_service_date:
-            secondary_tool_next_service_date = None
-        elif isinstance(self.secondary_tool_next_service_date, datetime.datetime):
-            secondary_tool_next_service_date = self.secondary_tool_next_service_date.isoformat()
-        else:
-            secondary_tool_next_service_date = self.secondary_tool_next_service_date
-
+        secondary_tool_last_service_date = self.secondary_tool_last_service_date.isoformat() if self.secondary_tool_last_service_date else None
+        secondary_tool_next_service_date = self.secondary_tool_next_service_date.isoformat() if self.secondary_tool_next_service_date else None
         secondary_tool_calibrated_by = self.secondary_tool_calibrated_by
-
         secondary_tool_tool_name = self.secondary_tool_tool_name
-
         secondary_tool_tool_description = self.secondary_tool_tool_description
-
         secondary_tool_tool_type_name = self.secondary_tool_tool_type_name
-
         secondary_tool_manufacturer = self.secondary_tool_manufacturer
-
         secondary_tool_manufacturer_part_number = self.secondary_tool_manufacturer_part_number
-
         secondary_tool_serial_number = self.secondary_tool_serial_number
-
         measurement_set_name = self.measurement_set_name
-
         decimal_places = self.decimal_places
-
         significant_figures = self.significant_figures
-
         sd_header = self.sd_header
-
         cv_header = self.cv_header
-
         measurement_local_time: Optional[str] = None
         if self.measurement_local_time:
             measurement_local_time = self.measurement_local_time.isoformat()
-
         mean = self.mean
-
         mean_raw = self.mean_raw
-
         mean_decimal_places = self.mean_decimal_places
-
         mean_extended = self.mean_extended
-
         sd = self.sd
-
         sd_raw = self.sd_raw
-
         sd_decimal_places = self.sd_decimal_places
-
         delta = self.delta
-
         range_ = self.range_
-
         sd_extended = self.sd_extended
-
         range_extended = self.range_extended
-
         delta_extended = self.delta_extended
-
         minimum_measured_value = self.minimum_measured_value
-
         maximum_measured_value = self.maximum_measured_value
-
         min_max_value_extended = self.min_max_value_extended
-
         cv = self.cv
-
         cv_raw = self.cv_raw
-
         cv_decimal_places = self.cv_decimal_places
-
         cv_extended = self.cv_extended
-
-        result: Optional[int] = None
-        if self.result:
-            result = self.result.value
-
+        result = self.result.value if self.result else None
         range_result = self.range_result
-
         delta_result = self.delta_result
-
         min_result = self.min_result
-
         max_result = self.max_result
-
         tar_result = self.tar_result
-
         tur_result = self.tur_result
-
         error_result = self.error_result
-
         sd_result = self.sd_result
-
         cv_result = self.cv_result
-
         custom_field_result = self.custom_field_result
-
         mu = self.mu
-
         mu_raw = self.mu_raw
-
         mu_effective_dof = self.mu_effective_dof
-
         mu_coverage_factor = self.mu_coverage_factor
-
         mu_extended = self.mu_extended
-
         cmc = self.cmc
-
         cmc_comments = self.cmc_comments
-
         tur = self.tur
-
         tur_raw = self.tur_raw
-
         tur_decimal_places = self.tur_decimal_places
-
         tar = self.tar
-
         tar_raw = self.tar_raw
-
         tar_decimal_places = self.tar_decimal_places
-
         guard_band = self.guard_band
-
-        guard_band_logic: Optional[str] = None
-        if self.guard_band_logic:
-            guard_band_logic = self.guard_band_logic.value
-
+        guard_band_logic = self.guard_band_logic.value if self.guard_band_logic else None
         uncertainty_budget = self.uncertainty_budget
-
         calculated_uncertainty = self.calculated_uncertainty
-
         lock_uncertainty_budget = self.lock_uncertainty_budget
-
         lab_mu = self.lab_mu
-
         channel = self.channel
-
-        measurement_type: Optional[str] = None
-        if self.measurement_type:
-            measurement_type = self.measurement_type.value
-
+        measurement_type = self.measurement_type.value if self.measurement_type else None
         updated_by = self.updated_by
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
         error = self.error
-
         error_extended = self.error_extended
-
         require_adjustment = self.require_adjustment
-
         adjustment_threshold = self.adjustment_threshold
-
         percent_of_tolerance = self.percent_of_tolerance
-
         percent_of_tolerance_extended = self.percent_of_tolerance_extended
-
         tol_decimal_places = self.tol_decimal_places
-
         specification_title = self.specification_title
-
         specification_subtitle = self.specification_subtitle
-
         specification_group = self.specification_group
-
         batch_type = self.batch_type
-
         batch_result = self.batch_result
-
         is_by_channel = self.is_by_channel
-
         channel_count = self.channel_count
-
         is_range_accredited = self.is_range_accredited
-
         commenced_on: Optional[str] = None
         if self.commenced_on:
             commenced_on = self.commenced_on.isoformat()
-
         commenced_by = self.commenced_by
-
         z_factor = self.z_factor
-
         air_buoyancy = self.air_buoyancy
-
         evaporation_rate = self.evaporation_rate
-
         air_humidity = self.air_humidity
-
         altitude = self.altitude
-
         ambient_temperature = self.ambient_temperature
-
         barometric_pressure = self.barometric_pressure
-
         light_intensity = self.light_intensity
-
         noise_level = self.noise_level
-
         ph_level = self.ph_level
-
         water_conductivity = self.water_conductivity
-
         water_temperature = self.water_temperature
-
         solar_radiation = self.solar_radiation
-
         wind_speed = self.wind_speed
-
         z_factor_uom = self.z_factor_uom
-
         air_buoyancy_uom = self.air_buoyancy_uom
-
         evaporation_rate_uom = self.evaporation_rate_uom
-
         air_humidity_uom = self.air_humidity_uom
-
         altitude_uom = self.altitude_uom
-
         ambient_temperature_uom = self.ambient_temperature_uom
-
         barometric_pressure_uom = self.barometric_pressure_uom
-
         light_intensity_uom = self.light_intensity_uom
-
         noise_level_uom = self.noise_level_uom
-
         ph_level_uom = self.ph_level_uom
-
         water_conductivity_uom = self.water_conductivity_uom
-
         water_temperature_uom = self.water_temperature_uom
-
         solar_radiation_uom = self.solar_radiation_uom
-
         wind_speed_uom = self.wind_speed_uom
-
         specification_name = self.specification_name
-
         parameter_name = self.parameter_name
-
         measurement_set_display_order = self.measurement_set_display_order
-
         display_order = self.display_order
-
         unit_of_measure = self.unit_of_measure
-
         display_format = self.display_format
-
         precision = self.precision
-
         minimum = self.minimum
-
         nominal = self.nominal
-
         expected_value = self.expected_value
-
         expected_value_raw = self.expected_value_raw
-
         test_value = self.test_value
-
         base_value = self.base_value
-
         use_expected_value = self.use_expected_value
-
-        reading_entry_logic: Optional[str] = None
-        if self.reading_entry_logic:
-            reading_entry_logic = self.reading_entry_logic.value
-
-        reading_entry_math: Optional[str] = None
-        if self.reading_entry_math:
-            reading_entry_math = self.reading_entry_math.value
-
-        double_substitution_sequence: Optional[str] = None
-        if self.double_substitution_sequence:
-            double_substitution_sequence = self.double_substitution_sequence.value
-
+        reading_entry_logic = self.reading_entry_logic.value if self.reading_entry_logic else None
+        reading_entry_math = self.reading_entry_math.value if self.reading_entry_math else None
+        double_substitution_sequence = self.double_substitution_sequence.value if self.double_substitution_sequence else None
         reading_entry_math_string = self.reading_entry_math_string
-
         nominal_extended = self.nominal_extended
-
         expected_value_extended = self.expected_value_extended
-
         maximum = self.maximum
-
         tolerance_min = self.tolerance_min
-
         tolerance_max = self.tolerance_max
-
         resolution = self.resolution
-
         resolution_count = self.resolution_count
-
         min_max_header = self.min_max_header
-
         accuracy_class = self.accuracy_class
-
         accuracy_class_min = self.accuracy_class_min
-
         accuracy_class_max = self.accuracy_class_max
-
-        environment_mask: Optional[str] = None
-        if self.environment_mask:
-            environment_mask = self.environment_mask.value
-
+        environment_mask = self.environment_mask.value if self.environment_mask else None
         display_name = self.display_name
-
         display_part_number = self.display_part_number
-
         part_number = self.part_number
-
         vendor_company_id = self.vendor_company_id
-
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
         completed_by_name = self.completed_by_name
-
         completed_on: Optional[str] = None
         if self.completed_on:
             completed_on = self.completed_on.isoformat()
-
         is_limited = self.is_limited
-
         vendor_tag = self.vendor_tag
-
         vendor_service_notes = self.vendor_service_notes
-
         room = self.room
-
         segment_name = self.segment_name
-
         schedule_name = self.schedule_name
-
         next_segment_name = self.next_segment_name
-
         certificate_number = self.certificate_number
-
-        work_status: Optional[int] = None
-        if self.work_status:
-            work_status = self.work_status.value
-
+        work_status = self.work_status.value if self.work_status else None
         service_type = self.service_type
-
         service_level = self.service_level
-
         barcode = self.barcode
-
         service_comments = self.service_comments
-
         order_item_number = self.order_item_number
-
         asset_tag = self.asset_tag
-
         asset_user = self.asset_user
-
         serial_number = self.serial_number
-
         equipment_id = self.equipment_id
-
         legacy_identifier = self.legacy_identifier
-
         site_name = self.site_name
-
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         product_name = self.product_name
-
         product_description = self.product_description
-
         asset_maker = self.asset_maker
-
         station = self.station
-
         asset_tag_change = self.asset_tag_change
-
         asset_user_change = self.asset_user_change
-
         serial_number_change = self.serial_number_change
-
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        service_date = self.service_date.isoformat() if self.service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         service_order_item_id = self.service_order_item_id
-
         service_order_id = self.service_order_id
-
         measurement_batch_id = self.measurement_batch_id
-
         measurement_id = self.measurement_id
-
         standard_id = self.standard_id
-
         tool_id = self.tool_id
-
         measurement_tool_id = self.measurement_tool_id
-
         measurement_condition_id = self.measurement_condition_id
-
         measurement_point_id = self.measurement_point_id
-
         measurement_set_id = self.measurement_set_id
-
         is_hidden = self.is_hidden
-
         readings = self.readings
-
-        tolerance_type: Optional[str] = None
-        if self.tolerance_type:
-            tolerance_type = self.tolerance_type.value
-
+        tolerance_type = self.tolerance_type.value if self.tolerance_type else None
         tolerance_type_string = self.tolerance_type_string
-
-        precision_type: Optional[str] = None
-        if self.precision_type:
-            precision_type = self.precision_type.value
-
-        specification_mode: Optional[int] = None
-        if self.specification_mode:
-            specification_mode = self.specification_mode.value
-
-        tolerance_mode: Optional[int] = None
-        if self.tolerance_mode:
-            tolerance_mode = self.tolerance_mode.value
-
-        tolerance_unit: Optional[int] = None
-        if self.tolerance_unit:
-            tolerance_unit = self.tolerance_unit.value
-
+        precision_type = self.precision_type.value if self.precision_type else None
+        specification_mode = self.specification_mode.value if self.specification_mode else None
+        tolerance_mode = self.tolerance_mode.value if self.tolerance_mode else None
+        tolerance_unit = self.tolerance_unit.value if self.tolerance_unit else None
         tolerance_string = self.tolerance_string
-
         po_number = self.po_number
-
         secondary_po = self.secondary_po
-
-        shipped_date: Optional[str]
-        if not self.shipped_date:
-            shipped_date = None
-        elif isinstance(self.shipped_date, datetime.datetime):
-            shipped_date = self.shipped_date.isoformat()
-        else:
-            shipped_date = self.shipped_date
-
-        shipment_status: Optional[str] = None
-        if self.shipment_status:
-            shipment_status = self.shipment_status.value
-
+        shipped_date = self.shipped_date.isoformat() if self.shipped_date else None
+        shipment_status = self.shipment_status.value if self.shipment_status else None
         shipped_on: Optional[str] = None
         if self.shipped_on:
             shipped_on = self.shipped_on.isoformat()
-
         delivered_on: Optional[str] = None
         if self.delivered_on:
             delivered_on = self.delivered_on.isoformat()
-
         tracking_number = self.tracking_number
-
         payment_terms = self.payment_terms
-
         shipping_method = self.shipping_method
-
         location = self.location
-
         site_access_notes = self.site_access_notes
-
         abbreviated_uom = self.abbreviated_uom
-
         unit_scale_factor = self.unit_scale_factor
-
-        measurement_not_taken_result: Optional[str] = None
-        if self.measurement_not_taken_result:
-            measurement_not_taken_result = self.measurement_not_taken_result.value
-
+        measurement_not_taken_result = self.measurement_not_taken_result.value if self.measurement_not_taken_result else None
         hide_from_certificate = self.hide_from_certificate
-
         measurement_not_taken_reason = self.measurement_not_taken_reason
-
         environment_text_1 = self.environment_text_1
-
         environment_text_2 = self.environment_text_2
-
         environment_text_3 = self.environment_text_3
-
         environment_text_4 = self.environment_text_4
-
         environment_text_5 = self.environment_text_5
-
         environment_text_6 = self.environment_text_6
-
         values = self.values
-
         value_1 = self.value_1
-
         value_2 = self.value_2
-
         value_3 = self.value_3
-
         value_4 = self.value_4
-
         value_5 = self.value_5
-
         value_6 = self.value_6
-
         value_7 = self.value_7
-
         value_8 = self.value_8
-
         value_9 = self.value_9
-
         value_10 = self.value_10
-
         value_11 = self.value_11
-
         value_12 = self.value_12
-
         value_13 = self.value_13
-
         value_14 = self.value_14
-
         value_15 = self.value_15
-
         value_16 = self.value_16
-
         value_17 = self.value_17
-
         value_18 = self.value_18
-
         value_19 = self.value_19
-
         value_20 = self.value_20
-
         value_21 = self.value_21
-
         value_22 = self.value_22
-
         value_23 = self.value_23
-
         value_24 = self.value_24
-
         value_25 = self.value_25
-
         value_26 = self.value_26
-
         value_27 = self.value_27
-
         value_28 = self.value_28
-
         value_29 = self.value_29
-
         value_30 = self.value_30
-
         value_31 = self.value_31
-
         value_32 = self.value_32
-
         value_33 = self.value_33
-
         value_34 = self.value_34
-
         value_35 = self.value_35
-
         value_36 = self.value_36
-
         value_37 = self.value_37
-
         value_38 = self.value_38
-
         value_39 = self.value_39
-
         value_40 = self.value_40
-
         raw_value_1 = self.raw_value_1
-
         raw_value_2 = self.raw_value_2
-
         raw_value_3 = self.raw_value_3
-
         raw_value_4 = self.raw_value_4
-
         raw_value_5 = self.raw_value_5
-
         raw_value_6 = self.raw_value_6
-
         raw_value_7 = self.raw_value_7
-
         raw_value_8 = self.raw_value_8
-
         raw_value_9 = self.raw_value_9
-
         raw_value_10 = self.raw_value_10
-
         raw_value_11 = self.raw_value_11
-
         raw_value_12 = self.raw_value_12
-
         raw_value_13 = self.raw_value_13
-
         raw_value_14 = self.raw_value_14
-
         raw_value_15 = self.raw_value_15
-
         raw_value_16 = self.raw_value_16
-
         raw_value_17 = self.raw_value_17
-
         raw_value_18 = self.raw_value_18
-
         raw_value_19 = self.raw_value_19
-
         raw_value_20 = self.raw_value_20
-
         raw_value_21 = self.raw_value_21
-
         raw_value_22 = self.raw_value_22
-
         raw_value_23 = self.raw_value_23
-
         raw_value_24 = self.raw_value_24
-
         raw_value_25 = self.raw_value_25
-
         raw_value_26 = self.raw_value_26
-
         raw_value_27 = self.raw_value_27
-
         raw_value_28 = self.raw_value_28
-
         raw_value_29 = self.raw_value_29
-
         raw_value_30 = self.raw_value_30
-
         raw_value_31 = self.raw_value_31
-
         raw_value_32 = self.raw_value_32
-
         raw_value_33 = self.raw_value_33
-
         raw_value_34 = self.raw_value_34
-
         raw_value_35 = self.raw_value_35
-
         raw_value_36 = self.raw_value_36
-
         raw_value_37 = self.raw_value_37
-
         raw_value_38 = self.raw_value_38
-
         raw_value_39 = self.raw_value_39
-
         raw_value_40 = self.raw_value_40
-
         subtitles_to_readings = self.subtitles_to_readings
-
         value_subtitle_1 = self.value_subtitle_1
-
         value_subtitle_2 = self.value_subtitle_2
-
         value_subtitle_3 = self.value_subtitle_3
-
         value_subtitle_4 = self.value_subtitle_4
-
         value_subtitle_5 = self.value_subtitle_5
-
         value_subtitle_6 = self.value_subtitle_6
-
         value_subtitle_7 = self.value_subtitle_7
-
         value_subtitle_8 = self.value_subtitle_8
-
         value_subtitle_9 = self.value_subtitle_9
-
         value_subtitle_10 = self.value_subtitle_10
-
         value_subtitle_11 = self.value_subtitle_11
-
         value_subtitle_12 = self.value_subtitle_12
-
         value_subtitle_13 = self.value_subtitle_13
-
         value_subtitle_14 = self.value_subtitle_14
-
         value_subtitle_15 = self.value_subtitle_15
-
         value_subtitle_16 = self.value_subtitle_16
-
         value_subtitle_17 = self.value_subtitle_17
-
         value_subtitle_18 = self.value_subtitle_18
-
         value_subtitle_19 = self.value_subtitle_19
-
         value_subtitle_20 = self.value_subtitle_20
-
         value_subtitle_21 = self.value_subtitle_21
-
         value_subtitle_22 = self.value_subtitle_22
-
         value_subtitle_23 = self.value_subtitle_23
-
         value_subtitle_24 = self.value_subtitle_24
-
         value_subtitle_25 = self.value_subtitle_25
-
         value_subtitle_26 = self.value_subtitle_26
-
         value_subtitle_27 = self.value_subtitle_27
-
         value_subtitle_28 = self.value_subtitle_28
-
         value_subtitle_29 = self.value_subtitle_29
-
         value_subtitle_30 = self.value_subtitle_30
-
         value_subtitle_31 = self.value_subtitle_31
-
         value_subtitle_32 = self.value_subtitle_32
-
         value_subtitle_33 = self.value_subtitle_33
-
         value_subtitle_34 = self.value_subtitle_34
-
         value_subtitle_35 = self.value_subtitle_35
-
         value_subtitle_36 = self.value_subtitle_36
-
         value_subtitle_37 = self.value_subtitle_37
-
         value_subtitle_38 = self.value_subtitle_38
-
         value_subtitle_39 = self.value_subtitle_39
-
         value_subtitle_40 = self.value_subtitle_40
-
         values_decimal_places = self.values_decimal_places
-
         repeat_measurement_and_calculate_hysteresis = (
             self.repeat_measurement_and_calculate_hysteresis
         )
-
-        measurement_point_order: Optional[str] = None
-        if self.measurement_point_order:
-            measurement_point_order = self.measurement_point_order.value
-
-        hysteresis_point: Optional[str] = None
-        if self.hysteresis_point:
-            hysteresis_point = self.hysteresis_point.value
-
+        measurement_point_order = self.measurement_point_order.value if self.measurement_point_order else None
+        hysteresis_point = self.hysteresis_point.value if self.hysteresis_point else None
         max_hysteresis = self.max_hysteresis
-
         run = self.run
-
         direction = self.direction
-
         hysteresis = self.hysteresis
-
         column_mean = self.column_mean
-
         column_mean_result = self.column_mean_result
-
         column_sd = self.column_sd
-
         column_sd_result = self.column_sd_result
-
         column_cv = self.column_cv
-
         column_cv_result = self.column_cv_result
-
         column_range = self.column_range
-
         column_range_result = self.column_range_result
-
         column_delta = self.column_delta
-
         column_delta_result = self.column_delta_result
-
         column_result = self.column_result
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -2449,26 +1993,18 @@ class ReportDatasetsToMeasurementResponse:
             field_dict["ColumnDeltaResult"] = column_delta_result
         if column_result is not None:
             field_dict["ColumnResult"] = column_result
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         is_accredited = d.pop("IsAccredited", None)
-
         service_total = d.pop("ServiceTotal", None)
-
         repairs_total = d.pop("RepairsTotal", None)
-
         parts_total = d.pop("PartsTotal", None)
-
         parameter_id = d.pop("ParameterId", None)
-
         tool_range_name = d.pop("ToolRangeName", None)
-
         tool_range_uncertainty = d.pop("ToolRangeUncertainty", None)
-
         def _parse_primary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2478,16 +2014,13 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 primary_tool_last_service_date_type_0 = isoparse(data)
-
                 return primary_tool_last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         primary_tool_last_service_date = _parse_primary_tool_last_service_date(
             d.pop("PrimaryToolLastServiceDate", None)
         )
-
         def _parse_primary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2497,30 +2030,20 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 primary_tool_next_service_date_type_0 = isoparse(data)
-
                 return primary_tool_next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         primary_tool_next_service_date = _parse_primary_tool_next_service_date(
             d.pop("PrimaryToolNextServiceDate", None)
         )
-
         primary_tool_calibrated_by = d.pop("PrimaryToolCalibratedBy", None)
-
         primary_tool_tool_name = d.pop("PrimaryToolToolName", None)
-
         primary_tool_tool_description = d.pop("PrimaryToolToolDescription", None)
-
         primary_tool_tool_type_name = d.pop("PrimaryToolToolTypeName", None)
-
         primary_tool_manufacturer = d.pop("PrimaryToolManufacturer", None)
-
         primary_tool_manufacturer_part_number = d.pop("PrimaryToolManufacturerPartNumber", None)
-
         primary_tool_serial_number = d.pop("PrimaryToolSerialNumber", None)
-
         def _parse_secondary_tool_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2530,16 +2053,13 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 secondary_tool_last_service_date_type_0 = isoparse(data)
-
                 return secondary_tool_last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         secondary_tool_last_service_date = _parse_secondary_tool_last_service_date(
             d.pop("SecondaryToolLastServiceDate", None)
         )
-
         def _parse_secondary_tool_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -2549,140 +2069,80 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 secondary_tool_next_service_date_type_0 = isoparse(data)
-
                 return secondary_tool_next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         secondary_tool_next_service_date = _parse_secondary_tool_next_service_date(
             d.pop("SecondaryToolNextServiceDate", None)
         )
-
         secondary_tool_calibrated_by = d.pop("SecondaryToolCalibratedBy", None)
-
         secondary_tool_tool_name = d.pop("SecondaryToolToolName", None)
-
         secondary_tool_tool_description = d.pop("SecondaryToolToolDescription", None)
-
         secondary_tool_tool_type_name = d.pop("SecondaryToolToolTypeName", None)
-
         secondary_tool_manufacturer = d.pop("SecondaryToolManufacturer", None)
-
         secondary_tool_manufacturer_part_number = d.pop("SecondaryToolManufacturerPartNumber", None)
-
         secondary_tool_serial_number = d.pop("SecondaryToolSerialNumber", None)
-
         measurement_set_name = d.pop("MeasurementSetName", None)
-
         decimal_places = d.pop("DecimalPlaces", None)
-
         significant_figures = d.pop("SignificantFigures", None)
-
         sd_header = d.pop("SdHeader", None)
-
         cv_header = d.pop("CvHeader", None)
-
         _measurement_local_time = d.pop("MeasurementLocalTime", None)
         measurement_local_time: Optional[datetime.datetime]
         if not _measurement_local_time:
             measurement_local_time = None
         else:
             measurement_local_time = isoparse(_measurement_local_time)
-
         mean = d.pop("Mean", None)
-
         mean_raw = d.pop("MeanRaw", None)
-
         mean_decimal_places = d.pop("MeanDecimalPlaces", None)
-
         mean_extended = d.pop("MeanExtended", None)
-
         sd = d.pop("Sd", None)
-
         sd_raw = d.pop("SdRaw", None)
-
         sd_decimal_places = d.pop("SDDecimalPlaces", None)
-
         delta = d.pop("Delta", None)
-
         range_ = d.pop("Range", None)
-
         sd_extended = d.pop("SdExtended", None)
-
         range_extended = d.pop("RangeExtended", None)
-
         delta_extended = d.pop("DeltaExtended", None)
-
         minimum_measured_value = d.pop("MinimumMeasuredValue", None)
-
         maximum_measured_value = d.pop("MaximumMeasuredValue", None)
-
         min_max_value_extended = d.pop("MinMaxValueExtended", None)
-
         cv = d.pop("Cv", None)
-
         cv_raw = d.pop("CvRaw", None)
-
         cv_decimal_places = d.pop("CVDecimalPlaces", None)
-
         cv_extended = d.pop("CvExtended", None)
-
         _result = d.pop("Result", None)
         result: Optional[ServiceResultStatus]
         if not _result:
             result = None
         else:
             result = ServiceResultStatus(_result)
-
         range_result = d.pop("RangeResult", None)
-
         delta_result = d.pop("DeltaResult", None)
-
         min_result = d.pop("MinResult", None)
-
         max_result = d.pop("MaxResult", None)
-
         tar_result = d.pop("TarResult", None)
-
         tur_result = d.pop("TurResult", None)
-
         error_result = d.pop("ErrorResult", None)
-
         sd_result = d.pop("SdResult", None)
-
         cv_result = d.pop("CvResult", None)
-
         custom_field_result = d.pop("CustomFieldResult", None)
-
         mu = d.pop("Mu", None)
-
         mu_raw = d.pop("MuRaw", None)
-
         mu_effective_dof = d.pop("MUEffectiveDOF", None)
-
         mu_coverage_factor = d.pop("MUCoverageFactor", None)
-
         mu_extended = d.pop("MuExtended", None)
-
         cmc = d.pop("Cmc", None)
-
         cmc_comments = d.pop("CmcComments", None)
-
         tur = d.pop("Tur", None)
-
         tur_raw = d.pop("TurRaw", None)
-
         tur_decimal_places = d.pop("TURDecimalPlaces", None)
-
         tar = d.pop("Tar", None)
-
         tar_raw = d.pop("TarRaw", None)
-
         tar_decimal_places = d.pop("TARDecimalPlaces", None)
-
         guard_band = d.pop("GuardBand", None)
-
         _guard_band_logic = d.pop("GuardBandLogic", None)
         guard_band_logic: Optional[ReportDatasetsToMeasurementResponseGuardBandLogic]
         if not _guard_band_logic:
@@ -2691,17 +2151,11 @@ class ReportDatasetsToMeasurementResponse:
             guard_band_logic = None
         else:
             guard_band_logic = ReportDatasetsToMeasurementResponseGuardBandLogic(_guard_band_logic)
-
         uncertainty_budget = d.pop("UncertaintyBudget", None)
-
         calculated_uncertainty = d.pop("CalculatedUncertainty", None)
-
         lock_uncertainty_budget = d.pop("LockUncertaintyBudget", None)
-
         lab_mu = d.pop("LabMu", None)
-
         channel = d.pop("Channel", None)
-
         _measurement_type = d.pop("MeasurementType", None)
         measurement_type: Optional[ReportDatasetsToMeasurementResponseMeasurementType]
         if not _measurement_type:
@@ -2729,46 +2183,28 @@ class ReportDatasetsToMeasurementResponse:
                 measurement_type = ReportDatasetsToMeasurementResponseMeasurementType(
                     _measurement_type
                 )
-
         updated_by = d.pop("UpdatedBy", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         error = d.pop("Error", None)
-
         error_extended = d.pop("ErrorExtended", None)
-
         require_adjustment = d.pop("RequireAdjustment", None)
-
         adjustment_threshold = d.pop("AdjustmentThreshold", None)
-
         percent_of_tolerance = d.pop("PercentOfTolerance", None)
-
         percent_of_tolerance_extended = d.pop("PercentOfToleranceExtended", None)
-
         tol_decimal_places = d.pop("TOLDecimalPlaces", None)
-
         specification_title = d.pop("SpecificationTitle", None)
-
         specification_subtitle = d.pop("SpecificationSubtitle", None)
-
         specification_group = d.pop("SpecificationGroup", None)
-
         batch_type = d.pop("BatchType", None)
-
         batch_result = d.pop("BatchResult", None)
-
         is_by_channel = d.pop("IsByChannel", None)
-
         channel_count = d.pop("ChannelCount", None)
-
         is_range_accredited = d.pop("IsRangeAccredited", None)
-
         _commenced_on = d.pop("CommencedOn", None)
         commenced_on: Optional[datetime.datetime]
         if not _commenced_on:
@@ -2777,93 +2213,49 @@ class ReportDatasetsToMeasurementResponse:
             commenced_on = None
         else:
             commenced_on = isoparse(_commenced_on)
-
         commenced_by = d.pop("CommencedBy", None)
-
         z_factor = d.pop("ZFactor", None)
-
         air_buoyancy = d.pop("AirBuoyancy", None)
-
         evaporation_rate = d.pop("EvaporationRate", None)
-
         air_humidity = d.pop("AirHumidity", None)
-
         altitude = d.pop("Altitude", None)
-
         ambient_temperature = d.pop("AmbientTemperature", None)
-
         barometric_pressure = d.pop("BarometricPressure", None)
-
         light_intensity = d.pop("LightIntensity", None)
-
         noise_level = d.pop("NoiseLevel", None)
-
         ph_level = d.pop("PhLevel", None)
-
         water_conductivity = d.pop("WaterConductivity", None)
-
         water_temperature = d.pop("WaterTemperature", None)
-
         solar_radiation = d.pop("SolarRadiation", None)
-
         wind_speed = d.pop("WindSpeed", None)
-
         z_factor_uom = d.pop("ZFactorUom", None)
-
         air_buoyancy_uom = d.pop("AirBuoyancyUom", None)
-
         evaporation_rate_uom = d.pop("EvaporationRateUom", None)
-
         air_humidity_uom = d.pop("AirHumidityUom", None)
-
         altitude_uom = d.pop("AltitudeUom", None)
-
         ambient_temperature_uom = d.pop("AmbientTemperatureUom", None)
-
         barometric_pressure_uom = d.pop("BarometricPressureUom", None)
-
         light_intensity_uom = d.pop("LightIntensityUom", None)
-
         noise_level_uom = d.pop("NoiseLevelUom", None)
-
         ph_level_uom = d.pop("PhLevelUom", None)
-
         water_conductivity_uom = d.pop("WaterConductivityUom", None)
-
         water_temperature_uom = d.pop("WaterTemperatureUom", None)
-
         solar_radiation_uom = d.pop("SolarRadiationUom", None)
-
         wind_speed_uom = d.pop("WindSpeedUom", None)
-
         specification_name = d.pop("SpecificationName", None)
-
         parameter_name = d.pop("ParameterName", None)
-
         measurement_set_display_order = d.pop("MeasurementSetDisplayOrder", None)
-
         display_order = d.pop("DisplayOrder", None)
-
         unit_of_measure = d.pop("UnitOfMeasure", None)
-
         display_format = d.pop("DisplayFormat", None)
-
         precision = d.pop("Precision", None)
-
         minimum = d.pop("Minimum", None)
-
         nominal = d.pop("Nominal", None)
-
         expected_value = d.pop("ExpectedValue", None)
-
         expected_value_raw = d.pop("ExpectedValueRaw", None)
-
         test_value = d.pop("TestValue", None)
-
         base_value = d.pop("BaseValue", None)
-
         use_expected_value = d.pop("UseExpectedValue", None)
-
         _reading_entry_logic = d.pop("ReadingEntryLogic", None)
         reading_entry_logic: Optional[ReportDatasetsToMeasurementResponseReadingEntryLogic]
         if not _reading_entry_logic:
@@ -2895,7 +2287,6 @@ class ReportDatasetsToMeasurementResponse:
                 reading_entry_logic = ReportDatasetsToMeasurementResponseReadingEntryLogic(
                     _reading_entry_logic
                 )
-
         _reading_entry_math = d.pop("ReadingEntryMath", None)
         reading_entry_math: Optional[ReportDatasetsToMeasurementResponseReadingEntryMath]
         if not _reading_entry_math:
@@ -2930,7 +2321,6 @@ class ReportDatasetsToMeasurementResponse:
                 reading_entry_math = ReportDatasetsToMeasurementResponseReadingEntryMath(
                     _reading_entry_math
                 )
-
         _double_substitution_sequence = d.pop("DoubleSubstitutionSequence", None)
         double_substitution_sequence: Optional[
             ReportDatasetsToMeasurementResponseDoubleSubstitutionSequence
@@ -2965,31 +2355,18 @@ class ReportDatasetsToMeasurementResponse:
                         _double_substitution_sequence
                     )
                 )
-
         reading_entry_math_string = d.pop("ReadingEntryMathString", None)
-
         nominal_extended = d.pop("NominalExtended", None)
-
         expected_value_extended = d.pop("ExpectedValueExtended", None)
-
         maximum = d.pop("Maximum", None)
-
         tolerance_min = d.pop("ToleranceMin", None)
-
         tolerance_max = d.pop("ToleranceMax", None)
-
         resolution = d.pop("Resolution", None)
-
         resolution_count = d.pop("ResolutionCount", None)
-
         min_max_header = d.pop("MinMaxHeader", None)
-
         accuracy_class = d.pop("AccuracyClass", None)
-
         accuracy_class_min = d.pop("AccuracyClassMin", None)
-
         accuracy_class_max = d.pop("AccuracyClassMax", None)
-
         _environment_mask = d.pop("EnvironmentMask", None)
         environment_mask: Optional[ReportDatasetsToMeasurementResponseEnvironmentMask]
         if not _environment_mask:
@@ -3029,21 +2406,13 @@ class ReportDatasetsToMeasurementResponse:
                 environment_mask = ReportDatasetsToMeasurementResponseEnvironmentMask(
                     _environment_mask
                 )
-
         display_name = d.pop("DisplayName", None)
-
         display_part_number = d.pop("DisplayPartNumber", None)
-
         part_number = d.pop("PartNumber", None)
-
         vendor_company_id = d.pop("VendorCompanyId", None)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         completed_by_name = d.pop("CompletedByName", None)
-
         _completed_on = d.pop("CompletedOn", None)
         completed_on: Optional[datetime.datetime]
         if not _completed_on:
@@ -3052,23 +2421,14 @@ class ReportDatasetsToMeasurementResponse:
             completed_on = None
         else:
             completed_on = isoparse(_completed_on)
-
         is_limited = d.pop("IsLimited", None)
-
         vendor_tag = d.pop("VendorTag", None)
-
         vendor_service_notes = d.pop("VendorServiceNotes", None)
-
         room = d.pop("Room", None)
-
         segment_name = d.pop("SegmentName", None)
-
         schedule_name = d.pop("ScheduleName", None)
-
         next_segment_name = d.pop("NextSegmentName", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         _work_status = d.pop("WorkStatus", None)
         work_status: Optional[WorkStatus]
         if not _work_status:
@@ -3077,47 +2437,26 @@ class ReportDatasetsToMeasurementResponse:
             work_status = None
         else:
             work_status = WorkStatus(_work_status)
-
         service_type = d.pop("ServiceType", None)
-
         service_level = d.pop("ServiceLevel", None)
-
         barcode = d.pop("Barcode", None)
-
         service_comments = d.pop("ServiceComments", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_user = d.pop("AssetUser", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         legacy_identifier = d.pop("LegacyIdentifier", None)
-
         site_name = d.pop("SiteName", None)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         product_name = d.pop("ProductName", None)
-
         product_description = d.pop("ProductDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         station = d.pop("Station", None)
-
         asset_tag_change = d.pop("AssetTagChange", None)
-
         asset_user_change = d.pop("AssetUserChange", None)
-
         serial_number_change = d.pop("SerialNumberChange", None)
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -3125,14 +2464,11 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -3142,38 +2478,23 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         measurement_batch_id = d.pop("MeasurementBatchId", None)
-
         measurement_id = d.pop("MeasurementId", None)
-
         standard_id = d.pop("StandardId", None)
-
         tool_id = d.pop("ToolId", None)
-
         measurement_tool_id = d.pop("MeasurementToolId", None)
-
         measurement_condition_id = d.pop("MeasurementConditionId", None)
-
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         measurement_set_id = d.pop("MeasurementSetId", None)
-
         is_hidden = d.pop("IsHidden", None)
-
         readings = d.pop("Readings", None)
-
         _tolerance_type = d.pop("ToleranceType", None)
         tolerance_type: Optional[ReportDatasetsToMeasurementResponseToleranceType]
         if not _tolerance_type:
@@ -3202,9 +2523,7 @@ class ReportDatasetsToMeasurementResponse:
             else:
                 # Handle string values normally
                 tolerance_type = ReportDatasetsToMeasurementResponseToleranceType(_tolerance_type)
-
         tolerance_type_string = d.pop("ToleranceTypeString", None)
-
         _precision_type = d.pop("PrecisionType", None)
         precision_type: Optional[ReportDatasetsToMeasurementResponsePrecisionType]
         if not _precision_type:
@@ -3229,7 +2548,6 @@ class ReportDatasetsToMeasurementResponse:
             else:
                 # Handle string values normally
                 precision_type = ReportDatasetsToMeasurementResponsePrecisionType(_precision_type)
-
         _specification_mode = d.pop("SpecificationMode", None)
         specification_mode: Optional[ReportDatasetsToMeasurementResponseSpecificationMode]
         if not _specification_mode:
@@ -3238,27 +2556,21 @@ class ReportDatasetsToMeasurementResponse:
             specification_mode = ReportDatasetsToMeasurementResponseSpecificationMode(
                 _specification_mode
             )
-
         _tolerance_mode = d.pop("ToleranceMode", None)
         tolerance_mode: Optional[ReportDatasetsToMeasurementResponseToleranceMode]
         if not _tolerance_mode:
             tolerance_mode = None
         else:
             tolerance_mode = ReportDatasetsToMeasurementResponseToleranceMode(_tolerance_mode)
-
         _tolerance_unit = d.pop("ToleranceUnit", None)
         tolerance_unit: Optional[ReportDatasetsToMeasurementResponseToleranceUnit]
         if not _tolerance_unit:
             tolerance_unit = None
         else:
             tolerance_unit = ReportDatasetsToMeasurementResponseToleranceUnit(_tolerance_unit)
-
         tolerance_string = d.pop("ToleranceString", None)
-
         po_number = d.pop("PoNumber", None)
-
         secondary_po = d.pop("SecondaryPo", None)
-
         def _parse_shipped_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -3266,14 +2578,11 @@ class ReportDatasetsToMeasurementResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 shipped_date_type_0 = isoparse(data)
-
                 return shipped_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         shipped_date = _parse_shipped_date(d.pop("ShippedDate", None))
-
         _shipment_status = d.pop("ShipmentStatus", None)
         shipment_status: Optional[ReportDatasetsToMeasurementResponseShipmentStatus]
         if not _shipment_status:
@@ -3294,7 +2603,6 @@ class ReportDatasetsToMeasurementResponse:
                 # This preserves the information while allowing the object to be created
                 shipment_status = None
                 # TODO: Consider logging this unknown value: _shipment_status
-
         _shipped_on = d.pop("ShippedOn", None)
         shipped_on: Optional[datetime.datetime]
         if not _shipped_on:
@@ -3303,7 +2611,6 @@ class ReportDatasetsToMeasurementResponse:
             shipped_on = None
         else:
             shipped_on = isoparse(_shipped_on)
-
         _delivered_on = d.pop("DeliveredOn", None)
         delivered_on: Optional[datetime.datetime]
         if not _delivered_on:
@@ -3312,21 +2619,13 @@ class ReportDatasetsToMeasurementResponse:
             delivered_on = None
         else:
             delivered_on = isoparse(_delivered_on)
-
         tracking_number = d.pop("TrackingNumber", None)
-
         payment_terms = d.pop("PaymentTerms", None)
-
         shipping_method = d.pop("ShippingMethod", None)
-
         location = d.pop("Location", None)
-
         site_access_notes = d.pop("SiteAccessNotes", None)
-
         abbreviated_uom = d.pop("AbbreviatedUOM", None)
-
         unit_scale_factor = d.pop("UnitScaleFactor", None)
-
         _measurement_not_taken_result = d.pop("MeasurementNotTakenResult", None)
         measurement_not_taken_result: Optional[
             ReportDatasetsToMeasurementResponseMeasurementNotTakenResult
@@ -3342,7 +2641,6 @@ class ReportDatasetsToMeasurementResponse:
                 _measurement_not_taken_result = int_to_str_map.get(
                     _measurement_not_taken_result, str(_measurement_not_taken_result)
                 )
-
             try:
                 measurement_not_taken_result = (
                     ReportDatasetsToMeasurementResponseMeasurementNotTakenResult(
@@ -3352,273 +2650,140 @@ class ReportDatasetsToMeasurementResponse:
             except ValueError:
                 # If the value is not recognized, use None as fallback
                 measurement_not_taken_result = None
-
         hide_from_certificate = d.pop("HideFromCertificate", None)
-
         measurement_not_taken_reason = d.pop("MeasurementNotTakenReason", None)
-
         environment_text_1 = d.pop("EnvironmentText1", None)
-
         environment_text_2 = d.pop("EnvironmentText2", None)
-
         environment_text_3 = d.pop("EnvironmentText3", None)
-
         environment_text_4 = d.pop("EnvironmentText4", None)
-
         environment_text_5 = d.pop("EnvironmentText5", None)
-
         environment_text_6 = d.pop("EnvironmentText6", None)
-
         values = d.pop("Values", None)
-
         value_1 = d.pop("Value1", None)
-
         value_2 = d.pop("Value2", None)
-
         value_3 = d.pop("Value3", None)
-
         value_4 = d.pop("Value4", None)
-
         value_5 = d.pop("Value5", None)
-
         value_6 = d.pop("Value6", None)
-
         value_7 = d.pop("Value7", None)
-
         value_8 = d.pop("Value8", None)
-
         value_9 = d.pop("Value9", None)
-
         value_10 = d.pop("Value10", None)
-
         value_11 = d.pop("Value11", None)
-
         value_12 = d.pop("Value12", None)
-
         value_13 = d.pop("Value13", None)
-
         value_14 = d.pop("Value14", None)
-
         value_15 = d.pop("Value15", None)
-
         value_16 = d.pop("Value16", None)
-
         value_17 = d.pop("Value17", None)
-
         value_18 = d.pop("Value18", None)
-
         value_19 = d.pop("Value19", None)
-
         value_20 = d.pop("Value20", None)
-
         value_21 = d.pop("Value21", None)
-
         value_22 = d.pop("Value22", None)
-
         value_23 = d.pop("Value23", None)
-
         value_24 = d.pop("Value24", None)
-
         value_25 = d.pop("Value25", None)
-
         value_26 = d.pop("Value26", None)
-
         value_27 = d.pop("Value27", None)
-
         value_28 = d.pop("Value28", None)
-
         value_29 = d.pop("Value29", None)
-
         value_30 = d.pop("Value30", None)
-
         value_31 = d.pop("Value31", None)
-
         value_32 = d.pop("Value32", None)
-
         value_33 = d.pop("Value33", None)
-
         value_34 = d.pop("Value34", None)
-
         value_35 = d.pop("Value35", None)
-
         value_36 = d.pop("Value36", None)
-
         value_37 = d.pop("Value37", None)
-
         value_38 = d.pop("Value38", None)
-
         value_39 = d.pop("Value39", None)
-
         value_40 = d.pop("Value40", None)
-
         raw_value_1 = d.pop("RawValue1", None)
-
         raw_value_2 = d.pop("RawValue2", None)
-
         raw_value_3 = d.pop("RawValue3", None)
-
         raw_value_4 = d.pop("RawValue4", None)
-
         raw_value_5 = d.pop("RawValue5", None)
-
         raw_value_6 = d.pop("RawValue6", None)
-
         raw_value_7 = d.pop("RawValue7", None)
-
         raw_value_8 = d.pop("RawValue8", None)
-
         raw_value_9 = d.pop("RawValue9", None)
-
         raw_value_10 = d.pop("RawValue10", None)
-
         raw_value_11 = d.pop("RawValue11", None)
-
         raw_value_12 = d.pop("RawValue12", None)
-
         raw_value_13 = d.pop("RawValue13", None)
-
         raw_value_14 = d.pop("RawValue14", None)
-
         raw_value_15 = d.pop("RawValue15", None)
-
         raw_value_16 = d.pop("RawValue16", None)
-
         raw_value_17 = d.pop("RawValue17", None)
-
         raw_value_18 = d.pop("RawValue18", None)
-
         raw_value_19 = d.pop("RawValue19", None)
-
         raw_value_20 = d.pop("RawValue20", None)
-
         raw_value_21 = d.pop("RawValue21", None)
-
         raw_value_22 = d.pop("RawValue22", None)
-
         raw_value_23 = d.pop("RawValue23", None)
-
         raw_value_24 = d.pop("RawValue24", None)
-
         raw_value_25 = d.pop("RawValue25", None)
-
         raw_value_26 = d.pop("RawValue26", None)
-
         raw_value_27 = d.pop("RawValue27", None)
-
         raw_value_28 = d.pop("RawValue28", None)
-
         raw_value_29 = d.pop("RawValue29", None)
-
         raw_value_30 = d.pop("RawValue30", None)
-
         raw_value_31 = d.pop("RawValue31", None)
-
         raw_value_32 = d.pop("RawValue32", None)
-
         raw_value_33 = d.pop("RawValue33", None)
-
         raw_value_34 = d.pop("RawValue34", None)
-
         raw_value_35 = d.pop("RawValue35", None)
-
         raw_value_36 = d.pop("RawValue36", None)
-
         raw_value_37 = d.pop("RawValue37", None)
-
         raw_value_38 = d.pop("RawValue38", None)
-
         raw_value_39 = d.pop("RawValue39", None)
-
         raw_value_40 = d.pop("RawValue40", None)
-
         subtitles_to_readings = d.pop("SubtitlesToReadings", None)
-
         value_subtitle_1 = d.pop("ValueSubtitle1", None)
-
         value_subtitle_2 = d.pop("ValueSubtitle2", None)
-
         value_subtitle_3 = d.pop("ValueSubtitle3", None)
-
         value_subtitle_4 = d.pop("ValueSubtitle4", None)
-
         value_subtitle_5 = d.pop("ValueSubtitle5", None)
-
         value_subtitle_6 = d.pop("ValueSubtitle6", None)
-
         value_subtitle_7 = d.pop("ValueSubtitle7", None)
-
         value_subtitle_8 = d.pop("ValueSubtitle8", None)
-
         value_subtitle_9 = d.pop("ValueSubtitle9", None)
-
         value_subtitle_10 = d.pop("ValueSubtitle10", None)
-
         value_subtitle_11 = d.pop("ValueSubtitle11", None)
-
         value_subtitle_12 = d.pop("ValueSubtitle12", None)
-
         value_subtitle_13 = d.pop("ValueSubtitle13", None)
-
         value_subtitle_14 = d.pop("ValueSubtitle14", None)
-
         value_subtitle_15 = d.pop("ValueSubtitle15", None)
-
         value_subtitle_16 = d.pop("ValueSubtitle16", None)
-
         value_subtitle_17 = d.pop("ValueSubtitle17", None)
-
         value_subtitle_18 = d.pop("ValueSubtitle18", None)
-
         value_subtitle_19 = d.pop("ValueSubtitle19", None)
-
         value_subtitle_20 = d.pop("ValueSubtitle20", None)
-
         value_subtitle_21 = d.pop("ValueSubtitle21", None)
-
         value_subtitle_22 = d.pop("ValueSubtitle22", None)
-
         value_subtitle_23 = d.pop("ValueSubtitle23", None)
-
         value_subtitle_24 = d.pop("ValueSubtitle24", None)
-
         value_subtitle_25 = d.pop("ValueSubtitle25", None)
-
         value_subtitle_26 = d.pop("ValueSubtitle26", None)
-
         value_subtitle_27 = d.pop("ValueSubtitle27", None)
-
         value_subtitle_28 = d.pop("ValueSubtitle28", None)
-
         value_subtitle_29 = d.pop("ValueSubtitle29", None)
-
         value_subtitle_30 = d.pop("ValueSubtitle30", None)
-
         value_subtitle_31 = d.pop("ValueSubtitle31", None)
-
         value_subtitle_32 = d.pop("ValueSubtitle32", None)
-
         value_subtitle_33 = d.pop("ValueSubtitle33", None)
-
         value_subtitle_34 = d.pop("ValueSubtitle34", None)
-
         value_subtitle_35 = d.pop("ValueSubtitle35", None)
-
         value_subtitle_36 = d.pop("ValueSubtitle36", None)
-
         value_subtitle_37 = d.pop("ValueSubtitle37", None)
-
         value_subtitle_38 = d.pop("ValueSubtitle38", None)
-
         value_subtitle_39 = d.pop("ValueSubtitle39", None)
-
         value_subtitle_40 = d.pop("ValueSubtitle40", None)
-
         values_decimal_places = d.pop("ValuesDecimalPlaces", None)
-
         repeat_measurement_and_calculate_hysteresis = d.pop(
             "RepeatMeasurementAndCalculateHysteresis", None
         )
-
         _measurement_point_order = d.pop("MeasurementPointOrder", None)
         measurement_point_order: Optional[ReportDatasetsToMeasurementResponseMeasurementPointOrder]
         if not _measurement_point_order:
@@ -3641,7 +2806,6 @@ class ReportDatasetsToMeasurementResponse:
             measurement_point_order = ReportDatasetsToMeasurementResponseMeasurementPointOrder(
                 _measurement_point_order
             )
-
         _hysteresis_point = d.pop("HysteresisPoint", None)
         hysteresis_point: Optional[ReportDatasetsToMeasurementResponseHysteresisPoint]
         if not _hysteresis_point:
@@ -3654,37 +2818,21 @@ class ReportDatasetsToMeasurementResponse:
                 hysteresis_point_map = {0: "First", 1: "None", 2: "Second", 3: "Zero"}
                 _hysteresis_point = hysteresis_point_map.get(_hysteresis_point, _hysteresis_point)
             hysteresis_point = ReportDatasetsToMeasurementResponseHysteresisPoint(_hysteresis_point)
-
         max_hysteresis = d.pop("MaxHysteresis", None)
-
         run = d.pop("Run", None)
-
         direction = d.pop("Direction", None)
-
         hysteresis = d.pop("Hysteresis", None)
-
         column_mean = d.pop("ColumnMean", None)
-
         column_mean_result = d.pop("ColumnMeanResult", None)
-
         column_sd = d.pop("ColumnSD", None)
-
         column_sd_result = d.pop("ColumnSDResult", None)
-
         column_cv = d.pop("ColumnCV", None)
-
         column_cv_result = d.pop("ColumnCVResult", None)
-
         column_range = d.pop("ColumnRange", None)
-
         column_range_result = d.pop("ColumnRangeResult", None)
-
         column_delta = d.pop("ColumnDelta", None)
-
         column_delta_result = d.pop("ColumnDeltaResult", None)
-
         column_result = d.pop("ColumnResult", None)
-
         qualer_api_models_report_datasets_to_measurement_response = cls(
             is_accredited=is_accredited,
             service_total=service_total,
@@ -4067,7 +3215,6 @@ class ReportDatasetsToMeasurementResponse:
             column_delta_result=column_delta_result,
             column_result=column_result,
         )
-
         qualer_api_models_report_datasets_to_measurement_response.additional_properties = d
         return qualer_api_models_report_datasets_to_measurement_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_order_item_image_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_order_item_image_response.py
@@ -23,11 +23,8 @@ class ReportDatasetsToOrderItemImageResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         image = self.image
-
         image_url = self.image_url
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ReportDatasetsToOrderItemImageResponse:
             field_dict["Image"] = image
         if image_url is not None:
             field_dict["ImageUrl"] = image_url
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         image = d.pop("Image", None)
-
         image_url = d.pop("ImageUrl", None)
-
         qualer_api_models_report_datasets_to_order_item_image_response = cls(
             service_order_item_id=service_order_item_id,
             image=image,
             image_url=image_url,
         )
-
         qualer_api_models_report_datasets_to_order_item_image_response.additional_properties = d
         return qualer_api_models_report_datasets_to_order_item_image_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_reference_standard_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_reference_standard_response.py
@@ -63,69 +63,27 @@ class ReportDatasetsToReferenceStandardResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         is_auxiliary = self.is_auxiliary
-
-        last_service_date: Optional[str]
-        if not self.last_service_date:
-            last_service_date = None
-        elif isinstance(self.last_service_date, datetime.datetime):
-            last_service_date = self.last_service_date.isoformat()
-        else:
-            last_service_date = self.last_service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        certificate_number: Optional[str]
-        if not self.certificate_number:
-            certificate_number = None
-        else:
-            certificate_number = self.certificate_number
-
-        calibrated_by: Optional[str]
-        if not self.calibrated_by:
-            calibrated_by = None
-        else:
-            calibrated_by = self.calibrated_by
-
+        last_service_date = self.last_service_date.isoformat() if self.last_service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        certificate_number = self.certificate_number
+        calibrated_by = self.calibrated_by
         tool_name = self.tool_name
-
         tool_site = self.tool_site
-
         tool_room = self.tool_room
-
         tool_station = self.tool_station
-
         tool_location = self.tool_location
-
         asset_tag = self.asset_tag
-
         lot_number = self.lot_number
-
         asset_user = self.asset_user
-
         tool_type_name = self.tool_type_name
-
         tool_description = self.tool_description
-
         tool_id = self.tool_id
-
         manufacturer = self.manufacturer
-
         serial_number = self.serial_number
-
         area = self.area
-
         service_order_item_id = self.service_order_item_id
-
         manufacturer_part_number = self.manufacturer_part_number
-
         equipment_id = self.equipment_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -173,14 +131,12 @@ class ReportDatasetsToReferenceStandardResponse:
             field_dict["ManufacturerPartNumber"] = manufacturer_part_number
         if equipment_id is not None:
             field_dict["EquipmentId"] = equipment_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         is_auxiliary = d.pop("IsAuxiliary", None)
-
         def _parse_last_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -190,14 +146,11 @@ class ReportDatasetsToReferenceStandardResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_service_date_type_0 = isoparse(data)
-
                 return last_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_service_date = _parse_last_service_date(d.pop("LastServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -207,62 +160,38 @@ class ReportDatasetsToReferenceStandardResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_certificate_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         certificate_number = _parse_certificate_number(d.pop("CertificateNumber", None))
-
         def _parse_calibrated_by(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         calibrated_by = _parse_calibrated_by(d.pop("CalibratedBy", None))
-
         tool_name = d.pop("ToolName", None)
-
         tool_site = d.pop("ToolSite", None)
-
         tool_room = d.pop("ToolRoom", None)
-
         tool_station = d.pop("ToolStation", None)
-
         tool_location = d.pop("ToolLocation", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         lot_number = d.pop("LotNumber", None)
-
         asset_user = d.pop("AssetUser", None)
-
         tool_type_name = d.pop("ToolTypeName", None)
-
         tool_description = d.pop("ToolDescription", None)
-
         tool_id = d.pop("ToolId", None)
-
         manufacturer = d.pop("Manufacturer", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         area = d.pop("Area", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         equipment_id = d.pop("EquipmentId", None)
-
         qualer_api_models_report_datasets_to_reference_standard_response = cls(
             is_auxiliary=is_auxiliary,
             last_service_date=last_service_date,
@@ -287,7 +216,6 @@ class ReportDatasetsToReferenceStandardResponse:
             manufacturer_part_number=manufacturer_part_number,
             equipment_id=equipment_id,
         )
-
         qualer_api_models_report_datasets_to_reference_standard_response.additional_properties = d
         return qualer_api_models_report_datasets_to_reference_standard_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_assignee_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_assignee_response.py
@@ -27,15 +27,10 @@ class ReportDatasetsToServiceOrderAssigneeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         first_name = self.first_name
-
         last_name = self.last_name
-
         alias = self.alias
-
         email = self.email
-
         title = self.title
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class ReportDatasetsToServiceOrderAssigneeResponse:
             field_dict["Email"] = email
         if title is not None:
             field_dict["Title"] = title
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         alias = d.pop("Alias", None)
-
         email = d.pop("Email", None)
-
         title = d.pop("Title", None)
-
         qualer_api_models_report_datasets_to_service_order_assignee_response = cls(
             first_name=first_name,
             last_name=last_name,
@@ -72,7 +61,6 @@ class ReportDatasetsToServiceOrderAssigneeResponse:
             email=email,
             title=title,
         )
-
         qualer_api_models_report_datasets_to_service_order_assignee_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_charge_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_charge_response.py
@@ -47,39 +47,19 @@ class ReportDatasetsToServiceOrderChargeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         description = self.description
-
         name = self.name
-
         unit_name = self.unit_name
-
         quantity = self.quantity
-
         discount = self.discount
-
         fixed_charge = self.fixed_charge
-
         price = self.price
-
         subtotal = self.subtotal
-
         is_taxable = self.is_taxable
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         is_hourly_pricing = self.is_hourly_pricing
-
         created_by = self.created_by
-
-        charge_date: Optional[str]
-        if not self.charge_date:
-            charge_date = None
-        elif isinstance(self.charge_date, datetime.datetime):
-            charge_date = self.charge_date.isoformat()
-        else:
-            charge_date = self.charge_date
-
+        charge_date = self.charge_date.isoformat() if self.charge_date else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -111,38 +91,24 @@ class ReportDatasetsToServiceOrderChargeResponse:
             field_dict["CreatedBy"] = created_by
         if charge_date is not None:
             field_dict["ChargeDate"] = charge_date
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         description = d.pop("Description", None)
-
         name = d.pop("Name", None)
-
         unit_name = d.pop("UnitName", None)
-
         quantity = d.pop("Quantity", None)
-
         discount = d.pop("Discount", None)
-
         fixed_charge = d.pop("FixedCharge", None)
-
         price = d.pop("Price", None)
-
         subtotal = d.pop("Subtotal", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         created_by = d.pop("CreatedBy", None)
-
         def _parse_charge_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -150,14 +116,11 @@ class ReportDatasetsToServiceOrderChargeResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 charge_date_type_0 = isoparse(data)
-
                 return charge_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         charge_date = _parse_charge_date(d.pop("ChargeDate", None))
-
         qualer_api_models_report_datasets_to_service_order_charge_response = cls(
             service_order_id=service_order_id,
             description=description,
@@ -174,7 +137,6 @@ class ReportDatasetsToServiceOrderChargeResponse:
             created_by=created_by,
             charge_date=charge_date,
         )
-
         qualer_api_models_report_datasets_to_service_order_charge_response.additional_properties = d
         return qualer_api_models_report_datasets_to_service_order_charge_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_component_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_component_response.py
@@ -43,31 +43,18 @@ class ReportDatasetsToServiceOrderItemComponentResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         order_item_id = self.order_item_id
-
         component_asset_id = self.component_asset_id
-
         component_serial_number = self.component_serial_number
-
         component_asset_tag = self.component_asset_tag
-
         component_asset_user = self.component_asset_user
-
         component_equipment_id = self.component_equipment_id
-
         component_manufacturer_part_number = self.component_manufacturer_part_number
-
         component_manufacturer = self.component_manufacturer
-
         component_root_category = self.component_root_category
-
         component_sub_category = self.component_sub_category
-
         component_location = self.component_location
-
         component_display_name = self.component_display_name
-
         component_display_part_number = self.component_display_part_number
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -97,38 +84,24 @@ class ReportDatasetsToServiceOrderItemComponentResponse:
             field_dict["ComponentDisplayName"] = component_display_name
         if component_display_part_number is not None:
             field_dict["ComponentDisplayPartNumber"] = component_display_part_number
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         order_item_id = d.pop("OrderItemId", None)
-
         component_asset_id = d.pop("ComponentAssetId", None)
-
         component_serial_number = d.pop("ComponentSerialNumber", None)
-
         component_asset_tag = d.pop("ComponentAssetTag", None)
-
         component_asset_user = d.pop("ComponentAssetUser", None)
-
         component_equipment_id = d.pop("ComponentEquipmentId", None)
-
         component_manufacturer_part_number = d.pop("ComponentManufacturerPartNumber", None)
-
         component_manufacturer = d.pop("ComponentManufacturer", None)
-
         component_root_category = d.pop("ComponentRootCategory", None)
-
         component_sub_category = d.pop("ComponentSubCategory", None)
-
         component_location = d.pop("ComponentLocation", None)
-
         component_display_name = d.pop("ComponentDisplayName", None)
-
         component_display_part_number = d.pop("ComponentDisplayPartNumber", None)
-
         qualer_api_models_report_datasets_to_service_order_item_component_response = cls(
             order_item_id=order_item_id,
             component_asset_id=component_asset_id,
@@ -144,7 +117,6 @@ class ReportDatasetsToServiceOrderItemComponentResponse:
             component_display_name=component_display_name,
             component_display_part_number=component_display_part_number,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_component_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_field_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_field_response.py
@@ -27,15 +27,10 @@ class ReportDatasetsToServiceOrderItemFieldResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         field_id = self.field_id
-
         type_ = self.type_
-
         value = self.value
-
         service_order_item_id = self.service_order_item_id
-
         service_order_item_task_id = self.service_order_item_task_id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class ReportDatasetsToServiceOrderItemFieldResponse:
             field_dict["ServiceOrderItemId"] = service_order_item_id
         if service_order_item_task_id is not None:
             field_dict["ServiceOrderItemTaskId"] = service_order_item_task_id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         field_id = d.pop("FieldId", None)
-
         type_ = d.pop("Type", None)
-
         value = d.pop("Value", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         service_order_item_task_id = d.pop("ServiceOrderItemTaskId", None)
-
         qualer_api_models_report_datasets_to_service_order_item_field_response = cls(
             field_id=field_id,
             type_=type_,
@@ -72,7 +61,6 @@ class ReportDatasetsToServiceOrderItemFieldResponse:
             service_order_item_id=service_order_item_id,
             service_order_item_task_id=service_order_item_task_id,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_field_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_option_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_option_response.py
@@ -29,17 +29,11 @@ class ReportDatasetsToServiceOrderItemOptionResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         service_charge = self.service_charge
-
         time_spent = self.time_spent
-
         is_hourly = self.is_hourly
-
         price = self.price
-
         task_name = self.task_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -55,24 +49,17 @@ class ReportDatasetsToServiceOrderItemOptionResponse:
             field_dict["Price"] = price
         if task_name is not None:
             field_dict["TaskName"] = task_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         service_charge = d.pop("ServiceCharge", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         price = d.pop("Price", None)
-
         task_name = d.pop("TaskName", None)
-
         qualer_api_models_report_datasets_to_service_order_item_option_response = cls(
             service_order_item_id=service_order_item_id,
             service_charge=service_charge,
@@ -81,7 +68,6 @@ class ReportDatasetsToServiceOrderItemOptionResponse:
             price=price,
             task_name=task_name,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_option_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_response.py
@@ -299,356 +299,176 @@ class ReportDatasetsToServiceOrderItemResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         certificate_number = self.certificate_number
-
         document_number = self.document_number
-
         revision = self.revision
-
-        effective_date: Optional[str]
-        if not self.effective_date:
-            effective_date = None
-        elif isinstance(self.effective_date, datetime.datetime):
-            effective_date = self.effective_date.isoformat()
-        else:
-            effective_date = self.effective_date
-
+        effective_date = self.effective_date.isoformat() if self.effective_date else None
         document_section = self.document_section
-
         service_level = self.service_level
-
         service_level_code = self.service_level_code
-
         service_type = self.service_type
-
         order_item_number = self.order_item_number
-
         service_charge = self.service_charge
-
         updated_by = self.updated_by
-
         updated_on: Optional[str] = None
         if self.updated_on:
             updated_on = self.updated_on.isoformat()
-
-        work_status: Optional[int] = None
-        if self.work_status:
-            work_status = self.work_status.value
-
+        work_status = self.work_status.value if self.work_status else None
         custom_work_status = self.custom_work_status
-
         service_comments = self.service_comments
-
         client_notes = self.client_notes
-
         vendor_service_notes = self.vendor_service_notes
-
         display_name = self.display_name
-
         display_part_number = self.display_part_number
-
         part_number = self.part_number
-
         schedule_name = self.schedule_name
-
         segment_name = self.segment_name
-
         next_segment_name = self.next_segment_name
-
         interval_length = self.interval_length
-
         interval_cycle = self.interval_cycle
-
         service_options = self.service_options
-
         service_options_price = self.service_options_price
-
         service_options_document_numbers = self.service_options_document_numbers
-
         location = self.location
-
         station = self.station
-
         room = self.room
-
         site = self.site
-
         vendor_id = self.vendor_id
-
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
         linked_order_number = self.linked_order_number
-
         asset_id = self.asset_id
-
         asset_class = self.asset_class
-
         asset_condition = self.asset_condition
-
         asset_criticality = self.asset_criticality
-
         asset_pool = self.asset_pool
-
         asset_name = self.asset_name
-
         asset_description = self.asset_description
-
         asset_document_number = self.asset_document_number
-
         asset_document_section = self.asset_document_section
-
         document_number_values = self.document_number_values
-
         product_name = self.product_name
-
         product_description = self.product_description
-
         asset_maker = self.asset_maker
-
         category_name = self.category_name
-
         root_category_name = self.root_category_name
-
         vendor_tag = self.vendor_tag
-
         result_status: Optional[int]
         if not self.result_status:
             result_status = None
         else:
             result_status: Optional[str]
-
             if not self.result_status:
-
                 result_status = None
             else:
                 result_status = self.result_status
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
-        original_due_date: Optional[str]
-        if not self.original_due_date:
-            original_due_date = None
-        elif isinstance(self.original_due_date, datetime.datetime):
-            original_due_date = self.original_due_date.isoformat()
-        else:
-            original_due_date = self.original_due_date
-
-        asset_tag: Optional[str]
-        if not self.asset_tag:
-            asset_tag = None
-        else:
-            asset_tag = self.asset_tag
-
-        department: Optional[str]
-        if not self.department:
-            department = None
-        else:
-            department = self.department
-
-        asset_user: Optional[str]
-        if not self.asset_user:
-            asset_user = None
-        else:
-            asset_user = self.asset_user
-
-        equipment_id: Optional[str]
-        if not self.equipment_id:
-            equipment_id = None
-        else:
-            equipment_id = self.equipment_id
-
-        legacy_identifier: Optional[str]
-        if not self.legacy_identifier:
-            legacy_identifier = None
-        else:
-            legacy_identifier = self.legacy_identifier
-
-        activation_date: Optional[str]
-        if not self.activation_date:
-            activation_date = None
-        elif isinstance(self.activation_date, datetime.datetime):
-            activation_date = self.activation_date.isoformat()
-        else:
-            activation_date = self.activation_date
-
-        purchase_date: Optional[str]
-        if not self.purchase_date:
-            purchase_date = None
-        elif isinstance(self.purchase_date, datetime.datetime):
-            purchase_date = self.purchase_date.isoformat()
-        else:
-            purchase_date = self.purchase_date
-
-        part_name: Optional[str]
-        if not self.part_name:
-            part_name = None
-        else:
-            part_name = self.part_name
-
-        part_description: Optional[str]
-        if not self.part_description:
-            part_description = None
-        else:
-            part_description = self.part_description
-
+        service_date = self.service_date.isoformat() if self.service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
+        original_due_date = self.original_due_date.isoformat() if self.original_due_date else None
+        asset_tag = self.asset_tag
+        department = self.department
+        asset_user = self.asset_user
+        equipment_id = self.equipment_id
+        legacy_identifier = self.legacy_identifier
+        activation_date = self.activation_date.isoformat() if self.activation_date else None
+        purchase_date = self.purchase_date.isoformat() if self.purchase_date else None
+        part_name = self.part_name
+        part_description = self.part_description
         is_taxable = self.is_taxable
-
         is_limited = self.is_limited
-
         quantity: Optional[float]
         if not self.quantity:
             quantity = None
         else:
             quantity = self.quantity
-
         discount: Optional[float]
         if not self.discount:
             discount = None
         else:
             discount = self.discount
-
         price: Optional[float]
         if not self.price:
             price = None
         else:
             price = self.price
-
         time_spent_in_minutes: Optional[float]
         if not self.time_spent_in_minutes:
             time_spent_in_minutes = None
         else:
             time_spent_in_minutes = self.time_spent_in_minutes
-
         is_hourly_pricing: Optional[bool]
         if not self.is_hourly_pricing:
             is_hourly_pricing = None
         else:
             is_hourly_pricing = self.is_hourly_pricing
-
         delivery_charge: Optional[float]
         if not self.delivery_charge:
             delivery_charge = None
         else:
             delivery_charge = self.delivery_charge
-
         serial_number = self.serial_number
-
         part_repair_charges: Optional[float]
         if not self.part_repair_charges:
             part_repair_charges = None
         else:
             part_repair_charges = self.part_repair_charges
-
         part_repair_price: Optional[float]
         if not self.part_repair_price:
             part_repair_price = None
         else:
             part_repair_price = self.part_repair_price
-
         override_parts_total = self.override_parts_total
-
         override_repairs_total = self.override_repairs_total
-
-        asset_custodian_name: Optional[str]
-        if not self.asset_custodian_name:
-            asset_custodian_name = None
-        else:
-            asset_custodian_name = self.asset_custodian_name
-
-        as_found_specification_group_name: Optional[str]
-        if not self.as_found_specification_group_name:
-            as_found_specification_group_name = None
-        else:
-            as_found_specification_group_name = self.as_found_specification_group_name
-
-        as_found_specification_company_name: Optional[str]
-        if not self.as_found_specification_company_name:
-            as_found_specification_company_name = None
-        else:
-            as_found_specification_company_name = self.as_found_specification_company_name
-
-        as_left_specification_group_name: Optional[str]
-        if not self.as_left_specification_group_name:
-            as_left_specification_group_name = None
-        else:
-            as_left_specification_group_name = self.as_left_specification_group_name
-
-        as_left_specification_company_name: Optional[str]
-        if not self.as_left_specification_company_name:
-            as_left_specification_company_name = None
-        else:
-            as_left_specification_company_name = self.as_left_specification_company_name
-
+        asset_custodian_name = self.asset_custodian_name
+        as_found_specification_group_name = self.as_found_specification_group_name
+        as_found_specification_company_name = self.as_found_specification_company_name
+        as_left_specification_group_name = self.as_left_specification_group_name
+        as_left_specification_company_name = self.as_left_specification_company_name
         order_id: Optional[int]
         if not self.order_id:
             order_id = None
         else:
             order_id = self.order_id
-
         parent_order_id: Optional[int]
         if not self.parent_order_id:
             parent_order_id = None
         else:
             parent_order_id = self.parent_order_id
-
         order_item_id: Optional[int]
         if not self.order_item_id:
             order_item_id = None
         else:
             order_item_id = self.order_item_id
-
         order_item_part_id: Optional[int]
         if not self.order_item_part_id:
             order_item_part_id = None
         else:
             order_item_part_id = self.order_item_part_id
-
         as_found_specification_group_id: Optional[int]
         if not self.as_found_specification_group_id:
             as_found_specification_group_id = None
         else:
             as_found_specification_group_id = self.as_found_specification_group_id
-
         as_left_specification_group_id: Optional[int]
         if not self.as_left_specification_group_id:
             as_left_specification_group_id = None
         else:
             as_left_specification_group_id = self.as_left_specification_group_id
-
         as_found_status: Optional[int]
         if not self.as_found_status:
             as_found_status = None
         else:
             as_found_status = self.as_found_status
-
         as_left_status: Optional[int]
         if not self.as_left_status:
             as_left_status = None
         else:
             as_left_status = self.as_left_status
-
         as_found_result: Optional[int]
         if not self.as_found_result:
             as_found_result = None
         else:
             as_found_result: Optional[str]
-
             if not self.as_found_result:
-
                 as_found_result = None
             else:
                 as_found_result = self.as_found_result
@@ -657,292 +477,80 @@ class ReportDatasetsToServiceOrderItemResponse:
             as_left_result = None
         else:
             as_left_result: Optional[str]
-
             if not self.as_left_result:
-
                 as_left_result = None
             else:
                 as_left_result = self.as_left_result
-        completed_on: Optional[str]
-        if not self.completed_on:
-            completed_on = None
-        elif isinstance(self.completed_on, datetime.datetime):
-            completed_on = self.completed_on.isoformat()
-        else:
-            completed_on = self.completed_on
-
-        received_on: Optional[str]
-        if not self.received_on:
-            received_on = None
-        elif isinstance(self.received_on, datetime.datetime):
-            received_on = self.received_on.isoformat()
-        else:
-            received_on = self.received_on
-
-        completed_by_name: Optional[str]
-        if not self.completed_by_name:
-            completed_by_name = None
-        else:
-            completed_by_name = self.completed_by_name
-
+        completed_on = self.completed_on.isoformat() if self.completed_on else None
+        received_on = self.received_on.isoformat() if self.received_on else None
+        completed_by_name = self.completed_by_name
         service_charge_base: Optional[float]
         if not self.service_charge_base:
             service_charge_base = None
         else:
             service_charge_base = self.service_charge_base
-
         service_total: Optional[float]
         if not self.service_total:
             service_total = None
         else:
             service_total = self.service_total
-
         repairs_total: Optional[float]
         if not self.repairs_total:
             repairs_total = None
         else:
             repairs_total = self.repairs_total
-
         parts_total: Optional[float]
         if not self.parts_total:
             parts_total = None
         else:
             parts_total = self.parts_total
-
         parts_total_before_discount: Optional[float]
         if not self.parts_total_before_discount:
             parts_total_before_discount = None
         else:
             parts_total_before_discount = self.parts_total_before_discount
-
-        parent_manufacturer: Optional[str]
-        if not self.parent_manufacturer:
-            parent_manufacturer = None
-        else:
-            parent_manufacturer = self.parent_manufacturer
-
-        parent_location: Optional[str]
-        if not self.parent_location:
-            parent_location = None
-        else:
-            parent_location = self.parent_location
-
-        parent_manufacturer_part_number: Optional[str]
-        if not self.parent_manufacturer_part_number:
-            parent_manufacturer_part_number = None
-        else:
-            parent_manufacturer_part_number = self.parent_manufacturer_part_number
-
-        parent_display_part_number: Optional[str]
-        if not self.parent_display_part_number:
-            parent_display_part_number = None
-        else:
-            parent_display_part_number = self.parent_display_part_number
-
+        parent_manufacturer = self.parent_manufacturer
+        parent_location = self.parent_location
+        parent_manufacturer_part_number = self.parent_manufacturer_part_number
+        parent_display_part_number = self.parent_display_part_number
         parent_asset_id: Optional[int]
         if not self.parent_asset_id:
             parent_asset_id = None
         else:
             parent_asset_id = self.parent_asset_id
-
-        parent_category_name: Optional[str]
-        if not self.parent_category_name:
-            parent_category_name = None
-        else:
-            parent_category_name = self.parent_category_name
-
-        parent_root_category_name: Optional[str]
-        if not self.parent_root_category_name:
-            parent_root_category_name = None
-        else:
-            parent_root_category_name = self.parent_root_category_name
-
-        parent_serial_number: Optional[str]
-        if not self.parent_serial_number:
-            parent_serial_number = None
-        else:
-            parent_serial_number = self.parent_serial_number
-
-        parent_asset_tag: Optional[str]
-        if not self.parent_asset_tag:
-            parent_asset_tag = None
-        else:
-            parent_asset_tag = self.parent_asset_tag
-
-        parent_asset_user: Optional[str]
-        if not self.parent_asset_user:
-            parent_asset_user = None
-        else:
-            parent_asset_user = self.parent_asset_user
-
-        parent_display_name: Optional[str]
-        if not self.parent_display_name:
-            parent_display_name = None
-        else:
-            parent_display_name = self.parent_display_name
-
-        parent_equipment_id: Optional[str]
-        if not self.parent_equipment_id:
-            parent_equipment_id = None
-        else:
-            parent_equipment_id = self.parent_equipment_id
-
-        asset_shipping_address_1: Optional[str]
-        if not self.asset_shipping_address_1:
-            asset_shipping_address_1 = None
-        else:
-            asset_shipping_address_1 = self.asset_shipping_address_1
-
-        asset_shipping_address_2: Optional[str]
-        if not self.asset_shipping_address_2:
-            asset_shipping_address_2 = None
-        else:
-            asset_shipping_address_2 = self.asset_shipping_address_2
-
-        asset_shipping_first_name: Optional[str]
-        if not self.asset_shipping_first_name:
-            asset_shipping_first_name = None
-        else:
-            asset_shipping_first_name = self.asset_shipping_first_name
-
-        asset_shipping_last_name: Optional[str]
-        if not self.asset_shipping_last_name:
-            asset_shipping_last_name = None
-        else:
-            asset_shipping_last_name = self.asset_shipping_last_name
-
-        asset_shipping_email: Optional[str]
-        if not self.asset_shipping_email:
-            asset_shipping_email = None
-        else:
-            asset_shipping_email = self.asset_shipping_email
-
-        asset_shipping_company: Optional[str]
-        if not self.asset_shipping_company:
-            asset_shipping_company = None
-        else:
-            asset_shipping_company = self.asset_shipping_company
-
-        asset_shipping_city: Optional[str]
-        if not self.asset_shipping_city:
-            asset_shipping_city = None
-        else:
-            asset_shipping_city = self.asset_shipping_city
-
-        asset_shipping_zip: Optional[str]
-        if not self.asset_shipping_zip:
-            asset_shipping_zip = None
-        else:
-            asset_shipping_zip = self.asset_shipping_zip
-
-        asset_shipping_phone_number: Optional[str]
-        if not self.asset_shipping_phone_number:
-            asset_shipping_phone_number = None
-        else:
-            asset_shipping_phone_number = self.asset_shipping_phone_number
-
-        asset_shipping_fax_number: Optional[str]
-        if not self.asset_shipping_fax_number:
-            asset_shipping_fax_number = None
-        else:
-            asset_shipping_fax_number = self.asset_shipping_fax_number
-
-        asset_shipping_country: Optional[str]
-        if not self.asset_shipping_country:
-            asset_shipping_country = None
-        else:
-            asset_shipping_country = self.asset_shipping_country
-
-        asset_shipping_state: Optional[str]
-        if not self.asset_shipping_state:
-            asset_shipping_state = None
-        else:
-            asset_shipping_state = self.asset_shipping_state
-
-        shipping_address_1: Optional[str]
-        if not self.shipping_address_1:
-            shipping_address_1 = None
-        else:
-            shipping_address_1 = self.shipping_address_1
-
-        shipping_address_2: Optional[str]
-        if not self.shipping_address_2:
-            shipping_address_2 = None
-        else:
-            shipping_address_2 = self.shipping_address_2
-
-        shipping_first_name: Optional[str]
-        if not self.shipping_first_name:
-            shipping_first_name = None
-        else:
-            shipping_first_name = self.shipping_first_name
-
-        shipping_last_name: Optional[str]
-        if not self.shipping_last_name:
-            shipping_last_name = None
-        else:
-            shipping_last_name = self.shipping_last_name
-
-        shipping_email: Optional[str]
-        if not self.shipping_email:
-            shipping_email = None
-        else:
-            shipping_email = self.shipping_email
-
-        shipping_company: Optional[str]
-        if not self.shipping_company:
-            shipping_company = None
-        else:
-            shipping_company = self.shipping_company
-
-        shipping_city: Optional[str]
-        if not self.shipping_city:
-            shipping_city = None
-        else:
-            shipping_city = self.shipping_city
-
-        shipping_zip: Optional[str]
-        if not self.shipping_zip:
-            shipping_zip = None
-        else:
-            shipping_zip = self.shipping_zip
-
-        shipping_phone_number: Optional[str]
-        if not self.shipping_phone_number:
-            shipping_phone_number = None
-        else:
-            shipping_phone_number = self.shipping_phone_number
-
-        shipping_fax_number: Optional[str]
-        if not self.shipping_fax_number:
-            shipping_fax_number = None
-        else:
-            shipping_fax_number = self.shipping_fax_number
-
-        shipping_country: Optional[str]
-        if not self.shipping_country:
-            shipping_country = None
-        else:
-            shipping_country = self.shipping_country
-
-        shipping_state: Optional[str]
-        if not self.shipping_state:
-            shipping_state = None
-        else:
-            shipping_state = self.shipping_state
-
-        asset_service_notes: Optional[str]
-        if not self.asset_service_notes:
-            asset_service_notes = None
-        else:
-            asset_service_notes = self.asset_service_notes
-
-        service_option_service_code: Optional[str]
-        if not self.service_option_service_code:
-            service_option_service_code = None
-        else:
-            service_option_service_code = self.service_option_service_code
-
+        parent_category_name = self.parent_category_name
+        parent_root_category_name = self.parent_root_category_name
+        parent_serial_number = self.parent_serial_number
+        parent_asset_tag = self.parent_asset_tag
+        parent_asset_user = self.parent_asset_user
+        parent_display_name = self.parent_display_name
+        parent_equipment_id = self.parent_equipment_id
+        asset_shipping_address_1 = self.asset_shipping_address_1
+        asset_shipping_address_2 = self.asset_shipping_address_2
+        asset_shipping_first_name = self.asset_shipping_first_name
+        asset_shipping_last_name = self.asset_shipping_last_name
+        asset_shipping_email = self.asset_shipping_email
+        asset_shipping_company = self.asset_shipping_company
+        asset_shipping_city = self.asset_shipping_city
+        asset_shipping_zip = self.asset_shipping_zip
+        asset_shipping_phone_number = self.asset_shipping_phone_number
+        asset_shipping_fax_number = self.asset_shipping_fax_number
+        asset_shipping_country = self.asset_shipping_country
+        asset_shipping_state = self.asset_shipping_state
+        shipping_address_1 = self.shipping_address_1
+        shipping_address_2 = self.shipping_address_2
+        shipping_first_name = self.shipping_first_name
+        shipping_last_name = self.shipping_last_name
+        shipping_email = self.shipping_email
+        shipping_company = self.shipping_company
+        shipping_city = self.shipping_city
+        shipping_zip = self.shipping_zip
+        shipping_phone_number = self.shipping_phone_number
+        shipping_fax_number = self.shipping_fax_number
+        shipping_country = self.shipping_country
+        shipping_state = self.shipping_state
+        asset_service_notes = self.asset_service_notes
+        service_option_service_code = self.service_option_service_code
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -1224,18 +832,14 @@ class ReportDatasetsToServiceOrderItemResponse:
             field_dict["AssetServiceNotes"] = asset_service_notes
         if service_option_service_code is not None:
             field_dict["ServiceOptionServiceCode"] = service_option_service_code
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         certificate_number = d.pop("CertificateNumber", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         revision = d.pop("Revision", None)
-
         def _parse_effective_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1245,35 +849,24 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 effective_date_type_0 = isoparse(data)
-
                 return effective_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         effective_date = _parse_effective_date(d.pop("EffectiveDate", None))
-
         document_section = d.pop("DocumentSection", None)
-
         service_level = d.pop("ServiceLevel", None)
-
         service_level_code = d.pop("ServiceLevelCode", None)
-
         service_type = d.pop("ServiceType", None)
-
         order_item_number = d.pop("OrderItemNumber", None)
-
         service_charge = d.pop("ServiceCharge", None)
-
         updated_by = d.pop("UpdatedBy", None)
-
         _updated_on = d.pop("UpdatedOn", None)
         updated_on: Optional[datetime.datetime]
         if not _updated_on:
             updated_on = None
         else:
             updated_on = isoparse(_updated_on)
-
         _work_status = d.pop("WorkStatus", None)
         work_status: Optional[WorkStatus]
         if not _work_status:
@@ -1282,92 +875,50 @@ class ReportDatasetsToServiceOrderItemResponse:
             work_status = None
         else:
             work_status = WorkStatus(_work_status)
-
         custom_work_status = d.pop("CustomWorkStatus", None)
-
         service_comments = d.pop("ServiceComments", None)
-
         client_notes = d.pop("ClientNotes", None)
-
         vendor_service_notes = d.pop("VendorServiceNotes", None)
-
         display_name = d.pop("DisplayName", None)
-
         display_part_number = d.pop("DisplayPartNumber", None)
-
         part_number = d.pop("PartNumber", None)
-
         schedule_name = d.pop("ScheduleName", None)
-
         segment_name = d.pop("SegmentName", None)
-
         next_segment_name = d.pop("NextSegmentName", None)
-
         interval_length = d.pop("IntervalLength", None)
-
         interval_cycle = d.pop("IntervalCycle", None)
-
         service_options = d.pop("ServiceOptions", None)
-
         service_options_price = d.pop("ServiceOptionsPrice", None)
-
         service_options_document_numbers = d.pop("ServiceOptionsDocumentNumbers", None)
-
         location = d.pop("Location", None)
-
         station = d.pop("Station", None)
-
         room = d.pop("Room", None)
-
         site = d.pop("Site", None)
-
         vendor_id = d.pop("VendorId", None)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         linked_order_number = d.pop("LinkedOrderNumber", None)
-
         asset_id = d.pop("AssetId", None)
-
         asset_class = d.pop("AssetClass", None)
-
         asset_condition = d.pop("AssetCondition", None)
-
         asset_criticality = d.pop("AssetCriticality", None)
-
         asset_pool = d.pop("AssetPool", None)
-
         asset_name = d.pop("AssetName", None)
-
         asset_description = d.pop("AssetDescription", None)
-
         asset_document_number = d.pop("AssetDocumentNumber", None)
-
         asset_document_section = d.pop("AssetDocumentSection", None)
-
         document_number_values = d.pop("DocumentNumberValues", None)
-
         product_name = d.pop("ProductName", None)
-
         product_description = d.pop("ProductDescription", None)
-
         asset_maker = d.pop("AssetMaker", None)
-
         category_name = d.pop("CategoryName", None)
-
         root_category_name = d.pop("RootCategoryName", None)
-
         vendor_tag = d.pop("VendorTag", None)
-
         def _parse_result_status(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1375,14 +926,11 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1392,14 +940,11 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         def _parse_original_due_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1409,49 +954,36 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 original_due_date_type_0 = isoparse(data)
-
                 return original_due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         original_due_date = _parse_original_due_date(d.pop("OriginalDueDate", None))
-
         def _parse_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag = _parse_asset_tag(d.pop("AssetTag", None))
-
         def _parse_department(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         department = _parse_department(d.pop("Department", None))
-
         def _parse_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user = _parse_asset_user(d.pop("AssetUser", None))
-
         def _parse_equipment_id(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         equipment_id = _parse_equipment_id(d.pop("EquipmentId", None))
-
         def _parse_legacy_identifier(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         legacy_identifier = _parse_legacy_identifier(d.pop("LegacyIdentifier", None))
-
         def _parse_activation_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1461,14 +993,11 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 activation_date_type_0 = isoparse(data)
-
                 return activation_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         activation_date = _parse_activation_date(d.pop("ActivationDate", None))
-
         def _parse_purchase_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1476,223 +1005,165 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 purchase_date_type_0 = isoparse(data)
-
                 return purchase_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         purchase_date = _parse_purchase_date(d.pop("PurchaseDate", None))
-
         def _parse_part_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         part_name = _parse_part_name(d.pop("PartName", None))
-
         def _parse_part_description(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         part_description = _parse_part_description(d.pop("PartDescription", None))
-
         is_taxable = d.pop("IsTaxable", None)
-
         is_limited = d.pop("IsLimited", None)
-
         def _parse_quantity(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         quantity = _parse_quantity(d.pop("Quantity", None))
-
         def _parse_discount(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         discount = _parse_discount(d.pop("Discount", None))
-
         def _parse_price(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         price = _parse_price(d.pop("Price", None))
-
         def _parse_time_spent_in_minutes(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         time_spent_in_minutes = _parse_time_spent_in_minutes(d.pop("TimeSpentInMinutes", None))
-
         def _parse_is_hourly_pricing(data: object) -> Optional[bool]:
             if not data:
                 return None
             return cast(Optional[bool], data)
-
         is_hourly_pricing = _parse_is_hourly_pricing(d.pop("IsHourlyPricing", None))
-
         def _parse_delivery_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         delivery_charge = _parse_delivery_charge(d.pop("DeliveryCharge", None))
-
         serial_number = d.pop("SerialNumber", None)
-
         def _parse_part_repair_charges(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         part_repair_charges = _parse_part_repair_charges(d.pop("PartRepairCharges", None))
-
         def _parse_part_repair_price(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         part_repair_price = _parse_part_repair_price(d.pop("PartRepairPrice", None))
-
         override_parts_total = d.pop("OverridePartsTotal", None)
-
         override_repairs_total = d.pop("OverrideRepairsTotal", None)
-
         def _parse_asset_custodian_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_custodian_name = _parse_asset_custodian_name(d.pop("AssetCustodianName", None))
-
         def _parse_as_found_specification_group_name(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_specification_group_name = _parse_as_found_specification_group_name(
             d.pop("AsFoundSpecificationGroupName", None)
         )
-
         def _parse_as_found_specification_company_name(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_specification_company_name = _parse_as_found_specification_company_name(
             d.pop("AsFoundSpecificationCompanyName", None)
         )
-
         def _parse_as_left_specification_group_name(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_specification_group_name = _parse_as_left_specification_group_name(
             d.pop("AsLeftSpecificationGroupName", None)
         )
-
         def _parse_as_left_specification_company_name(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_specification_company_name = _parse_as_left_specification_company_name(
             d.pop("AsLeftSpecificationCompanyName", None)
         )
-
         def _parse_order_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         order_id = _parse_order_id(d.pop("OrderId", None))
-
         def _parse_parent_order_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         parent_order_id = _parse_parent_order_id(d.pop("ParentOrderId", None))
-
         def _parse_order_item_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         order_item_id = _parse_order_item_id(d.pop("OrderItemId", None))
-
         def _parse_order_item_part_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         order_item_part_id = _parse_order_item_part_id(d.pop("OrderItemPartId", None))
-
         def _parse_as_found_specification_group_id(
             data: object,
         ) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_found_specification_group_id = _parse_as_found_specification_group_id(
             d.pop("AsFoundSpecificationGroupId", None)
         )
-
         def _parse_as_left_specification_group_id(
             data: object,
         ) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_left_specification_group_id = _parse_as_left_specification_group_id(
             d.pop("AsLeftSpecificationGroupId", None)
         )
-
         def _parse_as_found_status(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_found_status = _parse_as_found_status(d.pop("AsFoundStatus", None))
-
         def _parse_as_left_status(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_left_status = _parse_as_left_status(d.pop("AsLeftStatus", None))
-
         def _parse_as_found_result(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_completed_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1700,14 +1171,11 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 completed_on_type_0 = isoparse(data)
-
                 return completed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         completed_on = _parse_completed_on(d.pop("CompletedOn", None))
-
         def _parse_received_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1715,348 +1183,257 @@ class ReportDatasetsToServiceOrderItemResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 received_on_type_0 = isoparse(data)
-
                 return received_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         received_on = _parse_received_on(d.pop("ReceivedOn", None))
-
         def _parse_completed_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         completed_by_name = _parse_completed_by_name(d.pop("CompletedByName", None))
-
         def _parse_service_charge_base(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge_base = _parse_service_charge_base(d.pop("ServiceChargeBase", None))
-
         def _parse_service_total(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_total = _parse_service_total(d.pop("ServiceTotal", None))
-
         def _parse_repairs_total(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_total = _parse_repairs_total(d.pop("RepairsTotal", None))
-
         def _parse_parts_total(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_total = _parse_parts_total(d.pop("PartsTotal", None))
-
         def _parse_parts_total_before_discount(
             data: object,
         ) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_total_before_discount = _parse_parts_total_before_discount(
             d.pop("PartsTotalBeforeDiscount", None)
         )
-
         def _parse_parent_manufacturer(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_manufacturer = _parse_parent_manufacturer(d.pop("ParentManufacturer", None))
-
         def _parse_parent_location(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_location = _parse_parent_location(d.pop("ParentLocation", None))
-
         def _parse_parent_manufacturer_part_number(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_manufacturer_part_number = _parse_parent_manufacturer_part_number(
             d.pop("ParentManufacturerPartNumber", None)
         )
-
         def _parse_parent_display_part_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_display_part_number = _parse_parent_display_part_number(
             d.pop("ParentDisplayPartNumber", None)
         )
-
         def _parse_parent_asset_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         parent_asset_id = _parse_parent_asset_id(d.pop("ParentAssetId", None))
-
         def _parse_parent_category_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_category_name = _parse_parent_category_name(d.pop("ParentCategoryName", None))
-
         def _parse_parent_root_category_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_root_category_name = _parse_parent_root_category_name(
             d.pop("ParentRootCategoryName", None)
         )
-
         def _parse_parent_serial_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_serial_number = _parse_parent_serial_number(d.pop("ParentSerialNumber", None))
-
         def _parse_parent_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_asset_tag = _parse_parent_asset_tag(d.pop("ParentAssetTag", None))
-
         def _parse_parent_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_asset_user = _parse_parent_asset_user(d.pop("ParentAssetUser", None))
-
         def _parse_parent_display_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_display_name = _parse_parent_display_name(d.pop("ParentDisplayName", None))
-
         def _parse_parent_equipment_id(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         parent_equipment_id = _parse_parent_equipment_id(d.pop("ParentEquipmentId", None))
-
         def _parse_asset_shipping_address_1(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_address_1 = _parse_asset_shipping_address_1(
             d.pop("AssetShippingAddress1", None)
         )
-
         def _parse_asset_shipping_address_2(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_address_2 = _parse_asset_shipping_address_2(
             d.pop("AssetShippingAddress2", None)
         )
-
         def _parse_asset_shipping_first_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_first_name = _parse_asset_shipping_first_name(
             d.pop("AssetShippingFirstName", None)
         )
-
         def _parse_asset_shipping_last_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_last_name = _parse_asset_shipping_last_name(
             d.pop("AssetShippingLastName", None)
         )
-
         def _parse_asset_shipping_email(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_email = _parse_asset_shipping_email(d.pop("AssetShippingEmail", None))
-
         def _parse_asset_shipping_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_company = _parse_asset_shipping_company(d.pop("AssetShippingCompany", None))
-
         def _parse_asset_shipping_city(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_city = _parse_asset_shipping_city(d.pop("AssetShippingCity", None))
-
         def _parse_asset_shipping_zip(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_zip = _parse_asset_shipping_zip(d.pop("AssetShippingZip", None))
-
         def _parse_asset_shipping_phone_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_phone_number = _parse_asset_shipping_phone_number(
             d.pop("AssetShippingPhoneNumber", None)
         )
-
         def _parse_asset_shipping_fax_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_fax_number = _parse_asset_shipping_fax_number(
             d.pop("AssetShippingFaxNumber", None)
         )
-
         def _parse_asset_shipping_country(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_country = _parse_asset_shipping_country(d.pop("AssetShippingCountry", None))
-
         def _parse_asset_shipping_state(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_shipping_state = _parse_asset_shipping_state(d.pop("AssetShippingState", None))
-
         def _parse_shipping_address_1(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_address_1 = _parse_shipping_address_1(d.pop("ShippingAddress1", None))
-
         def _parse_shipping_address_2(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_address_2 = _parse_shipping_address_2(d.pop("ShippingAddress2", None))
-
         def _parse_shipping_first_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_first_name = _parse_shipping_first_name(d.pop("ShippingFirstName", None))
-
         def _parse_shipping_last_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_last_name = _parse_shipping_last_name(d.pop("ShippingLastName", None))
-
         def _parse_shipping_email(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_email = _parse_shipping_email(d.pop("ShippingEmail", None))
-
         def _parse_shipping_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_company = _parse_shipping_company(d.pop("ShippingCompany", None))
-
         def _parse_shipping_city(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_city = _parse_shipping_city(d.pop("ShippingCity", None))
-
         def _parse_shipping_zip(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_zip = _parse_shipping_zip(d.pop("ShippingZip", None))
-
         def _parse_shipping_phone_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_phone_number = _parse_shipping_phone_number(d.pop("ShippingPhoneNumber", None))
-
         def _parse_shipping_fax_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_fax_number = _parse_shipping_fax_number(d.pop("ShippingFaxNumber", None))
-
         def _parse_shipping_country(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_country = _parse_shipping_country(d.pop("ShippingCountry", None))
-
         def _parse_shipping_state(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipping_state = _parse_shipping_state(d.pop("ShippingState", None))
-
         def _parse_asset_service_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_service_notes = _parse_asset_service_notes(d.pop("AssetServiceNotes", None))
-
         def _parse_service_option_service_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_option_service_code = _parse_service_option_service_code(
             d.pop("ServiceOptionServiceCode", None)
         )
-
         qualer_api_models_report_datasets_to_service_order_item_response = cls(
             certificate_number=certificate_number,
             document_number=document_number,
@@ -2198,7 +1575,6 @@ class ReportDatasetsToServiceOrderItemResponse:
             asset_service_notes=asset_service_notes,
             service_option_service_code=service_option_service_code,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_response.additional_properties = d
         return qualer_api_models_report_datasets_to_service_order_item_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_status_history_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_status_history_response.py
@@ -41,31 +41,20 @@ class ReportDatasetsToServiceOrderItemStatusHistoryResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         previous_status_name = self.previous_status_name
-
         selected_status_name = self.selected_status_name
-
         explanation = self.explanation
-
         is_password_reentered = self.is_password_reentered
-
         created_on: Optional[str] = None
         if self.created_on:
             created_on = self.created_on.isoformat()
-
         created_on_utc: Optional[str] = None
         if self.created_on_utc:
             created_on_utc = self.created_on_utc.isoformat()
-
         employee_id = self.employee_id
-
         first_name = self.first_name
-
         last_name = self.last_name
-
         alias = self.alias
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -91,44 +80,32 @@ class ReportDatasetsToServiceOrderItemStatusHistoryResponse:
             field_dict["LastName"] = last_name
         if alias is not None:
             field_dict["Alias"] = alias
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         previous_status_name = d.pop("PreviousStatusName", None)
-
         selected_status_name = d.pop("SelectedStatusName", None)
-
         explanation = d.pop("Explanation", None)
-
         is_password_reentered = d.pop("IsPasswordReentered", None)
-
         _created_on = d.pop("CreatedOn", None)
         created_on: Optional[datetime.datetime]
         if not _created_on:
             created_on = None
         else:
             created_on = isoparse(_created_on)
-
         _created_on_utc = d.pop("CreatedOnUtc", None)
         created_on_utc: Optional[datetime.datetime]
         if not _created_on_utc:
             created_on_utc = None
         else:
             created_on_utc = isoparse(_created_on_utc)
-
         employee_id = d.pop("EmployeeId", None)
-
         first_name = d.pop("FirstName", None)
-
         last_name = d.pop("LastName", None)
-
         alias = d.pop("Alias", None)
-
         qualer_api_models_report_datasets_to_service_order_item_status_history_response = cls(
             service_order_item_id=service_order_item_id,
             previous_status_name=previous_status_name,
@@ -142,7 +119,6 @@ class ReportDatasetsToServiceOrderItemStatusHistoryResponse:
             last_name=last_name,
             alias=alias,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_status_history_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_item_task_response.py
@@ -41,29 +41,17 @@ class ReportDatasetsToServiceOrderItemTaskResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         service_order_item_id = self.service_order_item_id
-
         service_charge = self.service_charge
-
         time_spent = self.time_spent
-
         is_hourly = self.is_hourly
-
         as_found_details = self.as_found_details
-
         as_left_details = self.as_left_details
-
         price = self.price
-
         task_name = self.task_name
-
         task_description = self.task_description
-
         level_description = self.level_description
-
         custom_text_value = self.custom_text_value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -91,36 +79,23 @@ class ReportDatasetsToServiceOrderItemTaskResponse:
             field_dict["LevelDescription"] = level_description
         if custom_text_value is not None:
             field_dict["CustomTextValue"] = custom_text_value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         service_charge = d.pop("ServiceCharge", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         as_found_details = d.pop("AsFoundDetails", None)
-
         as_left_details = d.pop("AsLeftDetails", None)
-
         price = d.pop("Price", None)
-
         task_name = d.pop("TaskName", None)
-
         task_description = d.pop("TaskDescription", None)
-
         level_description = d.pop("LevelDescription", None)
-
         custom_text_value = d.pop("CustomTextValue", None)
-
         qualer_api_models_report_datasets_to_service_order_item_task_response = cls(
             id=id,
             service_order_item_id=service_order_item_id,
@@ -135,7 +110,6 @@ class ReportDatasetsToServiceOrderItemTaskResponse:
             level_description=level_description,
             custom_text_value=custom_text_value,
         )
-
         qualer_api_models_report_datasets_to_service_order_item_task_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_response.py
@@ -364,531 +364,182 @@ class ReportDatasetsToServiceOrderResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         guid = self.guid
-
         account_number = self.account_number
-
         service_order_number = self.service_order_number
-
         service_order_number_text = self.service_order_number_text
-
         number_of_instruments = self.number_of_instruments
-
         parts_discount_total = self.parts_discount_total
-
         po_number = self.po_number
-
         secondary_po = self.secondary_po
-
         location = self.location
-
-        shipped_date: Optional[str]
-        if not self.shipped_date:
-            shipped_date = None
-        elif isinstance(self.shipped_date, datetime.datetime):
-            shipped_date = self.shipped_date.isoformat()
-        else:
-            shipped_date = self.shipped_date
-
+        shipped_date = self.shipped_date.isoformat() if self.shipped_date else None
         payment_terms = self.payment_terms
-
         site_access_notes = self.site_access_notes
-
         grace_period = self.grace_period
-
         trade_in_credit = self.trade_in_credit
-
         prepaid_credit = self.prepaid_credit
-
         interest_rate = self.interest_rate
-
         service_taxation = self.service_taxation
-
         service_order_id = self.service_order_id
-
         federal_number = self.federal_number
-
         vendor_site_id = self.vendor_site_id
-
         vendor_site = self.vendor_site
-
         site_name = self.site_name
-
         site_code = self.site_code
-
         vendor_name = self.vendor_name
-
         domain_name = self.domain_name
-
         client_company_domain = self.client_company_domain
-
         provider_logo = self.provider_logo
-
         client_signature = self.client_signature
-
         vendor_signature = self.vendor_signature
-
         qr_code = self.qr_code
-
         bar_code = self.bar_code
-
         bar_code_string = self.bar_code_string
-
         po_balance = self.po_balance
-
         service_terms = self.service_terms
-
         service_total = self.service_total
-
         repairs_total = self.repairs_total
-
         parts_total = self.parts_total
-
         parts_total_before_discount = self.parts_total_before_discount
-
         effective_tax_rate = self.effective_tax_rate
-
         tax_amount = self.tax_amount
-
         shipping_fee = self.shipping_fee
-
         late_fee = self.late_fee
-
         grand_total = self.grand_total
-
         amount_paid = self.amount_paid
-
         balance_total = self.balance_total
-
         travel_charge = self.travel_charge
-
         private_notes = self.private_notes
-
         service_notes = self.service_notes
-
         display_service_comments = self.display_service_comments
-
         display_part_repairs = self.display_part_repairs
-
         print_separate_measurement = self.print_separate_measurement
-
         billing_address_1 = self.billing_address_1
-
         billing_address_2 = self.billing_address_2
-
         billing_first_name = self.billing_first_name
-
         billing_last_name = self.billing_last_name
-
         billing_company = self.billing_company
-
         billing_country = self.billing_country
-
         billing_city = self.billing_city
-
         billing_state = self.billing_state
-
         billing_zip = self.billing_zip
-
         billing_phone_number = self.billing_phone_number
-
         billing_fax_number = self.billing_fax_number
-
         billing_email = self.billing_email
-
         shipping_address_1 = self.shipping_address_1
-
         shipping_address_2 = self.shipping_address_2
-
         shipping_first_name = self.shipping_first_name
-
         shipping_last_name = self.shipping_last_name
-
         shipping_email = self.shipping_email
-
         shipping_company = self.shipping_company
-
         shipping_city = self.shipping_city
-
         shipping_zip = self.shipping_zip
-
         shipping_phone_number = self.shipping_phone_number
-
         shipping_fax_number = self.shipping_fax_number
-
         shipping_country = self.shipping_country
-
         shipping_state = self.shipping_state
-
         shipping_method = self.shipping_method
-
         return_shipping_method = self.return_shipping_method
-
         tracking_number = self.tracking_number
-
         provider_billing_address_1 = self.provider_billing_address_1
-
         provider_billing_address_2 = self.provider_billing_address_2
-
         provider_billing_first_name = self.provider_billing_first_name
-
         provider_billing_last_name = self.provider_billing_last_name
-
         provider_billing_email = self.provider_billing_email
-
         provider_billing_company = self.provider_billing_company
-
         provider_billing_city = self.provider_billing_city
-
         provider_billing_zip = self.provider_billing_zip
-
         provider_billing_phone_number = self.provider_billing_phone_number
-
         provider_billing_country = self.provider_billing_country
-
         provider_billing_state = self.provider_billing_state
-
         provider_billing_fax_number = self.provider_billing_fax_number
-
         provider_shipping_address_1 = self.provider_shipping_address_1
-
         provider_shipping_address_2 = self.provider_shipping_address_2
-
         provider_shipping_first_name = self.provider_shipping_first_name
-
         provider_shipping_last_name = self.provider_shipping_last_name
-
         provider_shipping_email = self.provider_shipping_email
-
         provider_shipping_company = self.provider_shipping_company
-
         provider_shipping_city = self.provider_shipping_city
-
         provider_shipping_zip = self.provider_shipping_zip
-
         provider_shipping_phone_number = self.provider_shipping_phone_number
-
         provider_shipping_country = self.provider_shipping_country
-
         provider_shipping_state = self.provider_shipping_state
-
         provider_shipping_fax_number = self.provider_shipping_fax_number
-
         culture_name = self.culture_name
-
         vendor_company_id = self.vendor_company_id
-
         client_vendor_id = self.client_vendor_id
-
-        sign_off_date: Optional[str]
-        if not self.sign_off_date:
-            sign_off_date = None
-        elif isinstance(self.sign_off_date, datetime.datetime):
-            sign_off_date = self.sign_off_date.isoformat()
-        else:
-            sign_off_date = self.sign_off_date
-
+        sign_off_date = self.sign_off_date.isoformat() if self.sign_off_date else None
         quality_control_date: Optional[str] = None
         if self.quality_control_date:
             quality_control_date = self.quality_control_date.isoformat()
-
-        client_sign_off_on: Optional[str]
-        if not self.client_sign_off_on:
-            client_sign_off_on = None
-        elif isinstance(self.client_sign_off_on, datetime.datetime):
-            client_sign_off_on = self.client_sign_off_on.isoformat()
-        else:
-            client_sign_off_on = self.client_sign_off_on
-
+        client_sign_off_on = self.client_sign_off_on.isoformat() if self.client_sign_off_on else None
         client_sign_off_by_name = self.client_sign_off_by_name
-
-        client_signed_on: Optional[str]
-        if not self.client_signed_on:
-            client_signed_on = None
-        elif isinstance(self.client_signed_on, datetime.datetime):
-            client_signed_on = self.client_signed_on.isoformat()
-        else:
-            client_signed_on = self.client_signed_on
-
+        client_signed_on = self.client_signed_on.isoformat() if self.client_signed_on else None
         client_sticker_notes = self.client_sticker_notes
-
         asset_sticker_notes = self.asset_sticker_notes
-
         order_sticker_notes = self.order_sticker_notes
-
         quality_control_name = self.quality_control_name
-
         fulfilled_by_name = self.fulfilled_by_name
-
         sign_off_name = self.sign_off_name
-
         display_as_found = self.display_as_found
-
         display_as_left = self.display_as_left
-
         created_on: Optional[str] = None
         if self.created_on:
             created_on = self.created_on.isoformat()
-
-        invoiced_on: Optional[str]
-        if not self.invoiced_on:
-            invoiced_on = None
-        elif isinstance(self.invoiced_on, datetime.datetime):
-            invoiced_on = self.invoiced_on.isoformat()
-        else:
-            invoiced_on = self.invoiced_on
-
-        submitted_on: Optional[str]
-        if not self.submitted_on:
-            submitted_on = None
-        elif isinstance(self.submitted_on, datetime.datetime):
-            submitted_on = self.submitted_on.isoformat()
-        else:
-            submitted_on = self.submitted_on
-
-        shipped_on: Optional[str]
-        if not self.shipped_on:
-            shipped_on = None
-        elif isinstance(self.shipped_on, datetime.datetime):
-            shipped_on = self.shipped_on.isoformat()
-        else:
-            shipped_on = self.shipped_on
-
-        completed_on: Optional[str]
-        if not self.completed_on:
-            completed_on = None
-        elif isinstance(self.completed_on, datetime.datetime):
-            completed_on = self.completed_on.isoformat()
-        else:
-            completed_on = self.completed_on
-
-        accepted_on: Optional[str]
-        if not self.accepted_on:
-            accepted_on = None
-        elif isinstance(self.accepted_on, datetime.datetime):
-            accepted_on = self.accepted_on.isoformat()
-        else:
-            accepted_on = self.accepted_on
-
-        approved_on: Optional[str]
-        if not self.approved_on:
-            approved_on = None
-        elif isinstance(self.approved_on, datetime.datetime):
-            approved_on = self.approved_on.isoformat()
-        else:
-            approved_on = self.approved_on
-
-        delivered_on: Optional[str]
-        if not self.delivered_on:
-            delivered_on = None
-        elif isinstance(self.delivered_on, datetime.datetime):
-            delivered_on = self.delivered_on.isoformat()
-        else:
-            delivered_on = self.delivered_on
-
-        paid_on: Optional[str]
-        if not self.paid_on:
-            paid_on = None
-        elif isinstance(self.paid_on, datetime.datetime):
-            paid_on = self.paid_on.isoformat()
-        else:
-            paid_on = self.paid_on
-
-        cancelled_on: Optional[str]
-        if not self.cancelled_on:
-            cancelled_on = None
-        elif isinstance(self.cancelled_on, datetime.datetime):
-            cancelled_on = self.cancelled_on.isoformat()
-        else:
-            cancelled_on = self.cancelled_on
-
-        fulfilled_on: Optional[str]
-        if not self.fulfilled_on:
-            fulfilled_on = None
-        elif isinstance(self.fulfilled_on, datetime.datetime):
-            fulfilled_on = self.fulfilled_on.isoformat()
-        else:
-            fulfilled_on = self.fulfilled_on
-
-        sign_off_on: Optional[str]
-        if not self.sign_off_on:
-            sign_off_on = None
-        elif isinstance(self.sign_off_on, datetime.datetime):
-            sign_off_on = self.sign_off_on.isoformat()
-        else:
-            sign_off_on = self.sign_off_on
-
-        vendor_signed_on: Optional[str]
-        if not self.vendor_signed_on:
-            vendor_signed_on = None
-        elif isinstance(self.vendor_signed_on, datetime.datetime):
-            vendor_signed_on = self.vendor_signed_on.isoformat()
-        else:
-            vendor_signed_on = self.vendor_signed_on
-
-        client_notes: Optional[str]
-        if not self.client_notes:
-            client_notes = None
-        else:
-            client_notes = self.client_notes
-
+        invoiced_on = self.invoiced_on.isoformat() if self.invoiced_on else None
+        submitted_on = self.submitted_on.isoformat() if self.submitted_on else None
+        shipped_on = self.shipped_on.isoformat() if self.shipped_on else None
+        completed_on = self.completed_on.isoformat() if self.completed_on else None
+        accepted_on = self.accepted_on.isoformat() if self.accepted_on else None
+        approved_on = self.approved_on.isoformat() if self.approved_on else None
+        delivered_on = self.delivered_on.isoformat() if self.delivered_on else None
+        paid_on = self.paid_on.isoformat() if self.paid_on else None
+        cancelled_on = self.cancelled_on.isoformat() if self.cancelled_on else None
+        fulfilled_on = self.fulfilled_on.isoformat() if self.fulfilled_on else None
+        sign_off_on = self.sign_off_on.isoformat() if self.sign_off_on else None
+        vendor_signed_on = self.vendor_signed_on.isoformat() if self.vendor_signed_on else None
+        client_notes = self.client_notes
         order_shipping_option = self.order_shipping_option
-
         shipment_status = self.shipment_status
-
         payment_status = self.payment_status
-
         payment_option = self.payment_option
-
         order_status = self.order_status
-
         created_by_name = self.created_by_name
-
-        completed_by_name: Optional[str]
-        if not self.completed_by_name:
-            completed_by_name = None
-        else:
-            completed_by_name = self.completed_by_name
-
-        shipped_by_name: Optional[str]
-        if not self.shipped_by_name:
-            shipped_by_name = None
-        else:
-            shipped_by_name = self.shipped_by_name
-
-        accepted_by_name: Optional[str]
-        if not self.accepted_by_name:
-            accepted_by_name = None
-        else:
-            accepted_by_name = self.accepted_by_name
-
-        approve_by_name: Optional[str]
-        if not self.approve_by_name:
-            approve_by_name = None
-        else:
-            approve_by_name = self.approve_by_name
-
-        invoiced_by_name: Optional[str]
-        if not self.invoiced_by_name:
-            invoiced_by_name = None
-        else:
-            invoiced_by_name = self.invoiced_by_name
-
-        delivered_by_name: Optional[str]
-        if not self.delivered_by_name:
-            delivered_by_name = None
-        else:
-            delivered_by_name = self.delivered_by_name
-
-        paid_by_name: Optional[str]
-        if not self.paid_by_name:
-            paid_by_name = None
-        else:
-            paid_by_name = self.paid_by_name
-
-        cancelled_by_name: Optional[str]
-        if not self.cancelled_by_name:
-            cancelled_by_name = None
-        else:
-            cancelled_by_name = self.cancelled_by_name
-
-        sign_off_by_name: Optional[str]
-        if not self.sign_off_by_name:
-            sign_off_by_name = None
-        else:
-            sign_off_by_name = self.sign_off_by_name
-
-        owner_name: Optional[str]
-        if not self.owner_name:
-            owner_name = None
-        else:
-            owner_name = self.owner_name
-
-        owner_department: Optional[str]
-        if not self.owner_department:
-            owner_department = None
-        else:
-            owner_department = self.owner_department
-
-        assignee_name: Optional[str]
-        if not self.assignee_name:
-            assignee_name = None
-        else:
-            assignee_name = self.assignee_name
-
-        payment_due_on: Optional[str]
-        if not self.payment_due_on:
-            payment_due_on = None
-        elif isinstance(self.payment_due_on, datetime.datetime):
-            payment_due_on = self.payment_due_on.isoformat()
-        else:
-            payment_due_on = self.payment_due_on
-
+        completed_by_name = self.completed_by_name
+        shipped_by_name = self.shipped_by_name
+        accepted_by_name = self.accepted_by_name
+        approve_by_name = self.approve_by_name
+        invoiced_by_name = self.invoiced_by_name
+        delivered_by_name = self.delivered_by_name
+        paid_by_name = self.paid_by_name
+        cancelled_by_name = self.cancelled_by_name
+        sign_off_by_name = self.sign_off_by_name
+        owner_name = self.owner_name
+        owner_department = self.owner_department
+        assignee_name = self.assignee_name
+        payment_due_on = self.payment_due_on.isoformat() if self.payment_due_on else None
         process_date_option = self.process_date_option
-
-        desired_date: Optional[str]
-        if not self.desired_date:
-            desired_date = None
-        elif isinstance(self.desired_date, datetime.datetime):
-            desired_date = self.desired_date.isoformat()
-        else:
-            desired_date = self.desired_date
-
-        deadline_date: Optional[str]
-        if not self.deadline_date:
-            deadline_date = None
-        elif isinstance(self.deadline_date, datetime.datetime):
-            deadline_date = self.deadline_date.isoformat()
-        else:
-            deadline_date = self.deadline_date
-
+        desired_date = self.desired_date.isoformat() if self.desired_date else None
+        deadline_date = self.deadline_date.isoformat() if self.deadline_date else None
         vendor_sign_off_on: Optional[str] = None
         if self.vendor_sign_off_on:
             vendor_sign_off_on = self.vendor_sign_off_on.isoformat()
-
         vendor_sign_off_by_name = self.vendor_sign_off_by_name
-
         service_discount = self.service_discount
-
         return_account = self.return_account
-
-        business_hours_from: Optional[str]
-        if not self.business_hours_from:
-            business_hours_from = None
-        elif isinstance(self.business_hours_from, datetime.datetime):
-            business_hours_from = self.business_hours_from.isoformat()
-        else:
-            business_hours_from = self.business_hours_from
-
-        business_hours_to: Optional[str]
-        if not self.business_hours_to:
-            business_hours_to = None
-        elif isinstance(self.business_hours_to, datetime.datetime):
-            business_hours_to = self.business_hours_to.isoformat()
-        else:
-            business_hours_to = self.business_hours_to
-
+        business_hours_from = self.business_hours_from.isoformat() if self.business_hours_from else None
+        business_hours_to = self.business_hours_to.isoformat() if self.business_hours_to else None
         client_company_alternative_names = self.client_company_alternative_names
-
         client_id = self.client_id
-
         client_class = self.client_class
-
         client_status = self.client_status
-
         client_invoicing = self.client_invoicing
-
         client_standing = self.client_standing
-
         client_category = self.client_category
-
         master_template_name = self.master_template_name
-
         client_site_code = self.client_site_code
-
         order_workflow_name = self.order_workflow_name
-
         request_workflow_name = self.request_workflow_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -1234,30 +885,20 @@ class ReportDatasetsToServiceOrderResponse:
             field_dict["OrderWorkflowName"] = order_workflow_name
         if request_workflow_name is not None:
             field_dict["RequestWorkflowName"] = request_workflow_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         guid = d.pop("Guid", None)
-
         account_number = d.pop("AccountNumber", None)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         service_order_number_text = d.pop("ServiceOrderNumberText", None)
-
         number_of_instruments = d.pop("NumberOfInstruments", None)
-
         parts_discount_total = d.pop("PartsDiscountTotal", None)
-
         po_number = d.pop("PoNumber", None)
-
         secondary_po = d.pop("SecondaryPo", None)
-
         location = d.pop("Location", None)
-
         def _parse_shipped_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1265,204 +906,106 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 shipped_date_type_0 = isoparse(data)
-
                 return shipped_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         shipped_date = _parse_shipped_date(d.pop("ShippedDate", None))
-
         payment_terms = d.pop("PaymentTerms", None)
-
         site_access_notes = d.pop("SiteAccessNotes", None)
-
         grace_period = d.pop("GracePeriod", None)
-
         trade_in_credit = d.pop("TradeInCredit", None)
-
         prepaid_credit = d.pop("PrepaidCredit", None)
-
         interest_rate = d.pop("InterestRate", None)
-
         service_taxation = d.pop("ServiceTaxation", None)
-
         service_order_id = d.pop("ServiceOrderId", None)
-
         federal_number = d.pop("FederalNumber", None)
-
         vendor_site_id = d.pop("VendorSiteId", None)
-
         vendor_site = d.pop("VendorSite", None)
-
         site_name = d.pop("SiteName", None)
-
         site_code = d.pop("SiteCode", None)
-
         vendor_name = d.pop("VendorName", None)
-
         domain_name = d.pop("DomainName", None)
-
         client_company_domain = d.pop("ClientCompanyDomain", None)
-
         provider_logo = d.pop("ProviderLogo", None)
-
         client_signature = d.pop("ClientSignature", None)
-
         vendor_signature = d.pop("VendorSignature", None)
-
         qr_code = d.pop("QrCode", None)
-
         bar_code = d.pop("BarCode", None)
-
         bar_code_string = d.pop("BarCodeString", None)
-
         po_balance = d.pop("PoBalance", None)
-
         service_terms = d.pop("ServiceTerms", None)
-
         service_total = d.pop("ServiceTotal", None)
-
         repairs_total = d.pop("RepairsTotal", None)
-
         parts_total = d.pop("PartsTotal", None)
-
         parts_total_before_discount = d.pop("PartsTotalBeforeDiscount", None)
-
         effective_tax_rate = d.pop("EffectiveTaxRate", None)
-
         tax_amount = d.pop("TaxAmount", None)
-
         shipping_fee = d.pop("ShippingFee", None)
-
         late_fee = d.pop("LateFee", None)
-
         grand_total = d.pop("GrandTotal", None)
-
         amount_paid = d.pop("AmountPaid", None)
-
         balance_total = d.pop("BalanceTotal", None)
-
         travel_charge = d.pop("TravelCharge", None)
-
         private_notes = d.pop("PrivateNotes", None)
-
         service_notes = d.pop("ServiceNotes", None)
-
         display_service_comments = d.pop("DisplayServiceComments", None)
-
         display_part_repairs = d.pop("DisplayPartRepairs", None)
-
         print_separate_measurement = d.pop("PrintSeparateMeasurement", None)
-
         billing_address_1 = d.pop("BillingAddress1", None)
-
         billing_address_2 = d.pop("BillingAddress2", None)
-
         billing_first_name = d.pop("BillingFirstName", None)
-
         billing_last_name = d.pop("BillingLastName", None)
-
         billing_company = d.pop("BillingCompany", None)
-
         billing_country = d.pop("BillingCountry", None)
-
         billing_city = d.pop("BillingCity", None)
-
         billing_state = d.pop("BillingState", None)
-
         billing_zip = d.pop("BillingZip", None)
-
         billing_phone_number = d.pop("BillingPhoneNumber", None)
-
         billing_fax_number = d.pop("BillingFaxNumber", None)
-
         billing_email = d.pop("BillingEmail", None)
-
         shipping_address_1 = d.pop("ShippingAddress1", None)
-
         shipping_address_2 = d.pop("ShippingAddress2", None)
-
         shipping_first_name = d.pop("ShippingFirstName", None)
-
         shipping_last_name = d.pop("ShippingLastName", None)
-
         shipping_email = d.pop("ShippingEmail", None)
-
         shipping_company = d.pop("ShippingCompany", None)
-
         shipping_city = d.pop("ShippingCity", None)
-
         shipping_zip = d.pop("ShippingZip", None)
-
         shipping_phone_number = d.pop("ShippingPhoneNumber", None)
-
         shipping_fax_number = d.pop("ShippingFaxNumber", None)
-
         shipping_country = d.pop("ShippingCountry", None)
-
         shipping_state = d.pop("ShippingState", None)
-
         shipping_method = d.pop("ShippingMethod", None)
-
         return_shipping_method = d.pop("ReturnShippingMethod", None)
-
         tracking_number = d.pop("TrackingNumber", None)
-
         provider_billing_address_1 = d.pop("ProviderBillingAddress1", None)
-
         provider_billing_address_2 = d.pop("ProviderBillingAddress2", None)
-
         provider_billing_first_name = d.pop("ProviderBillingFirstName", None)
-
         provider_billing_last_name = d.pop("ProviderBillingLastName", None)
-
         provider_billing_email = d.pop("ProviderBillingEmail", None)
-
         provider_billing_company = d.pop("ProviderBillingCompany", None)
-
         provider_billing_city = d.pop("ProviderBillingCity", None)
-
         provider_billing_zip = d.pop("ProviderBillingZip", None)
-
         provider_billing_phone_number = d.pop("ProviderBillingPhoneNumber", None)
-
         provider_billing_country = d.pop("ProviderBillingCountry", None)
-
         provider_billing_state = d.pop("ProviderBillingState", None)
-
         provider_billing_fax_number = d.pop("ProviderBillingFaxNumber", None)
-
         provider_shipping_address_1 = d.pop("ProviderShippingAddress1", None)
-
         provider_shipping_address_2 = d.pop("ProviderShippingAddress2", None)
-
         provider_shipping_first_name = d.pop("ProviderShippingFirstName", None)
-
         provider_shipping_last_name = d.pop("ProviderShippingLastName", None)
-
         provider_shipping_email = d.pop("ProviderShippingEmail", None)
-
         provider_shipping_company = d.pop("ProviderShippingCompany", None)
-
         provider_shipping_city = d.pop("ProviderShippingCity", None)
-
         provider_shipping_zip = d.pop("ProviderShippingZip", None)
-
         provider_shipping_phone_number = d.pop("ProviderShippingPhoneNumber", None)
-
         provider_shipping_country = d.pop("ProviderShippingCountry", None)
-
         provider_shipping_state = d.pop("ProviderShippingState", None)
-
         provider_shipping_fax_number = d.pop("ProviderShippingFaxNumber", None)
-
         culture_name = d.pop("CultureName", None)
-
         vendor_company_id = d.pop("VendorCompanyId", None)
-
         client_vendor_id = d.pop("ClientVendorId", None)
-
         def _parse_sign_off_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1470,14 +1013,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 sign_off_date_type_0 = isoparse(data)
-
                 return sign_off_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         sign_off_date = _parse_sign_off_date(d.pop("SignOffDate", None))
-
         _quality_control_date = d.pop("QualityControlDate", None)
         quality_control_date: Optional[datetime.datetime]
         if not _quality_control_date:
@@ -1486,7 +1026,6 @@ class ReportDatasetsToServiceOrderResponse:
             quality_control_date = None
         else:
             quality_control_date = isoparse(_quality_control_date)
-
         def _parse_client_sign_off_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1496,16 +1035,12 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 client_sign_off_on_type_0 = isoparse(data)
-
                 return client_sign_off_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         client_sign_off_on = _parse_client_sign_off_on(d.pop("ClientSignOffOn", None))
-
         client_sign_off_by_name = d.pop("ClientSignOffByName", None)
-
         def _parse_client_signed_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1515,37 +1050,25 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 client_signed_on_type_0 = isoparse(data)
-
                 return client_signed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         client_signed_on = _parse_client_signed_on(d.pop("ClientSignedOn", None))
-
         client_sticker_notes = d.pop("ClientStickerNotes", None)
-
         asset_sticker_notes = d.pop("AssetStickerNotes", None)
-
         order_sticker_notes = d.pop("OrderStickerNotes", None)
-
         quality_control_name = d.pop("QualityControlName", None)
-
         fulfilled_by_name = d.pop("FulfilledByName", None)
-
         sign_off_name = d.pop("SignOffName", None)
-
         display_as_found = d.pop("DisplayAsFound", None)
-
         display_as_left = d.pop("DisplayAsLeft", None)
-
         _created_on = d.pop("CreatedOn", None)
         created_on: Optional[datetime.datetime]
         if not _created_on:
             created_on = None
         else:
             created_on = isoparse(_created_on)
-
         def _parse_invoiced_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1553,14 +1076,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 invoiced_on_type_0 = isoparse(data)
-
                 return invoiced_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         invoiced_on = _parse_invoiced_on(d.pop("InvoicedOn", None))
-
         def _parse_submitted_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1568,14 +1088,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 submitted_on_type_0 = isoparse(data)
-
                 return submitted_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         submitted_on = _parse_submitted_on(d.pop("SubmittedOn", None))
-
         def _parse_shipped_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1583,14 +1100,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 shipped_on_type_0 = isoparse(data)
-
                 return shipped_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         shipped_on = _parse_shipped_on(d.pop("ShippedOn", None))
-
         def _parse_completed_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1598,14 +1112,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 completed_on_type_0 = isoparse(data)
-
                 return completed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         completed_on = _parse_completed_on(d.pop("CompletedOn", None))
-
         def _parse_accepted_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1613,14 +1124,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 accepted_on_type_0 = isoparse(data)
-
                 return accepted_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         accepted_on = _parse_accepted_on(d.pop("AcceptedOn", None))
-
         def _parse_approved_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1628,14 +1136,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 approved_on_type_0 = isoparse(data)
-
                 return approved_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         approved_on = _parse_approved_on(d.pop("ApprovedOn", None))
-
         def _parse_delivered_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1643,14 +1148,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 delivered_on_type_0 = isoparse(data)
-
                 return delivered_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         delivered_on = _parse_delivered_on(d.pop("DeliveredOn", None))
-
         def _parse_paid_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1658,14 +1160,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 paid_on_type_0 = isoparse(data)
-
                 return paid_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         paid_on = _parse_paid_on(d.pop("PaidOn", None))
-
         def _parse_cancelled_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1673,14 +1172,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 cancelled_on_type_0 = isoparse(data)
-
                 return cancelled_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         cancelled_on = _parse_cancelled_on(d.pop("CancelledOn", None))
-
         def _parse_fulfilled_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1688,14 +1184,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 fulfilled_on_type_0 = isoparse(data)
-
                 return fulfilled_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         fulfilled_on = _parse_fulfilled_on(d.pop("FulfilledOn", None))
-
         def _parse_sign_off_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1703,14 +1196,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 sign_off_on_type_0 = isoparse(data)
-
                 return sign_off_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         sign_off_on = _parse_sign_off_on(d.pop("SignOffOn", None))
-
         def _parse_vendor_signed_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1720,117 +1210,82 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 vendor_signed_on_type_0 = isoparse(data)
-
                 return vendor_signed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         vendor_signed_on = _parse_vendor_signed_on(d.pop("VendorSignedOn", None))
-
         def _parse_client_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         client_notes = _parse_client_notes(d.pop("ClientNotes", None))
-
         order_shipping_option = d.pop("OrderShippingOption", None)
-
         shipment_status = d.pop("ShipmentStatus", None)
-
         payment_status = d.pop("PaymentStatus", None)
-
         payment_option = d.pop("PaymentOption", None)
-
         order_status = d.pop("OrderStatus", None)
-
         created_by_name = d.pop("CreatedByName", None)
-
         def _parse_completed_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         completed_by_name = _parse_completed_by_name(d.pop("CompletedByName", None))
-
         def _parse_shipped_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         shipped_by_name = _parse_shipped_by_name(d.pop("ShippedByName", None))
-
         def _parse_accepted_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         accepted_by_name = _parse_accepted_by_name(d.pop("AcceptedByName", None))
-
         def _parse_approve_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         approve_by_name = _parse_approve_by_name(d.pop("ApproveByName", None))
-
         def _parse_invoiced_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         invoiced_by_name = _parse_invoiced_by_name(d.pop("InvoicedByName", None))
-
         def _parse_delivered_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         delivered_by_name = _parse_delivered_by_name(d.pop("DeliveredByName", None))
-
         def _parse_paid_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         paid_by_name = _parse_paid_by_name(d.pop("PaidByName", None))
-
         def _parse_cancelled_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         cancelled_by_name = _parse_cancelled_by_name(d.pop("CancelledByName", None))
-
         def _parse_sign_off_by_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         sign_off_by_name = _parse_sign_off_by_name(d.pop("SignOffByName", None))
-
         def _parse_owner_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         owner_name = _parse_owner_name(d.pop("OwnerName", None))
-
         def _parse_owner_department(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         owner_department = _parse_owner_department(d.pop("OwnerDepartment", None))
-
         def _parse_assignee_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         assignee_name = _parse_assignee_name(d.pop("AssigneeName", None))
-
         def _parse_payment_due_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1840,16 +1295,12 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 payment_due_on_type_0 = isoparse(data)
-
                 return payment_due_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         payment_due_on = _parse_payment_due_on(d.pop("PaymentDueOn", None))
-
         process_date_option = d.pop("ProcessDateOption", None)
-
         def _parse_desired_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1857,14 +1308,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 desired_date_type_0 = isoparse(data)
-
                 return desired_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         desired_date = _parse_desired_date(d.pop("DesiredDate", None))
-
         def _parse_deadline_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1872,27 +1320,20 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 deadline_date_type_0 = isoparse(data)
-
                 return deadline_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         deadline_date = _parse_deadline_date(d.pop("DeadlineDate", None))
-
         _vendor_sign_off_on = d.pop("VendorSignOffOn", None)
         vendor_sign_off_on: Optional[datetime.datetime]
         if not _vendor_sign_off_on:
             vendor_sign_off_on = None
         else:
             vendor_sign_off_on = isoparse(_vendor_sign_off_on)
-
         vendor_sign_off_by_name = d.pop("VendorSignOffByName", None)
-
         service_discount = d.pop("ServiceDiscount", None)
-
         return_account = d.pop("ReturnAccount", None)
-
         def _parse_business_hours_from(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1902,14 +1343,11 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_hours_from_type_0 = isoparse(data)
-
                 return business_hours_from_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_hours_from = _parse_business_hours_from(d.pop("BusinessHoursFrom", None))
-
         def _parse_business_hours_to(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1919,36 +1357,22 @@ class ReportDatasetsToServiceOrderResponse:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_hours_to_type_0 = isoparse(data)
-
                 return business_hours_to_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_hours_to = _parse_business_hours_to(d.pop("BusinessHoursTo", None))
-
         client_company_alternative_names = d.pop("ClientCompanyAlternativeNames", None)
-
         client_id = d.pop("ClientId", None)
-
         client_class = d.pop("ClientClass", None)
-
         client_status = d.pop("ClientStatus", None)
-
         client_invoicing = d.pop("ClientInvoicing", None)
-
         client_standing = d.pop("ClientStanding", None)
-
         client_category = d.pop("ClientCategory", None)
-
         master_template_name = d.pop("MasterTemplateName", None)
-
         client_site_code = d.pop("ClientSiteCode", None)
-
         order_workflow_name = d.pop("OrderWorkflowName", None)
-
         request_workflow_name = d.pop("RequestWorkflowName", None)
-
         qualer_api_models_report_datasets_to_service_order_response = cls(
             guid=guid,
             account_number=account_number,
@@ -2122,7 +1546,6 @@ class ReportDatasetsToServiceOrderResponse:
             order_workflow_name=order_workflow_name,
             request_workflow_name=request_workflow_name,
         )
-
         qualer_api_models_report_datasets_to_service_order_response.additional_properties = d
         return qualer_api_models_report_datasets_to_service_order_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_service_order_task_response.py
@@ -33,21 +33,13 @@ class ReportDatasetsToServiceOrderTaskResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         task_name = self.task_name
-
         task_order = self.task_order
-
         task_details = self.task_details
-
         time_spent = self.time_spent
-
         time_spent_hours = self.time_spent_hours
-
         time_spent_minutes = self.time_spent_minutes
-
         price = self.price
-
         is_hourly = self.is_hourly
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class ReportDatasetsToServiceOrderTaskResponse:
             field_dict["Price"] = price
         if is_hourly is not None:
             field_dict["IsHourly"] = is_hourly
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         task_name = d.pop("TaskName", None)
-
         task_order = d.pop("TaskOrder", None)
-
         task_details = d.pop("TaskDetails", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         time_spent_hours = d.pop("TimeSpentHours", None)
-
         time_spent_minutes = d.pop("TimeSpentMinutes", None)
-
         price = d.pop("Price", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         qualer_api_models_report_datasets_to_service_order_task_response = cls(
             task_name=task_name,
             task_order=task_order,
@@ -99,7 +82,6 @@ class ReportDatasetsToServiceOrderTaskResponse:
             price=price,
             is_hourly=is_hourly,
         )
-
         qualer_api_models_report_datasets_to_service_order_task_response.additional_properties = d
         return qualer_api_models_report_datasets_to_service_order_task_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_attribute_response.py
@@ -23,11 +23,8 @@ class ReportDatasetsToToolAttributeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         tool_id = self.tool_id
-
         attribute_name = self.attribute_name
-
         attribute_value = self.attribute_value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ReportDatasetsToToolAttributeResponse:
             field_dict["AttributeName"] = attribute_name
         if attribute_value is not None:
             field_dict["AttributeValue"] = attribute_value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         tool_id = d.pop("ToolId", None)
-
         attribute_name = d.pop("AttributeName", None)
-
         attribute_value = d.pop("AttributeValue", None)
-
         qualer_api_models_report_datasets_to_tool_attribute_response = cls(
             tool_id=tool_id,
             attribute_name=attribute_name,
             attribute_value=attribute_value,
         )
-
         qualer_api_models_report_datasets_to_tool_attribute_response.additional_properties = d
         return qualer_api_models_report_datasets_to_tool_attribute_response
 

--- a/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_range_attribute_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_report_datasets_to_tool_range_attribute_response.py
@@ -31,19 +31,12 @@ class ReportDatasetsToToolRangeAttributeResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         measurement_point_id = self.measurement_point_id
-
         service_order_item_id = self.service_order_item_id
-
         tool_id = self.tool_id
-
         range_title = self.range_title
-
         range_subtitle = self.range_subtitle
-
         attribute_name = self.attribute_name
-
         attribute_value = self.attribute_value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -61,26 +54,18 @@ class ReportDatasetsToToolRangeAttributeResponse:
             field_dict["AttributeName"] = attribute_name
         if attribute_value is not None:
             field_dict["AttributeValue"] = attribute_value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         measurement_point_id = d.pop("MeasurementPointId", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         tool_id = d.pop("ToolId", None)
-
         range_title = d.pop("RangeTitle", None)
-
         range_subtitle = d.pop("RangeSubtitle", None)
-
         attribute_name = d.pop("AttributeName", None)
-
         attribute_value = d.pop("AttributeValue", None)
-
         qualer_api_models_report_datasets_to_tool_range_attribute_response = cls(
             measurement_point_id=measurement_point_id,
             service_order_item_id=service_order_item_id,
@@ -90,7 +75,6 @@ class ReportDatasetsToToolRangeAttributeResponse:
             attribute_name=attribute_name,
             attribute_value=attribute_value,
         )
-
         qualer_api_models_report_datasets_to_tool_range_attribute_response.additional_properties = d
         return qualer_api_models_report_datasets_to_tool_range_attribute_response
 

--- a/src/qualer_sdk/models/qualer_api_models_service_options_to_service_option_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_options_to_service_option_response_model.py
@@ -33,21 +33,13 @@ class ServiceOptionsToServiceOptionResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         price = self.price
-
         service_charge = self.service_charge
-
         time_spent = self.time_spent
-
         is_hourly = self.is_hourly
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         service_code = self.service_code
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class ServiceOptionsToServiceOptionResponseModel:
             field_dict["DocumentSection"] = document_section
         if service_code is not None:
             field_dict["ServiceCode"] = service_code
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         service_charge = d.pop("ServiceCharge", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         service_code = d.pop("ServiceCode", None)
-
         qualer_api_models_service_options_to_service_option_response_model = cls(
             name=name,
             price=price,
@@ -99,7 +82,6 @@ class ServiceOptionsToServiceOptionResponseModel:
             document_section=document_section,
             service_code=service_code,
         )
-
         qualer_api_models_service_options_to_service_option_response_model.additional_properties = d
         return qualer_api_models_service_options_to_service_option_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_documents_list_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_documents_list_model.py
@@ -19,24 +19,20 @@ class ServiceOrderDocumentsFromDocumentsListModel:
 
     def to_dict(self) -> Dict[str, Any]:
         report_type = self.report_type
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if report_type is not None:
             field_dict["ReportType"] = report_type
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         report_type = d.pop("ReportType", None)
-
         qualer_api_models_service_order_documents_from_documents_list_model = cls(
             report_type=report_type,
         )
-
         qualer_api_models_service_order_documents_from_documents_list_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_get_documents_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_get_documents_model.py
@@ -19,24 +19,20 @@ class ServiceOrderDocumentsFromGetDocumentsModel:
 
     def to_dict(self) -> Dict[str, Any]:
         file_name = self.file_name
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if file_name is not None:
             field_dict["FileName"] = file_name
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         file_name = d.pop("FileName", None)
-
         qualer_api_models_service_order_documents_from_get_documents_model = cls(
             file_name=file_name,
         )
-
         qualer_api_models_service_order_documents_from_get_documents_model.additional_properties = d
         return qualer_api_models_service_order_documents_from_get_documents_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_upload_documents_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_from_upload_documents_model.py
@@ -21,9 +21,7 @@ class ServiceOrderDocumentsFromUploadDocumentsModel:
 
     def to_dict(self) -> Dict[str, Any]:
         report_type = self.report_type
-
         is_private = self.is_private
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ServiceOrderDocumentsFromUploadDocumentsModel:
             field_dict["ReportType"] = report_type
         if is_private is not None:
             field_dict["IsPrivate"] = is_private
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         report_type = d.pop("ReportType", None)
-
         is_private = d.pop("IsPrivate", None)
-
         qualer_api_models_service_order_documents_from_upload_documents_model = cls(
             report_type=report_type,
             is_private=is_private,
         )
-
         qualer_api_models_service_order_documents_from_upload_documents_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
@@ -44,27 +44,15 @@ class ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         guid: Optional[str] = None
         if self.guid:
             guid = str(self.guid)
-
         document_name = self.document_name
-
         file_name = self.file_name
-
-        document_type: Optional[int] = None
-        if self.document_type:
-            document_type = self.document_type.value
-
+        document_type = self.document_type.value if self.document_type else None
         revision_number = self.revision_number
-
-        report_type: Optional[int] = None
-        if self.report_type:
-            report_type = self.report_type.value
-
+        report_type = self.report_type.value if self.report_type else None
         download_url = self.download_url
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -84,25 +72,20 @@ class ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
             field_dict["ReportType"] = report_type
         if download_url is not None:
             field_dict["DownloadUrl"] = download_url
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         _guid = d.pop("Guid", None)
         guid: Optional[UUID]
         if not _guid:
             guid = None
         else:
             guid = UUID(_guid)
-
         document_name = d.pop("DocumentName", None)
-
         file_name = d.pop("FileName", None)
-
         _document_type = d.pop("DocumentType", None)
         document_type: Optional[
             ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType
@@ -115,18 +98,14 @@ class ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
                     _document_type
                 )
             )
-
         revision_number = d.pop("RevisionNumber", None)
-
         _report_type = d.pop("ReportType", None)
         report_type: Optional[ReportType]
         if not _report_type:
             report_type = None
         else:
             report_type = ReportType(_report_type)
-
         download_url = d.pop("DownloadUrl", None)
-
         qualer_api_models_service_order_documents_to_company_order_controlled_document_response = (
             cls(
                 service_order_id=service_order_id,
@@ -139,7 +118,6 @@ class ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
                 download_url=download_url,
             )
         )
-
         qualer_api_models_service_order_documents_to_company_order_controlled_document_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
@@ -41,27 +41,16 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         service_order_item_id = self.service_order_item_id
-
         guid: Optional[str] = None
         if self.guid:
             guid = str(self.guid)
-
         document_name = self.document_name
-
         file_name = self.file_name
-
         document_type = self.document_type
-
         revision_number = self.revision_number
-
-        report_type: Optional[int] = None
-        if self.report_type:
-            report_type = self.report_type.value
-
+        report_type = self.report_type.value if self.report_type else None
         download_url = self.download_url
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -83,40 +72,30 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
             field_dict["ReportType"] = report_type
         if download_url is not None:
             field_dict["DownloadUrl"] = download_url
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         _guid = d.pop("Guid", None)
         guid: Optional[UUID]
         if not _guid:
             guid = None
         else:
             guid = UUID(_guid)
-
         document_name = d.pop("DocumentName", None)
-
         file_name = d.pop("FileName", None)
-
         document_type = d.pop("DocumentType", None)
-
         revision_number = d.pop("RevisionNumber", None)
-
         _report_type = d.pop("ReportType", None)
         report_type: Optional[ReportType]
         if not _report_type:
             report_type = None
         else:
             report_type = ReportType(_report_type)
-
         download_url = d.pop("DownloadUrl", None)
-
         qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response = cls(
             service_order_id=service_order_id,
             service_order_item_id=service_order_item_id,
@@ -128,7 +107,6 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
             report_type=report_type,
             download_url=download_url,
         )
-
         qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_order_item_parts_to_order_item_part_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_item_parts_to_order_item_part_response_model.py
@@ -52,35 +52,19 @@ class ServiceOrderItemPartsToOrderItemPartResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_part_id = self.service_order_item_part_id
-
         service_order_item_id = self.service_order_item_id
-
         name = self.name
-
         description = self.description
-
         discount = self.discount
-
         is_taxable = self.is_taxable
-
         is_hourly_pricing = self.is_hourly_pricing
-
         price = self.price
-
         unit_name = self.unit_name
-
         quantity = self.quantity
-
         delivery_charge = self.delivery_charge
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         free_quantity = self.free_quantity
-
-        service_order_charge_type: Optional[str] = None
-        if self.service_order_charge_type:
-            service_order_charge_type = self.service_order_charge_type.value
-
+        service_order_charge_type = self.service_order_charge_type.value if self.service_order_charge_type else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -112,38 +96,24 @@ class ServiceOrderItemPartsToOrderItemPartResponseModel:
             field_dict["FreeQuantity"] = free_quantity
         if service_order_charge_type is not None:
             field_dict["ServiceOrderChargeType"] = service_order_charge_type
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_part_id = d.pop("ServiceOrderItemPartId", None)
-
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         name = d.pop("Name", None)
-
         description = d.pop("Description", None)
-
         discount = d.pop("Discount", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         price = d.pop("Price", None)
-
         unit_name = d.pop("UnitName", None)
-
         quantity = d.pop("Quantity", None)
-
         delivery_charge = d.pop("DeliveryCharge", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         free_quantity = d.pop("FreeQuantity", None)
-
         _service_order_charge_type = d.pop("ServiceOrderChargeType", None)
         service_order_charge_type: Optional[
             ServiceOrderItemPartsToOrderItemPartResponseModelServiceOrderChargeType
@@ -156,7 +126,6 @@ class ServiceOrderItemPartsToOrderItemPartResponseModel:
                     _service_order_charge_type
                 )
             )
-
         qualer_api_models_service_order_item_parts_to_order_item_part_response_model = cls(
             service_order_item_part_id=service_order_item_part_id,
             service_order_item_id=service_order_item_id,
@@ -173,7 +142,6 @@ class ServiceOrderItemPartsToOrderItemPartResponseModel:
             free_quantity=free_quantity,
             service_order_charge_type=service_order_charge_type,
         )
-
         qualer_api_models_service_order_item_parts_to_order_item_part_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model.py
@@ -27,15 +27,10 @@ class ServiceOrderItemTasksFromServiceOrderItemTaskCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_id = self.service_order_item_id
-
         task_name = self.task_name
-
         task_description = self.task_description
-
         as_found_details = self.as_found_details
-
         as_left_details = self.as_left_details
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -49,22 +44,16 @@ class ServiceOrderItemTasksFromServiceOrderItemTaskCreateModel:
             field_dict["AsFoundDetails"] = as_found_details
         if as_left_details is not None:
             field_dict["AsLeftDetails"] = as_left_details
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
-
         task_name = d.pop("TaskName", None)
-
         task_description = d.pop("TaskDescription", None)
-
         as_found_details = d.pop("AsFoundDetails", None)
-
         as_left_details = d.pop("AsLeftDetails", None)
-
         qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model = cls(
             service_order_item_id=service_order_item_id,
             task_name=task_name,
@@ -72,7 +61,6 @@ class ServiceOrderItemTasksFromServiceOrderItemTaskCreateModel:
             as_found_details=as_found_details,
             as_left_details=as_left_details,
         )
-
         qualer_api_models_service_order_item_tasks_from_service_order_item_task_create_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_payment_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_payment_model.py
@@ -23,11 +23,8 @@ class ServiceOrdersFromAddPaymentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         payment_type = self.payment_type
-
         payment_amount = self.payment_amount
-
         details = self.details
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ServiceOrdersFromAddPaymentModel:
             field_dict["PaymentAmount"] = payment_amount
         if details is not None:
             field_dict["Details"] = details
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         payment_type = d.pop("PaymentType", None)
-
         payment_amount = d.pop("PaymentAmount", None)
-
         details = d.pop("Details", None)
-
         qualer_api_models_service_orders_from_add_payment_model = cls(
             payment_type=payment_type,
             payment_amount=payment_amount,
             details=details,
         )
-
         qualer_api_models_service_orders_from_add_payment_model.additional_properties = d
         return qualer_api_models_service_orders_from_add_payment_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_work_items_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_add_work_items_model.py
@@ -23,11 +23,9 @@ class ServiceOrdersFromAddWorkItemsModel:
         asset_ids: Optional[List[int]] = None
         if self.asset_ids:
             asset_ids = self.asset_ids
-
         schedule_segment_ids: Optional[List[int]] = None
         if self.schedule_segment_ids:
             schedule_segment_ids = self.schedule_segment_ids
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -35,21 +33,17 @@ class ServiceOrdersFromAddWorkItemsModel:
             field_dict["AssetIds"] = asset_ids
         if schedule_segment_ids is not None:
             field_dict["ScheduleSegmentIds"] = schedule_segment_ids
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_ids = cast(List[int], d.pop("AssetIds", None))
-
         schedule_segment_ids = cast(List[int], d.pop("ScheduleSegmentIds", None))
-
         qualer_api_models_service_orders_from_add_work_items_model = cls(
             asset_ids=asset_ids,
             schedule_segment_ids=schedule_segment_ids,
         )
-
         qualer_api_models_service_orders_from_add_work_items_model.additional_properties = d
         return qualer_api_models_service_orders_from_add_work_items_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_append_tracking_number_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_append_tracking_number_model.py
@@ -19,24 +19,20 @@ class ServiceOrdersFromAppendTrackingNumberModel:
 
     def to_dict(self) -> Dict[str, Any]:
         tracking_number = self.tracking_number
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if tracking_number is not None:
             field_dict["TrackingNumber"] = tracking_number
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         tracking_number = d.pop("TrackingNumber", None)
-
         qualer_api_models_service_orders_from_append_tracking_number_model = cls(
             tracking_number=tracking_number,
         )
-
         qualer_api_models_service_orders_from_append_tracking_number_model.additional_properties = d
         return qualer_api_models_service_orders_from_append_tracking_number_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_change_service_order_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_change_service_order_status_model.py
@@ -29,13 +29,9 @@ class ServiceOrdersFromChangeServiceOrderStatusModel:
         service_order_status: Optional[str] = (
             self.service_order_status.value if self.service_order_status else None
         )
-
         reset_status = self.reset_status
-
         email = self.email
-
         password = self.password
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -47,7 +43,6 @@ class ServiceOrdersFromChangeServiceOrderStatusModel:
             field_dict["Email"] = email
         if password is not None:
             field_dict["Password"] = password
-
         return field_dict
 
     @classmethod
@@ -55,20 +50,15 @@ class ServiceOrdersFromChangeServiceOrderStatusModel:
         d = dict(src_dict)
         _service_order_status = d.pop("ServiceOrderStatus", None)
         service_order_status = ServiceOrderStatus.from_api_value(_service_order_status)
-
         reset_status = d.pop("ResetStatus", None)
-
         email = d.pop("Email", None)
-
         password = d.pop("Password", None)
-
         qualer_api_models_service_orders_from_change_service_order_status_model = cls(
             service_order_status=service_order_status,
             reset_status=reset_status,
             email=email,
             password=password,
         )
-
         (
             qualer_api_models_service_orders_from_change_service_order_status_model.additional_properties
         ) = d

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model.py
@@ -30,13 +30,11 @@ class ServiceOrdersFromChargeUpdateModel:
             for charges_item_data in self.charges:
                 charges_item = charges_item_data.to_dict()
                 charges.append(charges_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if charges is not None:
             field_dict["Charges"] = charges
-
         return field_dict
 
     @classmethod
@@ -44,19 +42,15 @@ class ServiceOrdersFromChargeUpdateModel:
         from ..models.qualer_api_models_service_orders_from_charge_update_model_price_model import (
             ServiceOrdersFromChargeUpdateModelPriceModel,
         )
-
         d = dict(src_dict)
         charges = []
         _charges = d.pop("Charges", None)
         for charges_item_data in _charges or []:
             charges_item = ServiceOrdersFromChargeUpdateModelPriceModel.from_dict(charges_item_data)
-
             charges.append(charges_item)
-
         qualer_api_models_service_orders_from_charge_update_model = cls(
             charges=charges,
         )
-
         qualer_api_models_service_orders_from_charge_update_model.additional_properties = d
         return qualer_api_models_service_orders_from_charge_update_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_charge_update_model_price_model.py
@@ -21,9 +21,7 @@ class ServiceOrdersFromChargeUpdateModelPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         price = self.price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ServiceOrdersFromChargeUpdateModelPriceModel:
             field_dict["Name"] = name
         if price is not None:
             field_dict["Price"] = price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         qualer_api_models_service_orders_from_charge_update_model_price_model = cls(
             name=name,
             price=price,
         )
-
         qualer_api_models_service_orders_from_charge_update_model_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_create_order_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_create_order_model.py
@@ -31,25 +31,18 @@ class ServiceOrdersFromCreateOrderModel:
 
     def to_dict(self) -> Dict[str, Any]:
         client_company_id = self.client_company_id
-
         vendor_site_id = self.vendor_site_id
-
         asset_ids: Optional[List[int]] = None
         if self.asset_ids:
             asset_ids = self.asset_ids
-
         schedule_segment_ids: Optional[List[int]] = None
         if self.schedule_segment_ids:
             schedule_segment_ids = self.schedule_segment_ids
-
         service_level_ids: Optional[List[int]] = None
         if self.service_level_ids:
             service_level_ids = self.service_level_ids
-
         use_due_segments = self.use_due_segments
-
         order_notes = self.order_notes
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,26 +60,18 @@ class ServiceOrdersFromCreateOrderModel:
             field_dict["UseDueSegments"] = use_due_segments
         if order_notes is not None:
             field_dict["OrderNotes"] = order_notes
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         client_company_id = d.pop("ClientCompanyId", None)
-
         vendor_site_id = d.pop("VendorSiteId", None)
-
         asset_ids = cast(List[int], d.pop("AssetIds", None))
-
         schedule_segment_ids = cast(List[int], d.pop("ScheduleSegmentIds", None))
-
         service_level_ids = cast(List[int], d.pop("ServiceLevelIds", None))
-
         use_due_segments = d.pop("UseDueSegments", None)
-
         order_notes = d.pop("OrderNotes", None)
-
         qualer_api_models_service_orders_from_create_order_model = cls(
             client_company_id=client_company_id,
             vendor_site_id=vendor_site_id,
@@ -96,7 +81,6 @@ class ServiceOrdersFromCreateOrderModel:
             use_due_segments=use_due_segments,
             order_notes=order_notes,
         )
-
         qualer_api_models_service_orders_from_create_order_model.additional_properties = d
         return qualer_api_models_service_orders_from_create_order_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model.py
@@ -34,13 +34,11 @@ class ServiceOrdersFromItemChargeUpdateModel:
             for charges_item_data in self.charges:
                 charges_item = charges_item_data.to_dict()
                 charges.append(charges_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if charges is not None:
             field_dict["Charges"] = charges
-
         return field_dict
 
     @classmethod
@@ -48,7 +46,6 @@ class ServiceOrdersFromItemChargeUpdateModel:
         from ..models.qualer_api_models_service_orders_from_item_charge_update_model_item_price_model import (
             ServiceOrdersFromItemChargeUpdateModelItemPriceModel,
         )
-
         d = dict(src_dict)
         charges = []
         _charges = d.pop("Charges", None)
@@ -56,13 +53,10 @@ class ServiceOrdersFromItemChargeUpdateModel:
             charges_item = ServiceOrdersFromItemChargeUpdateModelItemPriceModel.from_dict(
                 charges_item_data
             )
-
             charges.append(charges_item)
-
         qualer_api_models_service_orders_from_item_charge_update_model = cls(
             charges=charges,
         )
-
         qualer_api_models_service_orders_from_item_charge_update_model.additional_properties = d
         return qualer_api_models_service_orders_from_item_charge_update_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model_item_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_item_charge_update_model_item_price_model.py
@@ -21,9 +21,7 @@ class ServiceOrdersFromItemChargeUpdateModelItemPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         price = self.price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ServiceOrdersFromItemChargeUpdateModelItemPriceModel:
             field_dict["Name"] = name
         if price is not None:
             field_dict["Price"] = price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         qualer_api_models_service_orders_from_item_charge_update_model_item_price_model = cls(
             name=name,
             price=price,
         )
-
         qualer_api_models_service_orders_from_item_charge_update_model_item_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_order_item_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_order_item_update_model.py
@@ -94,99 +94,42 @@ class ServiceOrdersFromOrderItemUpdateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_comments = self.service_comments
-
         private_comments = self.private_comments
-
         service_notes = self.service_notes
-
         service_total = self.service_total
-
         repairs_total = self.repairs_total
-
         parts_total = self.parts_total
-
-        work_status: Optional[int] = None
-        if self.work_status:
-            work_status = self.work_status.value
-
+        work_status = self.work_status.value if self.work_status else None
         custom_work_status = self.custom_work_status
-
         is_limited = self.is_limited
-
         checked_on: Optional[str] = None
         if self.checked_on:
             checked_on = self.checked_on.isoformat()
-
         checked_by_name = self.checked_by_name
-
         completed_on: Optional[str] = None
         if self.completed_on:
             completed_on = self.completed_on.isoformat()
-
         completed_by_name = self.completed_by_name
-
-        as_found_check: Optional[str] = None
-        if self.as_found_check:
-            as_found_check = self.as_found_check.value
-
-        as_left_check: Optional[str] = None
-        if self.as_left_check:
-            as_left_check = self.as_left_check.value
-
-        result_status: Optional[int] = None
-        if self.result_status:
-            result_status = self.result_status.value
-
-        as_found_result: Optional[int] = None
-        if self.as_found_result:
-            as_found_result = self.as_found_result.value
-
-        as_left_result: Optional[int] = None
-        if self.as_left_result:
-            as_left_result = self.as_left_result.value
-
+        as_found_check = self.as_found_check.value if self.as_found_check else None
+        as_left_check = self.as_left_check.value if self.as_left_check else None
+        result_status = self.result_status.value if self.result_status else None
+        as_found_result = self.as_found_result.value if self.as_found_result else None
+        as_left_result = self.as_left_result.value if self.as_left_result else None
         equipment_id = self.equipment_id
-
         legacy_id = self.legacy_id
-
         serial_number = self.serial_number
-
         serial_number_change = self.serial_number_change
-
         asset_tag = self.asset_tag
-
         asset_tag_change = self.asset_tag_change
-
         asset_user = self.asset_user
-
         asset_user_change = self.asset_user_change
-
         provider_technician = self.provider_technician
-
         provider_phone = self.provider_phone
-
         provider_company = self.provider_company
-
         certificate_number = self.certificate_number
-
-        service_date: Optional[str]
-        if not self.service_date:
-            service_date = None
-        elif isinstance(self.service_date, datetime.datetime):
-            service_date = self.service_date.isoformat()
-        else:
-            service_date = self.service_date
-
-        next_service_date: Optional[str]
-        if not self.next_service_date:
-            next_service_date = None
-        elif isinstance(self.next_service_date, datetime.datetime):
-            next_service_date = self.next_service_date.isoformat()
-        else:
-            next_service_date = self.next_service_date
-
+        service_date = self.service_date.isoformat() if self.service_date else None
+        next_service_date = self.next_service_date.isoformat() if self.next_service_date else None
         vendor_tag = self.vendor_tag
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -256,24 +199,17 @@ class ServiceOrdersFromOrderItemUpdateModel:
             field_dict["NextServiceDate"] = next_service_date
         if vendor_tag is not None:
             field_dict["VendorTag"] = vendor_tag
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_comments = d.pop("ServiceComments", None)
-
         private_comments = d.pop("PrivateComments", None)
-
         service_notes = d.pop("ServiceNotes", None)
-
         service_total = d.pop("ServiceTotal", None)
-
         repairs_total = d.pop("RepairsTotal", None)
-
         parts_total = d.pop("PartsTotal", None)
-
         _work_status = d.pop("WorkStatus", None)
         work_status: Optional[WorkStatus]
         if not _work_status:
@@ -282,43 +218,34 @@ class ServiceOrdersFromOrderItemUpdateModel:
             work_status = None
         else:
             work_status = WorkStatus(_work_status)
-
         custom_work_status = d.pop("CustomWorkStatus", None)
-
         is_limited = d.pop("IsLimited", None)
-
         _checked_on = d.pop("CheckedOn", None)
         checked_on: Optional[datetime.datetime]
         if not _checked_on:
             checked_on = None
         else:
             checked_on = isoparse(_checked_on)
-
         checked_by_name = d.pop("CheckedByName", None)
-
         _completed_on = d.pop("CompletedOn", None)
         completed_on: Optional[datetime.datetime]
         if not _completed_on:
             completed_on = None
         else:
             completed_on = isoparse(_completed_on)
-
         completed_by_name = d.pop("CompletedByName", None)
-
         _as_found_check = d.pop("AsFoundCheck", None)
         as_found_check: Optional[ServiceOrdersFromOrderItemUpdateModelAsFoundCheck]
         if not _as_found_check:
             as_found_check = None
         else:
             as_found_check = ServiceOrdersFromOrderItemUpdateModelAsFoundCheck(_as_found_check)
-
         _as_left_check = d.pop("AsLeftCheck", None)
         as_left_check: Optional[ServiceOrdersFromOrderItemUpdateModelAsLeftCheck]
         if not _as_left_check:
             as_left_check = None
         else:
             as_left_check = ServiceOrdersFromOrderItemUpdateModelAsLeftCheck(_as_left_check)
-
         _result_status = d.pop("ResultStatus", None)
         result_status: Optional[ServiceResultStatus]
         if not _result_status:
@@ -327,7 +254,6 @@ class ServiceOrdersFromOrderItemUpdateModel:
             result_status = None
         else:
             result_status = ServiceResultStatus(_result_status)
-
         _as_found_result = d.pop("AsFoundResult", None)
         as_found_result: Optional[ServiceResultStatus]
         if not _as_found_result:
@@ -336,7 +262,6 @@ class ServiceOrdersFromOrderItemUpdateModel:
             as_found_result = None
         else:
             as_found_result = ServiceResultStatus(_as_found_result)
-
         _as_left_result = d.pop("AsLeftResult", None)
         as_left_result: Optional[ServiceResultStatus]
         if not _as_left_result:
@@ -345,31 +270,18 @@ class ServiceOrdersFromOrderItemUpdateModel:
             as_left_result = None
         else:
             as_left_result = ServiceResultStatus(_as_left_result)
-
         equipment_id = d.pop("EquipmentId", None)
-
         legacy_id = d.pop("LegacyId", None)
-
         serial_number = d.pop("SerialNumber", None)
-
         serial_number_change = d.pop("SerialNumberChange", None)
-
         asset_tag = d.pop("AssetTag", None)
-
         asset_tag_change = d.pop("AssetTagChange", None)
-
         asset_user = d.pop("AssetUser", None)
-
         asset_user_change = d.pop("AssetUserChange", None)
-
         provider_technician = d.pop("ProviderTechnician", None)
-
         provider_phone = d.pop("ProviderPhone", None)
-
         provider_company = d.pop("ProviderCompany", None)
-
         certificate_number = d.pop("CertificateNumber", None)
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -377,14 +289,11 @@ class ServiceOrdersFromOrderItemUpdateModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 service_date_type_0 = isoparse(data)
-
                 return service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -394,16 +303,12 @@ class ServiceOrdersFromOrderItemUpdateModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 next_service_date_type_0 = isoparse(data)
-
                 return next_service_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
-
         vendor_tag = d.pop("VendorTag", None)
-
         qualer_api_models_service_orders_from_order_item_update_model = cls(
             service_comments=service_comments,
             private_comments=private_comments,
@@ -439,7 +344,6 @@ class ServiceOrdersFromOrderItemUpdateModel:
             next_service_date=next_service_date,
             vendor_tag=vendor_tag,
         )
-
         qualer_api_models_service_orders_from_order_item_update_model.additional_properties = d
         return qualer_api_models_service_orders_from_order_item_update_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_create_model.py
@@ -31,11 +31,9 @@ class ServiceOrdersFromServiceOrderMetadataCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         metadata = self.metadata
-
         exhibits: Optional[Dict[str, Any]] = None
         if self.exhibits:
             exhibits = self.exhibits.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -43,7 +41,6 @@ class ServiceOrdersFromServiceOrderMetadataCreateModel:
             field_dict["Metadata"] = metadata
         if exhibits is not None:
             field_dict["Exhibits"] = exhibits
-
         return field_dict
 
     @classmethod
@@ -51,10 +48,8 @@ class ServiceOrdersFromServiceOrderMetadataCreateModel:
         from ..models.qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits import (
             QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits,
         )
-
         d = dict(src_dict)
         metadata = d.pop("Metadata", None)
-
         _exhibits = d.pop("Exhibits", None)
         exhibits: Optional[QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]
         if not _exhibits:
@@ -65,12 +60,10 @@ class ServiceOrdersFromServiceOrderMetadataCreateModel:
                     _exhibits
                 )
             )
-
         qualer_api_models_service_orders_from_service_order_metadata_create_model = cls(
             metadata=metadata,
             exhibits=exhibits,
         )
-
         qualer_api_models_service_orders_from_service_order_metadata_create_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_metadata_update_model.py
@@ -31,13 +31,10 @@ class ServiceOrdersFromServiceOrderMetadataUpdateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_metadata_id = self.service_order_metadata_id
-
         metadata = self.metadata
-
         exhibits: Optional[Dict[str, Any]] = None
         if self.exhibits:
             exhibits = self.exhibits.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -47,7 +44,6 @@ class ServiceOrdersFromServiceOrderMetadataUpdateModel:
             field_dict["Metadata"] = metadata
         if exhibits is not None:
             field_dict["Exhibits"] = exhibits
-
         return field_dict
 
     @classmethod
@@ -55,12 +51,9 @@ class ServiceOrdersFromServiceOrderMetadataUpdateModel:
         from ..models.qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits import (
             QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits,
         )
-
         d = dict(src_dict)
         service_order_metadata_id = d.pop("ServiceOrderMetadataId", None)
-
         metadata = d.pop("Metadata", None)
-
         _exhibits = d.pop("Exhibits", None)
         exhibits: Optional[QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits]
         if not _exhibits:
@@ -71,13 +64,11 @@ class ServiceOrdersFromServiceOrderMetadataUpdateModel:
                     _exhibits
                 )
             )
-
         qualer_api_models_service_orders_from_service_order_metadata_update_model = cls(
             service_order_metadata_id=service_order_metadata_id,
             metadata=metadata,
             exhibits=exhibits,
         )
-
         qualer_api_models_service_orders_from_service_order_metadata_update_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_create_model.py
@@ -33,23 +33,16 @@ class ServiceOrdersFromServiceOrderTaskCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         task_name = self.task_name
-
         task_details = self.task_details
-
         start_time: Optional[str] = None
         if self.start_time:
             start_time = self.start_time.isoformat()
-
         finish_time: Optional[str] = None
         if self.finish_time:
             finish_time = self.finish_time.isoformat()
-
         time_spent_minutes = self.time_spent_minutes
-
         price = self.price
-
         is_hourly = self.is_hourly
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,36 +60,28 @@ class ServiceOrdersFromServiceOrderTaskCreateModel:
             field_dict["Price"] = price
         if is_hourly is not None:
             field_dict["IsHourly"] = is_hourly
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         task_name = d.pop("TaskName", None)
-
         task_details = d.pop("TaskDetails", None)
-
         _start_time = d.pop("StartTime", None)
         start_time: Optional[datetime.datetime]
         if not _start_time:
             start_time = None
         else:
             start_time = isoparse(_start_time)
-
         _finish_time = d.pop("FinishTime", None)
         finish_time: Optional[datetime.datetime]
         if not _finish_time:
             finish_time = None
         else:
             finish_time = isoparse(_finish_time)
-
         time_spent_minutes = d.pop("TimeSpentMinutes", None)
-
         price = d.pop("Price", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         qualer_api_models_service_orders_from_service_order_task_create_model = cls(
             task_name=task_name,
             task_details=task_details,
@@ -106,7 +91,6 @@ class ServiceOrdersFromServiceOrderTaskCreateModel:
             price=price,
             is_hourly=is_hourly,
         )
-
         qualer_api_models_service_orders_from_service_order_task_create_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_service_order_task_update_model.py
@@ -35,25 +35,17 @@ class ServiceOrdersFromServiceOrderTaskUpdateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_task_id = self.service_order_task_id
-
         task_name = self.task_name
-
         task_details = self.task_details
-
         start_time: Optional[str] = None
         if self.start_time:
             start_time = self.start_time.isoformat()
-
         finish_time: Optional[str] = None
         if self.finish_time:
             finish_time = self.finish_time.isoformat()
-
         time_spent_minutes = self.time_spent_minutes
-
         price = self.price
-
         is_hourly = self.is_hourly
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -73,38 +65,29 @@ class ServiceOrdersFromServiceOrderTaskUpdateModel:
             field_dict["Price"] = price
         if is_hourly is not None:
             field_dict["IsHourly"] = is_hourly
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_task_id = d.pop("ServiceOrderTaskId", None)
-
         task_name = d.pop("TaskName", None)
-
         task_details = d.pop("TaskDetails", None)
-
         _start_time = d.pop("StartTime", None)
         start_time: Optional[datetime.datetime]
         if not _start_time:
             start_time = None
         else:
             start_time = isoparse(_start_time)
-
         _finish_time = d.pop("FinishTime", None)
         finish_time: Optional[datetime.datetime]
         if not _finish_time:
             finish_time = None
         else:
             finish_time = isoparse(_finish_time)
-
         time_spent_minutes = d.pop("TimeSpentMinutes", None)
-
         price = d.pop("Price", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         qualer_api_models_service_orders_from_service_order_task_update_model = cls(
             service_order_task_id=service_order_task_id,
             task_name=task_name,
@@ -115,7 +98,6 @@ class ServiceOrdersFromServiceOrderTaskUpdateModel:
             price=price,
             is_hourly=is_hourly,
         )
-
         qualer_api_models_service_orders_from_service_order_task_update_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_payment_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_payment_status_model.py
@@ -23,15 +23,7 @@ class ServiceOrdersFromUpdatePaymentStatusModel:
 
     def to_dict(self) -> Dict[str, Any]:
         payment_status = self.payment_status
-
-        invoiced_on: Optional[str]
-        if not self.invoiced_on:
-            invoiced_on = None
-        elif isinstance(self.invoiced_on, datetime.datetime):
-            invoiced_on = self.invoiced_on.isoformat()
-        else:
-            invoiced_on = self.invoiced_on
-
+        invoiced_on = self.invoiced_on.isoformat() if self.invoiced_on else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -39,14 +31,12 @@ class ServiceOrdersFromUpdatePaymentStatusModel:
             field_dict["PaymentStatus"] = payment_status
         if invoiced_on is not None:
             field_dict["InvoicedOn"] = invoiced_on
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         payment_status = d.pop("PaymentStatus", None)
-
         def _parse_invoiced_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -54,19 +44,15 @@ class ServiceOrdersFromUpdatePaymentStatusModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 invoiced_on_type_0 = isoparse(data)
-
                 return invoiced_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         invoiced_on = _parse_invoiced_on(d.pop("InvoicedOn", None))
-
         qualer_api_models_service_orders_from_update_payment_status_model = cls(
             payment_status=payment_status,
             invoiced_on=invoiced_on,
         )
-
         qualer_api_models_service_orders_from_update_payment_status_model.additional_properties = d
         return qualer_api_models_service_orders_from_update_payment_status_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_shipment_status_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_from_update_shipment_status_model.py
@@ -19,24 +19,20 @@ class ServiceOrdersFromUpdateShipmentStatusModel:
 
     def to_dict(self) -> Dict[str, Any]:
         shipment_status = self.shipment_status
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if shipment_status is not None:
             field_dict["ShipmentStatus"] = shipment_status
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         shipment_status = d.pop("ShipmentStatus", None)
-
         qualer_api_models_service_orders_from_update_shipment_status_model = cls(
             shipment_status=shipment_status,
         )
-
         qualer_api_models_service_orders_from_update_shipment_status_model.additional_properties = d
         return qualer_api_models_service_orders_from_update_shipment_status_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_asset_add_result_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_asset_add_result_response_model.py
@@ -21,11 +21,9 @@ class ServiceOrdersToAssetAddResultResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         asset_count = self.asset_count
-
         already_added_asset_serials: Optional[List[str]] = None
         if self.already_added_asset_serials:
             already_added_asset_serials = self.already_added_asset_serials
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -33,21 +31,17 @@ class ServiceOrdersToAssetAddResultResponseModel:
             field_dict["AssetCount"] = asset_count
         if already_added_asset_serials is not None:
             field_dict["AlreadyAddedAssetSerials"] = already_added_asset_serials
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         asset_count = d.pop("AssetCount", None)
-
         already_added_asset_serials = cast(List[str], d.pop("AlreadyAddedAssetSerials", None))
-
         qualer_api_models_service_orders_to_asset_add_result_response_model = cls(
             asset_count=asset_count,
             already_added_asset_serials=already_added_asset_serials,
         )
-
         qualer_api_models_service_orders_to_asset_add_result_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model.py
@@ -53,25 +53,20 @@ class ServiceOrdersToBaseWorkItemModel:
             for tasks_item_data in self.tasks:
                 tasks_item = tasks_item_data.to_dict()
                 tasks.append(tasks_item)
-
         parts: Optional[List[Dict[str, Any]]] = None
         if self.parts:
             parts = []
             for parts_item_data in self.parts:
                 parts_item = parts_item_data.to_dict()
                 parts.append(parts_item)
-
         repairs: Optional[List[Dict[str, Any]]] = None
         if self.repairs:
             repairs = []
             for repairs_item_data in self.repairs:
                 repairs_item = repairs_item_data.to_dict()
                 repairs.append(repairs_item)
-
         work_item_id = self.work_item_id
-
         vendor_tag = self.vendor_tag
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -85,7 +80,6 @@ class ServiceOrdersToBaseWorkItemModel:
             field_dict["WorkItemId"] = work_item_id
         if vendor_tag is not None:
             field_dict["VendorTag"] = vendor_tag
-
         return field_dict
 
     @classmethod
@@ -96,7 +90,6 @@ class ServiceOrdersToBaseWorkItemModel:
         from ..models.qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model import (
             ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel,
         )
-
         d = dict(src_dict)
         tasks = []
         _tasks = d.pop("Tasks", None)
@@ -104,31 +97,23 @@ class ServiceOrdersToBaseWorkItemModel:
             tasks_item = ServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel.from_dict(
                 tasks_item_data
             )
-
             tasks.append(tasks_item)
-
         parts = []
         _parts = d.pop("Parts", None)
         for parts_item_data in _parts or []:
             parts_item = ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel.from_dict(
                 parts_item_data
             )
-
             parts.append(parts_item)
-
         repairs = []
         _repairs = d.pop("Repairs", None)
         for repairs_item_data in _repairs or []:
             repairs_item = ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel.from_dict(
                 repairs_item_data
             )
-
             repairs.append(repairs_item)
-
         work_item_id = d.pop("WorkItemId", None)
-
         vendor_tag = d.pop("VendorTag", None)
-
         qualer_api_models_service_orders_to_base_work_item_model = cls(
             tasks=tasks,
             parts=parts,
@@ -136,7 +121,6 @@ class ServiceOrdersToBaseWorkItemModel:
             work_item_id=work_item_id,
             vendor_tag=vendor_tag,
         )
-
         qualer_api_models_service_orders_to_base_work_item_model.additional_properties = d
         return qualer_api_models_service_orders_to_base_work_item_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model.py
@@ -23,11 +23,8 @@ class ServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         contract_discount = self.contract_discount
-
         name = self.name
-
         price = self.price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -37,24 +34,19 @@ class ServiceOrdersToBaseWorkItemModelOrderItemTaskPriceModel:
             field_dict["Name"] = name
         if price is not None:
             field_dict["Price"] = price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         contract_discount = d.pop("ContractDiscount", None)
-
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model = cls(
             contract_discount=contract_discount,
             name=name,
             price=price,
         )
-
         qualer_api_models_service_orders_to_base_work_item_model_order_item_task_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model.py
@@ -38,23 +38,14 @@ class ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         delivery_charge = self.delivery_charge
-
         quantity = self.quantity
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         is_hourly_pricing = self.is_hourly_pricing
-
         description = self.description
-
         name = self.name
-
         price = self.price
-
         unit_name = self.unit_name
-
         is_taxable = self.is_taxable
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -76,30 +67,20 @@ class ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel:
             field_dict["UnitName"] = unit_name
         if is_taxable is not None:
             field_dict["IsTaxable"] = is_taxable
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delivery_charge = d.pop("DeliveryCharge", None)
-
         quantity = d.pop("Quantity", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         description = d.pop("Description", None)
-
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         unit_name = d.pop("UnitName", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model = (
             cls(
                 delivery_charge=delivery_charge,
@@ -113,7 +94,6 @@ class ServiceOrdersToBaseWorkItemModelOrderPartRepairPriceModel:
                 is_taxable=is_taxable,
             )
         )
-
         qualer_api_models_service_orders_to_base_work_item_model_order_part_repair_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model.py
@@ -36,21 +36,13 @@ class ServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         delivery_charge = self.delivery_charge
-
         quantity = self.quantity
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         is_hourly_pricing = self.is_hourly_pricing
-
         description = self.description
-
         name = self.name
-
         price = self.price
-
         is_taxable = self.is_taxable
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -70,28 +62,19 @@ class ServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel:
             field_dict["Price"] = price
         if is_taxable is not None:
             field_dict["IsTaxable"] = is_taxable
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         delivery_charge = d.pop("DeliveryCharge", None)
-
         quantity = d.pop("Quantity", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         description = d.pop("Description", None)
-
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model = cls(
             delivery_charge=delivery_charge,
             quantity=quantity,
@@ -102,7 +85,6 @@ class ServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel:
             price=price,
             is_taxable=is_taxable,
         )
-
         qualer_api_models_service_orders_to_charge_response_model_base_order_part_repair_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model.py
@@ -32,17 +32,11 @@ class ServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         contract_discount = self.contract_discount
-
         time_spent = self.time_spent
-
         is_hourly = self.is_hourly
-
         details = self.details
-
         name = self.name
-
         price = self.price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -58,24 +52,17 @@ class ServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel:
             field_dict["Name"] = name
         if price is not None:
             field_dict["Price"] = price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         contract_discount = d.pop("ContractDiscount", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         details = d.pop("Details", None)
-
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model = cls(
             contract_discount=contract_discount,
             time_spent=time_spent,
@@ -84,7 +71,6 @@ class ServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel:
             name=name,
             price=price,
         )
-
         qualer_api_models_service_orders_to_charge_response_model_base_order_task_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_price_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_charge_response_model_base_price_model.py
@@ -21,9 +21,7 @@ class ServiceOrdersToChargeResponseModelBasePriceModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         price = self.price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class ServiceOrdersToChargeResponseModelBasePriceModel:
             field_dict["Name"] = name
         if price is not None:
             field_dict["Price"] = price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         price = d.pop("Price", None)
-
         qualer_api_models_service_orders_to_charge_response_model_base_price_model = cls(
             name=name,
             price=price,
         )
-
         qualer_api_models_service_orders_to_charge_response_model_base_price_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_item_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_item_response_model.py
@@ -447,7 +447,6 @@ class ServiceOrdersToClientOrderItemResponseModel:
         from ..models.qualer_api_models_service_options_to_service_option_response_model import (
             ServiceOptionsToServiceOptionResponseModel,
         )
-
         d = dict(src_dict)
         work_item_id = d.pop("WorkItemId", None)
         client_notes = d.pop("ClientNotes", None)
@@ -469,7 +468,6 @@ class ServiceOrdersToClientOrderItemResponseModel:
         work_status = d.pop("WorkStatus", None)
         custom_work_status = d.pop("CustomWorkStatus", None)
         is_limited = d.pop("IsLimited", None)
-
         def _parse_checked_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -481,11 +479,9 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         checked_on = _parse_checked_on(d.pop("CheckedOn", None))
         checked_by_name = d.pop("CheckedByName", None)
         checked_by_id = d.pop("CheckedById", None)
-
         def _parse_completed_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -497,7 +493,6 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         completed_on = _parse_completed_on(d.pop("CompletedOn", None))
         completed_by_name = d.pop("CompletedByName", None)
         completed_by_id = d.pop("CompletedById", None)
@@ -505,42 +500,31 @@ class ServiceOrdersToClientOrderItemResponseModel:
         updated_by = d.pop("UpdatedBy", None)
         as_found_check = d.pop("AsFoundCheck", None)
         as_left_check = d.pop("AsLeftCheck", None)
-
         def _parse_item_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         item_result_status = _parse_item_result_status(d.pop("ItemResultStatus", None))
-
         def _parse_item_as_found_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         item_as_found_result = _parse_item_as_found_result(d.pop("ItemAsFoundResult", None))
-
         def _parse_item_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         item_as_left_result = _parse_item_as_left_result(d.pop("ItemAsLeftResult", None))
-
         def _parse_as_found_specification(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_found_specification = _parse_as_found_specification(d.pop("AsFoundSpecification", None))
-
         def _parse_as_left_specification(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         as_left_specification = _parse_as_left_specification(d.pop("AsLeftSpecification", None))
-
         def _parse_created_on_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -554,9 +538,7 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         created_on_utc = _parse_created_on_utc(d.pop("CreatedOnUtc", None))
-
         def _parse_updated_on_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -570,268 +552,196 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         updated_on_utc = _parse_updated_on_utc(d.pop("UpdatedOnUtc", None))
-
         def _parse_equipment_id(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         equipment_id = _parse_equipment_id(d.pop("EquipmentId", None))
-
         def _parse_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level = _parse_service_level(d.pop("ServiceLevel", None))
-
         def _parse_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_code = _parse_service_level_code(d.pop("ServiceLevelCode", None))
-
         def _parse_service_level_document_number(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_document_number = _parse_service_level_document_number(
             d.pop("ServiceLevelDocumentNumber", None)
         )
-
         def _parse_service_level_document_section(
             data: object,
         ) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_level_document_section = _parse_service_level_document_section(
             d.pop("ServiceLevelDocumentSection", None)
         )
-
         def _parse_next_service_level(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level = _parse_next_service_level(d.pop("NextServiceLevel", None))
-
         def _parse_next_service_level_code(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         next_service_level_code = _parse_next_service_level_code(
             d.pop("NextServiceLevelCode", None)
         )
-
         def _parse_result_status(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         result_status = _parse_result_status(d.pop("ResultStatus", None))
-
         def _parse_as_found_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_found_result = _parse_as_found_result(d.pop("AsFoundResult", None))
-
         def _parse_as_left_result(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         as_left_result = _parse_as_left_result(d.pop("AsLeftResult", None))
-
         def _parse_serial_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         serial_number = _parse_serial_number(d.pop("SerialNumber", None))
-
         def _parse_serial_number_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         serial_number_change = _parse_serial_number_change(d.pop("SerialNumberChange", None))
-
         def _parse_asset_tag(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag = _parse_asset_tag(d.pop("AssetTag", None))
-
         def _parse_asset_user(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user = _parse_asset_user(d.pop("AssetUser", None))
-
         def _parse_asset_tag_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_tag_change = _parse_asset_tag_change(d.pop("AssetTagChange", None))
-
         def _parse_asset_user_change(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_user_change = _parse_asset_user_change(d.pop("AssetUserChange", None))
-
         def _parse_asset_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         asset_id = _parse_asset_id(d.pop("AssetId", None))
-
         def _parse_asset_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_name = _parse_asset_name(d.pop("AssetName", None))
-
         def _parse_asset_description(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_description = _parse_asset_description(d.pop("AssetDescription", None))
-
         def _parse_asset_site_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_site_name = _parse_asset_site_name(d.pop("AssetSiteName", None))
-
         def _parse_asset_site_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         asset_site_id = _parse_asset_site_id(d.pop("AssetSiteId", None))
-
         def _parse_asset_company_name(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         asset_company_name = _parse_asset_company_name(d.pop("AssetCompanyName", None))
-
         def _parse_asset_company_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         asset_company_id = _parse_asset_company_id(d.pop("AssetCompanyId", None))
-
         def _parse_client_company_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         client_company_id = _parse_client_company_id(d.pop("ClientCompanyId", None))
-
         def _parse_vendor_company_id(data: object) -> Optional[int]:
             if not data:
                 return None
             return cast(Optional[int], data)
-
         vendor_company_id = _parse_vendor_company_id(d.pop("VendorCompanyId", None))
-
         def _parse_service_notes(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         service_notes = _parse_service_notes(d.pop("ServiceNotes", None))
-
         def _parse_provider_technician(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_technician = _parse_provider_technician(d.pop("ProviderTechnician", None))
-
         def _parse_provider_phone(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_phone = _parse_provider_phone(d.pop("ProviderPhone", None))
-
         def _parse_provider_company(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         provider_company = _parse_provider_company(d.pop("ProviderCompany", None))
-
         def _parse_service_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         service_charge = _parse_service_charge(d.pop("ServiceCharge", None))
-
         def _parse_repairs_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         repairs_charge = _parse_repairs_charge(d.pop("RepairsCharge", None))
-
         def _parse_parts_charge(data: object) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge = _parse_parts_charge(d.pop("PartsCharge", None))
-
         def _parse_parts_charge_before_discount(
             data: object,
         ) -> Optional[float]:
             if not data:
                 return None
             return cast(Optional[float], data)
-
         parts_charge_before_discount = _parse_parts_charge_before_discount(
             d.pop("PartsChargeBeforeDiscount", None)
         )
-
         def _parse_custom_order_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         custom_order_number = _parse_custom_order_number(d.pop("CustomOrderNumber", None))
-
         def _parse_certificate_number(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         certificate_number = _parse_certificate_number(d.pop("CertificateNumber", None))
-
         def _parse_service_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -843,9 +753,7 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         service_date = _parse_service_date(d.pop("ServiceDate", None))
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -857,9 +765,7 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         def _parse_next_service_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -873,15 +779,12 @@ class ServiceOrdersToClientOrderItemResponseModel:
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         next_service_date = _parse_next_service_date(d.pop("NextServiceDate", None))
         maintenance_task = d.pop("MaintenanceTask", None)
-
         def _parse_maintenance_plan(data: object) -> Optional[str]:
             if not data:
                 return None
             return cast(Optional[str], data)
-
         maintenance_plan = _parse_maintenance_plan(d.pop("MaintenancePlan", None))
         service_options = []
         _service_options = d.pop("ServiceOptions", None)

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model.py
@@ -254,383 +254,118 @@ class ServiceOrdersToClientOrderResponseModel:
         from ..models.qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0 import (
             ServiceOrdersToClientOrderResponseModelShippingAddressType0,
         )
-
         service_order_id = self.service_order_id
-
         parent_order_id = self.parent_order_id
-
         client_legacy_id = self.client_legacy_id
-
         owner_name = self.owner_name
-
         submited_by_name = self.submited_by_name
-
         sign_off_by_name = self.sign_off_by_name
-
         vendor_sign_off_by_name = self.vendor_sign_off_by_name
-
         approved_by_name = self.approved_by_name
-
         accepted_by_name = self.accepted_by_name
-
         ready_for_quality_control_by_name = self.ready_for_quality_control_by_name
-
         quality_control_by_name = self.quality_control_by_name
-
         created_by_name = self.created_by_name
-
         completed_by_name = self.completed_by_name
-
         shipped_by_name = self.shipped_by_name
-
         delivered_by_name = self.delivered_by_name
-
         invoiced_by_name = self.invoiced_by_name
-
         paid_by_name = self.paid_by_name
-
         cancelled_by_name = self.cancelled_by_name
-
         closed_by_name = self.closed_by_name
-
         client_company_id = self.client_company_id
-
         client_company_name = self.client_company_name
-
         client_domain_name = self.client_domain_name
-
         client_alternative_names = self.client_alternative_names
-
         service_comments = self.service_comments
-
         service_private_comments = self.service_private_comments
-
-        created_on: Optional[str]
-        if not self.created_on:
-            created_on = None
-        elif isinstance(self.created_on, datetime.datetime):
-            created_on = self.created_on.isoformat()
-        else:
-            created_on = self.created_on
-
-        approved_on: Optional[str]
-        if not self.approved_on:
-            approved_on = None
-        elif isinstance(self.approved_on, datetime.datetime):
-            approved_on = self.approved_on.isoformat()
-        else:
-            approved_on = self.approved_on
-
-        sign_off_on: Optional[str]
-        if not self.sign_off_on:
-            sign_off_on = None
-        elif isinstance(self.sign_off_on, datetime.datetime):
-            sign_off_on = self.sign_off_on.isoformat()
-        else:
-            sign_off_on = self.sign_off_on
-
-        vendor_sign_off_on: Optional[str]
-        if not self.vendor_sign_off_on:
-            vendor_sign_off_on = None
-        elif isinstance(self.vendor_sign_off_on, datetime.datetime):
-            vendor_sign_off_on = self.vendor_sign_off_on.isoformat()
-        else:
-            vendor_sign_off_on = self.vendor_sign_off_on
-
-        completed_on: Optional[str]
-        if not self.completed_on:
-            completed_on = None
-        elif isinstance(self.completed_on, datetime.datetime):
-            completed_on = self.completed_on.isoformat()
-        else:
-            completed_on = self.completed_on
-
-        submited_on: Optional[str]
-        if not self.submited_on:
-            submited_on = None
-        elif isinstance(self.submited_on, datetime.datetime):
-            submited_on = self.submited_on.isoformat()
-        else:
-            submited_on = self.submited_on
-
-        shipped_on: Optional[str]
-        if not self.shipped_on:
-            shipped_on = None
-        elif isinstance(self.shipped_on, datetime.datetime):
-            shipped_on = self.shipped_on.isoformat()
-        else:
-            shipped_on = self.shipped_on
-
-        accepted_on: Optional[str]
-        if not self.accepted_on:
-            accepted_on = None
-        elif isinstance(self.accepted_on, datetime.datetime):
-            accepted_on = self.accepted_on.isoformat()
-        else:
-            accepted_on = self.accepted_on
-
-        ready_for_quality_control_on: Optional[str]
-        if not self.ready_for_quality_control_on:
-            ready_for_quality_control_on = None
-        elif isinstance(self.ready_for_quality_control_on, datetime.datetime):
-            ready_for_quality_control_on = self.ready_for_quality_control_on.isoformat()
-        else:
-            ready_for_quality_control_on = self.ready_for_quality_control_on
-
-        quality_control_on: Optional[str]
-        if not self.quality_control_on:
-            quality_control_on = None
-        elif isinstance(self.quality_control_on, datetime.datetime):
-            quality_control_on = self.quality_control_on.isoformat()
-        else:
-            quality_control_on = self.quality_control_on
-
-        delivered_on: Optional[str]
-        if not self.delivered_on:
-            delivered_on = None
-        elif isinstance(self.delivered_on, datetime.datetime):
-            delivered_on = self.delivered_on.isoformat()
-        else:
-            delivered_on = self.delivered_on
-
-        invoiced_on: Optional[str]
-        if not self.invoiced_on:
-            invoiced_on = None
-        elif isinstance(self.invoiced_on, datetime.datetime):
-            invoiced_on = self.invoiced_on.isoformat()
-        else:
-            invoiced_on = self.invoiced_on
-
-        last_invoiced_on: Optional[str]
-        if not self.last_invoiced_on:
-            last_invoiced_on = None
-        elif isinstance(self.last_invoiced_on, datetime.datetime):
-            last_invoiced_on = self.last_invoiced_on.isoformat()
-        else:
-            last_invoiced_on = self.last_invoiced_on
-
-        payment_due_on: Optional[str]
-        if not self.payment_due_on:
-            payment_due_on = None
-        elif isinstance(self.payment_due_on, datetime.datetime):
-            payment_due_on = self.payment_due_on.isoformat()
-        else:
-            payment_due_on = self.payment_due_on
-
-        paid_on: Optional[str]
-        if not self.paid_on:
-            paid_on = None
-        elif isinstance(self.paid_on, datetime.datetime):
-            paid_on = self.paid_on.isoformat()
-        else:
-            paid_on = self.paid_on
-
-        late_fee_on: Optional[str]
-        if not self.late_fee_on:
-            late_fee_on = None
-        elif isinstance(self.late_fee_on, datetime.datetime):
-            late_fee_on = self.late_fee_on.isoformat()
-        else:
-            late_fee_on = self.late_fee_on
-
-        cancelled_on: Optional[str]
-        if not self.cancelled_on:
-            cancelled_on = None
-        elif isinstance(self.cancelled_on, datetime.datetime):
-            cancelled_on = self.cancelled_on.isoformat()
-        else:
-            cancelled_on = self.cancelled_on
-
-        closed_on: Optional[str]
-        if not self.closed_on:
-            closed_on = None
-        elif isinstance(self.closed_on, datetime.datetime):
-            closed_on = self.closed_on.isoformat()
-        else:
-            closed_on = self.closed_on
-
+        created_on = self.created_on.isoformat() if self.created_on else None
+        approved_on = self.approved_on.isoformat() if self.approved_on else None
+        sign_off_on = self.sign_off_on.isoformat() if self.sign_off_on else None
+        vendor_sign_off_on = self.vendor_sign_off_on.isoformat() if self.vendor_sign_off_on else None
+        completed_on = self.completed_on.isoformat() if self.completed_on else None
+        submited_on = self.submited_on.isoformat() if self.submited_on else None
+        shipped_on = self.shipped_on.isoformat() if self.shipped_on else None
+        accepted_on = self.accepted_on.isoformat() if self.accepted_on else None
+        ready_for_quality_control_on = self.ready_for_quality_control_on.isoformat() if self.ready_for_quality_control_on else None
+        quality_control_on = self.quality_control_on.isoformat() if self.quality_control_on else None
+        delivered_on = self.delivered_on.isoformat() if self.delivered_on else None
+        invoiced_on = self.invoiced_on.isoformat() if self.invoiced_on else None
+        last_invoiced_on = self.last_invoiced_on.isoformat() if self.last_invoiced_on else None
+        payment_due_on = self.payment_due_on.isoformat() if self.payment_due_on else None
+        paid_on = self.paid_on.isoformat() if self.paid_on else None
+        late_fee_on = self.late_fee_on.isoformat() if self.late_fee_on else None
+        cancelled_on = self.cancelled_on.isoformat() if self.cancelled_on else None
+        closed_on = self.closed_on.isoformat() if self.closed_on else None
         last_updated_on: Optional[str] = None
         if self.last_updated_on:
             last_updated_on = self.last_updated_on.isoformat()
-
         last_updated_by = self.last_updated_by
-
         submited_by_id = self.submited_by_id
-
         sign_off_by_id = self.sign_off_by_id
-
         vendor_sign_off_by_id = self.vendor_sign_off_by_id
-
         approved_by_id = self.approved_by_id
-
         late_fee_by_id = self.late_fee_by_id
-
         accepted_by_id = self.accepted_by_id
-
         ready_for_quality_control_by_id = self.ready_for_quality_control_by_id
-
         quality_control_by_id = self.quality_control_by_id
-
         created_by_id = self.created_by_id
-
         completed_by_id = self.completed_by_id
-
         shipped_by_id = self.shipped_by_id
-
         delivered_by_id = self.delivered_by_id
-
         invoiced_by_id = self.invoiced_by_id
-
         paid_by_id = self.paid_by_id
-
         cancelled_by_id = self.cancelled_by_id
-
         closed_by_id = self.closed_by_id
-
         po_number = self.po_number
-
         secondary_po = self.secondary_po
-
         service_total = self.service_total
-
         repairs_total = self.repairs_total
-
         parts_total = self.parts_total
-
         parts_total_before_discount = self.parts_total_before_discount
-
         parts_discount_total = self.parts_discount_total
-
         effective_tax_rate = self.effective_tax_rate
-
         tax_amount = self.tax_amount
-
         shipping_fee = self.shipping_fee
-
         travel_charge = self.travel_charge
-
         late_fee = self.late_fee
-
         is_tax_exempt = self.is_tax_exempt
-
         service_discount = self.service_discount
-
         trade_in_credit = self.trade_in_credit
-
         prepaid_credit = self.prepaid_credit
-
         grand_total = self.grand_total
-
         paid_amount = self.paid_amount
-
         remaining_balance = self.remaining_balance
-
         service_discount_details = self.service_discount_details
-
         trade_in_credit_details = self.trade_in_credit_details
-
         prepaid_credit_details = self.prepaid_credit_details
-
         payment_notes = self.payment_notes
-
         service_order_number = self.service_order_number
-
         legacy_order_number = self.legacy_order_number
-
         custom_order_number = self.custom_order_number
-
         payment_status = self.payment_status
-
         payment_option = self.payment_option
-
         shipment_status = self.shipment_status
-
         order_status = self.order_status
-
         owner_id = self.owner_id
-
         owner_department = self.owner_department
-
         client_site = self.client_site
-
         client_site_code = self.client_site_code
-
         vendor_site = self.vendor_site
-
         internal = self.internal
-
         guid: Optional[str] = None
         if self.guid:
             guid = str(self.guid)
-
-        business_from_time: Optional[str]
-        if not self.business_from_time:
-            business_from_time = None
-        elif isinstance(self.business_from_time, datetime.datetime):
-            business_from_time = self.business_from_time.isoformat()
-        else:
-            business_from_time = self.business_from_time
-
-        business_to_time: Optional[str]
-        if not self.business_to_time:
-            business_to_time = None
-        elif isinstance(self.business_to_time, datetime.datetime):
-            business_to_time = self.business_to_time.isoformat()
-        else:
-            business_to_time = self.business_to_time
-
+        business_from_time = self.business_from_time.isoformat() if self.business_from_time else None
+        business_to_time = self.business_to_time.isoformat() if self.business_to_time else None
         site_access_notes = self.site_access_notes
-
-        desired_date: Optional[str]
-        if not self.desired_date:
-            desired_date = None
-        elif isinstance(self.desired_date, datetime.datetime):
-            desired_date = self.desired_date.isoformat()
-        else:
-            desired_date = self.desired_date
-
-        deadline_date: Optional[str]
-        if not self.deadline_date:
-            deadline_date = None
-        elif isinstance(self.deadline_date, datetime.datetime):
-            deadline_date = self.deadline_date.isoformat()
-        else:
-            deadline_date = self.deadline_date
-
-        request_from_date: Optional[str]
-        if not self.request_from_date:
-            request_from_date = None
-        elif isinstance(self.request_from_date, datetime.datetime):
-            request_from_date = self.request_from_date.isoformat()
-        else:
-            request_from_date = self.request_from_date
-
-        request_from_time: Optional[str]
-        if not self.request_from_time:
-            request_from_time = None
-        elif isinstance(self.request_from_time, datetime.datetime):
-            request_from_time = self.request_from_time.isoformat()
-        else:
-            request_from_time = self.request_from_time
-
-        request_to_date: Optional[str]
-        if not self.request_to_date:
-            request_to_date = None
-        elif isinstance(self.request_to_date, datetime.datetime):
-            request_to_date = self.request_to_date.isoformat()
-        else:
-            request_to_date = self.request_to_date
-
-        request_to_time: Optional[str]
-        if not self.request_to_time:
-            request_to_time = None
-        elif isinstance(self.request_to_time, datetime.datetime):
-            request_to_time = self.request_to_time.isoformat()
-        else:
-            request_to_time = self.request_to_time
-
+        desired_date = self.desired_date.isoformat() if self.desired_date else None
+        deadline_date = self.deadline_date.isoformat() if self.deadline_date else None
+        request_from_date = self.request_from_date.isoformat() if self.request_from_date else None
+        request_from_time = self.request_from_time.isoformat() if self.request_from_time else None
+        request_to_date = self.request_to_date.isoformat() if self.request_to_date else None
+        request_to_time = self.request_to_time.isoformat() if self.request_to_time else None
         order_notes = self.order_notes
-
         billing_address: Optional[Dict[str, Any]]
         if not self.billing_address:
             billing_address = None
@@ -641,7 +376,6 @@ class ServiceOrdersToClientOrderResponseModel:
             billing_address = self.billing_address.to_dict()
         else:
             billing_address = self.billing_address
-
         shipping_address: Optional[Dict[str, Any]]
         if not self.shipping_address:
             shipping_address = None
@@ -652,7 +386,6 @@ class ServiceOrdersToClientOrderResponseModel:
             shipping_address = self.shipping_address.to_dict()
         else:
             shipping_address = self.shipping_address
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -876,7 +609,6 @@ class ServiceOrdersToClientOrderResponseModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -887,58 +619,32 @@ class ServiceOrdersToClientOrderResponseModel:
         from ..models.qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0 import (
             ServiceOrdersToClientOrderResponseModelShippingAddressType0,
         )
-
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         parent_order_id = d.pop("ParentOrderId", None)
-
         client_legacy_id = d.pop("ClientLegacyId", None)
-
         owner_name = d.pop("OwnerName", None)
-
         submited_by_name = d.pop("SubmitedByName", None)
-
         sign_off_by_name = d.pop("SignOffByName", None)
-
         vendor_sign_off_by_name = d.pop("VendorSignOffByName", None)
-
         approved_by_name = d.pop("ApprovedByName", None)
-
         accepted_by_name = d.pop("AcceptedByName", None)
-
         ready_for_quality_control_by_name = d.pop("ReadyForQualityControlByName", None)
-
         quality_control_by_name = d.pop("QualityControlByName", None)
-
         created_by_name = d.pop("CreatedByName", None)
-
         completed_by_name = d.pop("CompletedByName", None)
-
         shipped_by_name = d.pop("ShippedByName", None)
-
         delivered_by_name = d.pop("DeliveredByName", None)
-
         invoiced_by_name = d.pop("InvoicedByName", None)
-
         paid_by_name = d.pop("PaidByName", None)
-
         cancelled_by_name = d.pop("CancelledByName", None)
-
         closed_by_name = d.pop("ClosedByName", None)
-
         client_company_id = d.pop("ClientCompanyId", None)
-
         client_company_name = d.pop("ClientCompanyName", None)
-
         client_domain_name = d.pop("ClientDomainName", None)
-
         client_alternative_names = d.pop("ClientAlternativeNames", None)
-
         service_comments = d.pop("ServiceComments", None)
-
         service_private_comments = d.pop("ServicePrivateComments", None)
-
         def _parse_created_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -946,14 +652,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 created_on_type_0 = isoparse(data)
-
                 return created_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         created_on = _parse_created_on(d.pop("CreatedOn", None))
-
         def _parse_approved_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -961,14 +664,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 approved_on_type_0 = isoparse(data)
-
                 return approved_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         approved_on = _parse_approved_on(d.pop("ApprovedOn", None))
-
         def _parse_sign_off_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -976,14 +676,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 sign_off_on_type_0 = isoparse(data)
-
                 return sign_off_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         sign_off_on = _parse_sign_off_on(d.pop("SignOffOn", None))
-
         def _parse_vendor_sign_off_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -993,14 +690,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 vendor_sign_off_on_type_0 = isoparse(data)
-
                 return vendor_sign_off_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         vendor_sign_off_on = _parse_vendor_sign_off_on(d.pop("VendorSignOffOn", None))
-
         def _parse_completed_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1008,14 +702,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 completed_on_type_0 = isoparse(data)
-
                 return completed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         completed_on = _parse_completed_on(d.pop("CompletedOn", None))
-
         def _parse_submited_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1023,14 +714,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 submited_on_type_0 = isoparse(data)
-
                 return submited_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         submited_on = _parse_submited_on(d.pop("SubmitedOn", None))
-
         def _parse_shipped_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1038,14 +726,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 shipped_on_type_0 = isoparse(data)
-
                 return shipped_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         shipped_on = _parse_shipped_on(d.pop("ShippedOn", None))
-
         def _parse_accepted_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1053,14 +738,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 accepted_on_type_0 = isoparse(data)
-
                 return accepted_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         accepted_on = _parse_accepted_on(d.pop("AcceptedOn", None))
-
         def _parse_ready_for_quality_control_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1070,16 +752,13 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 ready_for_quality_control_on_type_0 = isoparse(data)
-
                 return ready_for_quality_control_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         ready_for_quality_control_on = _parse_ready_for_quality_control_on(
             d.pop("ReadyForQualityControlOn", None)
         )
-
         def _parse_quality_control_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1089,14 +768,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 quality_control_on_type_0 = isoparse(data)
-
                 return quality_control_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         quality_control_on = _parse_quality_control_on(d.pop("QualityControlOn", None))
-
         def _parse_delivered_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1104,14 +780,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 delivered_on_type_0 = isoparse(data)
-
                 return delivered_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         delivered_on = _parse_delivered_on(d.pop("DeliveredOn", None))
-
         def _parse_invoiced_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1119,14 +792,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 invoiced_on_type_0 = isoparse(data)
-
                 return invoiced_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         invoiced_on = _parse_invoiced_on(d.pop("InvoicedOn", None))
-
         def _parse_last_invoiced_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1136,14 +806,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_invoiced_on_type_0 = isoparse(data)
-
                 return last_invoiced_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_invoiced_on = _parse_last_invoiced_on(d.pop("LastInvoicedOn", None))
-
         def _parse_payment_due_on(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1153,14 +820,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 payment_due_on_type_0 = isoparse(data)
-
                 return payment_due_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         payment_due_on = _parse_payment_due_on(d.pop("PaymentDueOn", None))
-
         def _parse_paid_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1168,14 +832,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 paid_on_type_0 = isoparse(data)
-
                 return paid_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         paid_on = _parse_paid_on(d.pop("PaidOn", None))
-
         def _parse_late_fee_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1183,14 +844,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 late_fee_on_type_0 = isoparse(data)
-
                 return late_fee_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         late_fee_on = _parse_late_fee_on(d.pop("LateFeeOn", None))
-
         def _parse_cancelled_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1198,14 +856,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 cancelled_on_type_0 = isoparse(data)
-
                 return cancelled_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         cancelled_on = _parse_cancelled_on(d.pop("CancelledOn", None))
-
         def _parse_closed_on(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1213,134 +868,76 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 closed_on_type_0 = isoparse(data)
-
                 return closed_on_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         closed_on = _parse_closed_on(d.pop("ClosedOn", None))
-
         _last_updated_on = d.pop("LastUpdatedOn", None)
         last_updated_on: Optional[datetime.datetime]
         if not _last_updated_on:
             last_updated_on = None
         else:
             last_updated_on = isoparse(_last_updated_on)
-
         last_updated_by = d.pop("LastUpdatedBy", None)
-
         submited_by_id = d.pop("SubmitedById", None)
-
         sign_off_by_id = d.pop("SignOffById", None)
-
         vendor_sign_off_by_id = d.pop("VendorSignOffById", None)
-
         approved_by_id = d.pop("ApprovedById", None)
-
         late_fee_by_id = d.pop("LateFeeById", None)
-
         accepted_by_id = d.pop("AcceptedById", None)
-
         ready_for_quality_control_by_id = d.pop("ReadyForQualityControlById", None)
-
         quality_control_by_id = d.pop("QualityControlById", None)
-
         created_by_id = d.pop("CreatedById", None)
-
         completed_by_id = d.pop("CompletedById", None)
-
         shipped_by_id = d.pop("ShippedById", None)
-
         delivered_by_id = d.pop("DeliveredById", None)
-
         invoiced_by_id = d.pop("InvoicedById", None)
-
         paid_by_id = d.pop("PaidById", None)
-
         cancelled_by_id = d.pop("CancelledById", None)
-
         closed_by_id = d.pop("ClosedById", None)
-
         po_number = d.pop("PoNumber", None)
-
         secondary_po = d.pop("SecondaryPo", None)
-
         service_total = d.pop("ServiceTotal", None)
-
         repairs_total = d.pop("RepairsTotal", None)
-
         parts_total = d.pop("PartsTotal", None)
-
         parts_total_before_discount = d.pop("PartsTotalBeforeDiscount", None)
-
         parts_discount_total = d.pop("PartsDiscountTotal", None)
-
         effective_tax_rate = d.pop("EffectiveTaxRate", None)
-
         tax_amount = d.pop("TaxAmount", None)
-
         shipping_fee = d.pop("ShippingFee", None)
-
         travel_charge = d.pop("TravelCharge", None)
-
         late_fee = d.pop("LateFee", None)
-
         is_tax_exempt = d.pop("IsTaxExempt", None)
-
         service_discount = d.pop("ServiceDiscount", None)
-
         trade_in_credit = d.pop("TradeInCredit", None)
-
         prepaid_credit = d.pop("PrepaidCredit", None)
-
         grand_total = d.pop("GrandTotal", None)
-
         paid_amount = d.pop("PaidAmount", None)
-
         remaining_balance = d.pop("RemainingBalance", None)
-
         service_discount_details = d.pop("ServiceDiscountDetails", None)
-
         trade_in_credit_details = d.pop("TradeInCreditDetails", None)
-
         prepaid_credit_details = d.pop("PrepaidCreditDetails", None)
-
         payment_notes = d.pop("PaymentNotes", None)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         legacy_order_number = d.pop("LegacyOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         payment_status = d.pop("PaymentStatus", None)
-
         payment_option = d.pop("PaymentOption", None)
-
         shipment_status = d.pop("ShipmentStatus", None)
-
         order_status = d.pop("OrderStatus", None)
-
         owner_id = d.pop("OwnerId", None)
-
         owner_department = d.pop("OwnerDepartment", None)
-
         client_site = d.pop("ClientSite", None)
-
         client_site_code = d.pop("ClientSiteCode", None)
-
         vendor_site = d.pop("VendorSite", None)
-
         internal = d.pop("Internal", None)
-
         _guid = d.pop("Guid", None)
         guid: Optional[UUID]
         if not _guid:
             guid = None
         else:
             guid = UUID(_guid)
-
         def _parse_business_from_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1350,14 +947,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_from_time_type_0 = isoparse(data)
-
                 return business_from_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_from_time = _parse_business_from_time(d.pop("BusinessFromTime", None))
-
         def _parse_business_to_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1367,16 +961,12 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_to_time_type_0 = isoparse(data)
-
                 return business_to_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_to_time = _parse_business_to_time(d.pop("BusinessToTime", None))
-
         site_access_notes = d.pop("SiteAccessNotes", None)
-
         def _parse_desired_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1384,14 +974,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 desired_date_type_0 = isoparse(data)
-
                 return desired_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         desired_date = _parse_desired_date(d.pop("DesiredDate", None))
-
         def _parse_deadline_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -1399,14 +986,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 deadline_date_type_0 = isoparse(data)
-
                 return deadline_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         deadline_date = _parse_deadline_date(d.pop("DeadlineDate", None))
-
         def _parse_request_from_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1416,14 +1000,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_from_date_type_0 = isoparse(data)
-
                 return request_from_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_from_date = _parse_request_from_date(d.pop("RequestFromDate", None))
-
         def _parse_request_from_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1433,14 +1014,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_from_time_type_0 = isoparse(data)
-
                 return request_from_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_from_time = _parse_request_from_time(d.pop("RequestFromTime", None))
-
         def _parse_request_to_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1450,14 +1028,11 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_to_date_type_0 = isoparse(data)
-
                 return request_to_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_to_date = _parse_request_to_date(d.pop("RequestToDate", None))
-
         def _parse_request_to_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -1467,16 +1042,12 @@ class ServiceOrdersToClientOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_to_time_type_0 = isoparse(data)
-
                 return request_to_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_to_time = _parse_request_to_time(d.pop("RequestToTime", None))
-
         order_notes = d.pop("OrderNotes", None)
-
         def _parse_billing_address(
             data: object,
         ) -> Optional["ServiceOrdersToClientOrderResponseModelBillingAddressType0"]:
@@ -1488,7 +1059,6 @@ class ServiceOrdersToClientOrderResponseModel:
                 billing_address_type_0 = (
                     ServiceOrdersToClientOrderResponseModelBillingAddressType0.from_dict(data)
                 )
-
                 return billing_address_type_0
             except Exception:
                 pass
@@ -1496,9 +1066,7 @@ class ServiceOrdersToClientOrderResponseModel:
                 Optional["ServiceOrdersToClientOrderResponseModelBillingAddressType0"],
                 data,
             )
-
         billing_address = _parse_billing_address(d.pop("BillingAddress", None))
-
         def _parse_shipping_address(
             data: object,
         ) -> Optional["ServiceOrdersToClientOrderResponseModelShippingAddressType0"]:
@@ -1510,7 +1078,6 @@ class ServiceOrdersToClientOrderResponseModel:
                 shipping_address_type_0 = (
                     ServiceOrdersToClientOrderResponseModelShippingAddressType0.from_dict(data)
                 )
-
                 return shipping_address_type_0
             except Exception:
                 pass
@@ -1518,9 +1085,7 @@ class ServiceOrdersToClientOrderResponseModel:
                 Optional["ServiceOrdersToClientOrderResponseModelShippingAddressType0"],
                 data,
             )
-
         shipping_address = _parse_shipping_address(d.pop("ShippingAddress", None))
-
         qualer_api_models_service_orders_to_client_order_response_model = cls(
             service_order_id=service_order_id,
             parent_order_id=parent_order_id,
@@ -1633,7 +1198,6 @@ class ServiceOrdersToClientOrderResponseModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_service_orders_to_client_order_response_model.additional_properties = d
         return qualer_api_models_service_orders_to_client_order_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model_billing_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model_billing_address_type_0.py
@@ -19,7 +19,6 @@ class ServiceOrdersToClientOrderResponseModelBillingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
@@ -28,7 +27,6 @@ class ServiceOrdersToClientOrderResponseModelBillingAddressType0:
         qualer_api_models_service_orders_to_client_order_response_model_billing_address_type_0 = (
             cls()
         )
-
         qualer_api_models_service_orders_to_client_order_response_model_billing_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0.py
@@ -19,7 +19,6 @@ class ServiceOrdersToClientOrderResponseModelShippingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
@@ -28,7 +27,6 @@ class ServiceOrdersToClientOrderResponseModelShippingAddressType0:
         qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0 = (
             cls()
         )
-
         qualer_api_models_service_orders_to_client_order_response_model_shipping_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_created_work_order_payment_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_created_work_order_payment_response.py
@@ -19,24 +19,20 @@ class ServiceOrdersToCreatedWorkOrderPaymentResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_service_orders_to_created_work_order_payment_response = cls(
             id=id,
         )
-
         qualer_api_models_service_orders_to_created_work_order_payment_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_order_assignment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_order_assignment_response_model.py
@@ -43,35 +43,17 @@ class ServiceOrdersToOrderAssignmentResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         work_item_id = self.work_item_id
-
         employee_id = self.employee_id
-
         company_id = self.company_id
-
         subscription_email = self.subscription_email
-
         subscription_phone = self.subscription_phone
-
         office_phone = self.office_phone
-
         is_locked = self.is_locked
-
         image_url = self.image_url
-
         alias = self.alias
-
         title = self.title
-
         is_deleted = self.is_deleted
-
-        last_seen_date_utc: Optional[str]
-        if not self.last_seen_date_utc:
-            last_seen_date_utc = None
-        elif isinstance(self.last_seen_date_utc, datetime.datetime):
-            last_seen_date_utc = self.last_seen_date_utc.isoformat()
-        else:
-            last_seen_date_utc = self.last_seen_date_utc
-
+        last_seen_date_utc = self.last_seen_date_utc.isoformat() if self.last_seen_date_utc else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -99,34 +81,22 @@ class ServiceOrdersToOrderAssignmentResponseModel:
             field_dict["IsDeleted"] = is_deleted
         if last_seen_date_utc is not None:
             field_dict["LastSeenDateUtc"] = last_seen_date_utc
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         work_item_id = d.pop("WorkItemId", None)
-
         employee_id = d.pop("EmployeeId", None)
-
         company_id = d.pop("CompanyId", None)
-
         subscription_email = d.pop("SubscriptionEmail", None)
-
         subscription_phone = d.pop("SubscriptionPhone", None)
-
         office_phone = d.pop("OfficePhone", None)
-
         is_locked = d.pop("IsLocked", None)
-
         image_url = d.pop("ImageUrl", None)
-
         alias = d.pop("Alias", None)
-
         title = d.pop("Title", None)
-
         is_deleted = d.pop("IsDeleted", None)
-
         def _parse_last_seen_date_utc(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -136,14 +106,11 @@ class ServiceOrdersToOrderAssignmentResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 last_seen_date_utc_type_0 = isoparse(data)
-
                 return last_seen_date_utc_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         last_seen_date_utc = _parse_last_seen_date_utc(d.pop("LastSeenDateUtc", None))
-
         qualer_api_models_service_orders_to_order_assignment_response_model = cls(
             work_item_id=work_item_id,
             employee_id=employee_id,
@@ -158,7 +125,6 @@ class ServiceOrdersToOrderAssignmentResponseModel:
             is_deleted=is_deleted,
             last_seen_date_utc=last_seen_date_utc,
         )
-
         qualer_api_models_service_orders_to_order_assignment_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_payment_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_payment_response_model.py
@@ -33,21 +33,13 @@ class ServiceOrdersToPaymentResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         created_by_id = self.created_by_id
-
         transaction_id = self.transaction_id
-
         transaction_status = self.transaction_status
-
         payment_type = self.payment_type
-
         service_order_payment_id = self.service_order_payment_id
-
         payment_amount = self.payment_amount
-
         details = self.details
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -67,28 +59,19 @@ class ServiceOrdersToPaymentResponseModel:
             field_dict["PaymentAmount"] = payment_amount
         if details is not None:
             field_dict["Details"] = details
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         created_by_id = d.pop("CreatedById", None)
-
         transaction_id = d.pop("TransactionId", None)
-
         transaction_status = d.pop("TransactionStatus", None)
-
         payment_type = d.pop("PaymentType", None)
-
         service_order_payment_id = d.pop("ServiceOrderPaymentId", None)
-
         payment_amount = d.pop("PaymentAmount", None)
-
         details = d.pop("Details", None)
-
         qualer_api_models_service_orders_to_payment_response_model = cls(
             service_order_id=service_order_id,
             created_by_id=created_by_id,
@@ -99,7 +82,6 @@ class ServiceOrdersToPaymentResponseModel:
             payment_amount=payment_amount,
             details=details,
         )
-
         qualer_api_models_service_orders_to_payment_response_model.additional_properties = d
         return qualer_api_models_service_orders_to_payment_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_provider_service_order_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_provider_service_order_response_model.py
@@ -73,113 +73,31 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-
         guid: Optional[str] = None
         if self.guid:
             guid = str(self.guid)
-
         service_order_number = self.service_order_number
-
         custom_order_number = self.custom_order_number
-
-        due_date: Optional[str]
-        if not self.due_date:
-            due_date = None
-        elif isinstance(self.due_date, datetime.datetime):
-            due_date = self.due_date.isoformat()
-        else:
-            due_date = self.due_date
-
+        due_date = self.due_date.isoformat() if self.due_date else None
         assets = self.assets
-
         completed_assets = self.completed_assets
-
-        order_status: Optional[str] = None
-        if self.order_status:
-            order_status = self.order_status.value
-
+        order_status = self.order_status.value if self.order_status else None
         is_quality_control_fail = self.is_quality_control_fail
-
         service_private_comments = self.service_private_comments
-
         client_company_id = self.client_company_id
-
         client_company_name = self.client_company_name
-
         client_site_name = self.client_site_name
-
         client_legacy_id = self.client_legacy_id
-
-        business_from_time: Optional[str]
-        if not self.business_from_time:
-            business_from_time = None
-        elif isinstance(self.business_from_time, datetime.datetime):
-            business_from_time = self.business_from_time.isoformat()
-        else:
-            business_from_time = self.business_from_time
-
-        business_to_time: Optional[str]
-        if not self.business_to_time:
-            business_to_time = None
-        elif isinstance(self.business_to_time, datetime.datetime):
-            business_to_time = self.business_to_time.isoformat()
-        else:
-            business_to_time = self.business_to_time
-
-        timeframe: Optional[str] = None
-        if self.timeframe:
-            timeframe = self.timeframe.value
-
+        business_from_time = self.business_from_time.isoformat() if self.business_from_time else None
+        business_to_time = self.business_to_time.isoformat() if self.business_to_time else None
+        timeframe = self.timeframe.value if self.timeframe else None
         site_access_notes = self.site_access_notes
-
-        desired_date: Optional[str]
-        if not self.desired_date:
-            desired_date = None
-        elif isinstance(self.desired_date, datetime.datetime):
-            desired_date = self.desired_date.isoformat()
-        else:
-            desired_date = self.desired_date
-
-        deadline_date: Optional[str]
-        if not self.deadline_date:
-            deadline_date = None
-        elif isinstance(self.deadline_date, datetime.datetime):
-            deadline_date = self.deadline_date.isoformat()
-        else:
-            deadline_date = self.deadline_date
-
-        request_from_date: Optional[str]
-        if not self.request_from_date:
-            request_from_date = None
-        elif isinstance(self.request_from_date, datetime.datetime):
-            request_from_date = self.request_from_date.isoformat()
-        else:
-            request_from_date = self.request_from_date
-
-        request_from_time: Optional[str]
-        if not self.request_from_time:
-            request_from_time = None
-        elif isinstance(self.request_from_time, datetime.datetime):
-            request_from_time = self.request_from_time.isoformat()
-        else:
-            request_from_time = self.request_from_time
-
-        request_to_date: Optional[str]
-        if not self.request_to_date:
-            request_to_date = None
-        elif isinstance(self.request_to_date, datetime.datetime):
-            request_to_date = self.request_to_date.isoformat()
-        else:
-            request_to_date = self.request_to_date
-
-        request_to_time: Optional[str]
-        if not self.request_to_time:
-            request_to_time = None
-        elif isinstance(self.request_to_time, datetime.datetime):
-            request_to_time = self.request_to_time.isoformat()
-        else:
-            request_to_time = self.request_to_time
-
+        desired_date = self.desired_date.isoformat() if self.desired_date else None
+        deadline_date = self.deadline_date.isoformat() if self.deadline_date else None
+        request_from_date = self.request_from_date.isoformat() if self.request_from_date else None
+        request_from_time = self.request_from_time.isoformat() if self.request_from_time else None
+        request_to_date = self.request_to_date.isoformat() if self.request_to_date else None
+        request_to_time = self.request_to_time.isoformat() if self.request_to_time else None
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -231,25 +149,20 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
             field_dict["RequestToDate"] = request_to_date
         if request_to_time is not None:
             field_dict["RequestToTime"] = request_to_time
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_id = d.pop("ServiceOrderId", None)
-
         _guid = d.pop("Guid", None)
         guid: Optional[UUID]
         if not _guid:
             guid = None
         else:
             guid = UUID(_guid)
-
         service_order_number = d.pop("ServiceOrderNumber", None)
-
         custom_order_number = d.pop("CustomOrderNumber", None)
-
         def _parse_due_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -257,37 +170,25 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 due_date_type_0 = isoparse(data)
-
                 return due_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         due_date = _parse_due_date(d.pop("DueDate", None))
-
         assets = d.pop("Assets", None)
-
         completed_assets = d.pop("CompletedAssets", None)
-
         _order_status = d.pop("OrderStatus", None)
         order_status: Optional[ServiceOrderStatus]
         if not _order_status:
             order_status = None
         else:
             order_status = ServiceOrderStatus(_order_status)
-
         is_quality_control_fail = d.pop("IsQualityControlFail", None)
-
         service_private_comments = d.pop("ServicePrivateComments", None)
-
         client_company_id = d.pop("ClientCompanyId", None)
-
         client_company_name = d.pop("ClientCompanyName", None)
-
         client_site_name = d.pop("ClientSiteName", None)
-
         client_legacy_id = d.pop("ClientLegacyId", None)
-
         def _parse_business_from_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -297,14 +198,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_from_time_type_0 = isoparse(data)
-
                 return business_from_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_from_time = _parse_business_from_time(d.pop("BusinessFromTime", None))
-
         def _parse_business_to_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -314,23 +212,18 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 business_to_time_type_0 = isoparse(data)
-
                 return business_to_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         business_to_time = _parse_business_to_time(d.pop("BusinessToTime", None))
-
         _timeframe = d.pop("Timeframe", None)
         timeframe: Optional[ServiceOrdersToProviderServiceOrderResponseModelTimeframe]
         if not _timeframe:
             timeframe = None
         else:
             timeframe = ServiceOrdersToProviderServiceOrderResponseModelTimeframe(_timeframe)
-
         site_access_notes = d.pop("SiteAccessNotes", None)
-
         def _parse_desired_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -338,14 +231,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 desired_date_type_0 = isoparse(data)
-
                 return desired_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         desired_date = _parse_desired_date(d.pop("DesiredDate", None))
-
         def _parse_deadline_date(data: object) -> Optional[datetime.datetime]:
             if not data:
                 return None
@@ -353,14 +243,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 deadline_date_type_0 = isoparse(data)
-
                 return deadline_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         deadline_date = _parse_deadline_date(d.pop("DeadlineDate", None))
-
         def _parse_request_from_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -370,14 +257,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_from_date_type_0 = isoparse(data)
-
                 return request_from_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_from_date = _parse_request_from_date(d.pop("RequestFromDate", None))
-
         def _parse_request_from_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -387,14 +271,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_from_time_type_0 = isoparse(data)
-
                 return request_from_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_from_time = _parse_request_from_time(d.pop("RequestFromTime", None))
-
         def _parse_request_to_date(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -404,14 +285,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_to_date_type_0 = isoparse(data)
-
                 return request_to_date_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_to_date = _parse_request_to_date(d.pop("RequestToDate", None))
-
         def _parse_request_to_time(
             data: object,
         ) -> Optional[datetime.datetime]:
@@ -421,14 +299,11 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
                 if not isinstance(data, str):
                     raise TypeError()
                 request_to_time_type_0 = isoparse(data)
-
                 return request_to_time_type_0
             except Exception:
                 pass
             return cast(Optional[datetime.datetime], data)
-
         request_to_time = _parse_request_to_time(d.pop("RequestToTime", None))
-
         qualer_api_models_service_orders_to_provider_service_order_response_model = cls(
             service_order_id=service_order_id,
             guid=guid,
@@ -455,7 +330,6 @@ class ServiceOrdersToProviderServiceOrderResponseModel:
             request_to_date=request_to_date,
             request_to_time=request_to_time,
         )
-
         qualer_api_models_service_orders_to_provider_service_order_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_part_repair_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_part_repair_response.py
@@ -65,55 +65,32 @@ class ServiceOrdersToServiceOrderPartRepairResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_part_id = self.service_order_item_part_id
-
         price = self.price
-
         description = self.description
-
         name = self.name
-
         unit_name = self.unit_name
-
         quantity = self.quantity
-
         discount = self.discount
-
         delivery_charge = self.delivery_charge
-
         is_taxable = self.is_taxable
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         is_hourly_pricing = self.is_hourly_pricing
-
         free_quantity = self.free_quantity
-
         currency_iso_symbol = self.currency_iso_symbol
-
         created_by_id = self.created_by_id
-
         created_by = self.created_by
-
         created_on_utc: Optional[str] = None
         if self.created_on_utc:
             created_on_utc = self.created_on_utc.isoformat()
-
         charge_date: Optional[str] = None
         if self.charge_date:
             charge_date = self.charge_date.isoformat()
-
         contract_repairs_discount = self.contract_repairs_discount
-
         contract_parts_discount = self.contract_parts_discount
-
         service_order_charge_type = self.service_order_charge_type
-
         total_discount = self.total_discount
-
         total_price = self.total_price
-
         discount_price = self.discount_price
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -163,68 +140,44 @@ class ServiceOrdersToServiceOrderPartRepairResponse:
             field_dict["TotalPrice"] = total_price
         if discount_price is not None:
             field_dict["DiscountPrice"] = discount_price
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_part_id = d.pop("ServiceOrderItemPartId", None)
-
         price = d.pop("Price", None)
-
         description = d.pop("Description", None)
-
         name = d.pop("Name", None)
-
         unit_name = d.pop("UnitName", None)
-
         quantity = d.pop("Quantity", None)
-
         discount = d.pop("Discount", None)
-
         delivery_charge = d.pop("DeliveryCharge", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         free_quantity = d.pop("FreeQuantity", None)
-
         currency_iso_symbol = d.pop("CurrencyIsoSymbol", None)
-
         created_by_id = d.pop("CreatedById", None)
-
         created_by = d.pop("CreatedBy", None)
-
         _created_on_utc = d.pop("CreatedOnUtc", None)
         created_on_utc: Optional[datetime.datetime]
         if not _created_on_utc:
             created_on_utc = None
         else:
             created_on_utc = isoparse(_created_on_utc)
-
         _charge_date = d.pop("ChargeDate", None)
         charge_date: Optional[datetime.datetime]
         if not _charge_date:
             charge_date = None
         else:
             charge_date = isoparse(_charge_date)
-
         contract_repairs_discount = d.pop("ContractRepairsDiscount", None)
-
         contract_parts_discount = d.pop("ContractPartsDiscount", None)
-
         service_order_charge_type = d.pop("ServiceOrderChargeType", None)
-
         total_discount = d.pop("TotalDiscount", None)
-
         total_price = d.pop("TotalPrice", None)
-
         discount_price = d.pop("DiscountPrice", None)
-
         qualer_api_models_service_orders_to_service_order_part_repair_response = cls(
             service_order_item_part_id=service_order_item_part_id,
             price=price,
@@ -250,7 +203,6 @@ class ServiceOrdersToServiceOrderPartRepairResponse:
             total_price=total_price,
             discount_price=discount_price,
         )
-
         qualer_api_models_service_orders_to_service_order_part_repair_response.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_task_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_orders_to_service_order_task_response.py
@@ -39,29 +39,19 @@ class ServiceOrdersToServiceOrderTaskResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_task_id = self.service_order_task_id
-
         task_name = self.task_name
-
         task_order = self.task_order
-
         task_details = self.task_details
-
         time_spent = self.time_spent
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         start_time: Optional[str] = None
         if self.start_time:
             start_time = self.start_time.isoformat()
-
         finish_time: Optional[str] = None
         if self.finish_time:
             finish_time = self.finish_time.isoformat()
-
         price = self.price
-
         is_hourly = self.is_hourly
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -85,42 +75,31 @@ class ServiceOrdersToServiceOrderTaskResponse:
             field_dict["Price"] = price
         if is_hourly is not None:
             field_dict["IsHourly"] = is_hourly
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_task_id = d.pop("ServiceOrderTaskId", None)
-
         task_name = d.pop("TaskName", None)
-
         task_order = d.pop("TaskOrder", None)
-
         task_details = d.pop("TaskDetails", None)
-
         time_spent = d.pop("TimeSpent", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         _start_time = d.pop("StartTime", None)
         start_time: Optional[datetime.datetime]
         if not _start_time:
             start_time = None
         else:
             start_time = isoparse(_start_time)
-
         _finish_time = d.pop("FinishTime", None)
         finish_time: Optional[datetime.datetime]
         if not _finish_time:
             finish_time = None
         else:
             finish_time = isoparse(_finish_time)
-
         price = d.pop("Price", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         qualer_api_models_service_orders_to_service_order_task_response = cls(
             service_order_task_id=service_order_task_id,
             task_name=task_name,
@@ -133,7 +112,6 @@ class ServiceOrdersToServiceOrderTaskResponse:
             price=price,
             is_hourly=is_hourly,
         )
-
         qualer_api_models_service_orders_to_service_order_task_response.additional_properties = d
         return qualer_api_models_service_orders_to_service_order_task_response
 

--- a/src/qualer_sdk/models/qualer_api_models_site_from_site_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_from_site_create_model.py
@@ -55,43 +55,26 @@ class SiteFromSiteCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         site_name = self.site_name
-
         site_code = self.site_code
-
         shipping_inherited = self.shipping_inherited
-
         default_account_representative_employee_id = self.default_account_representative_employee_id
-
         billing_inherited = self.billing_inherited
-
         federal_number = self.federal_number
-
         state_number = self.state_number
-
         culture_name = self.culture_name
-
         is_science_facility = self.is_science_facility
-
         is_service_center = self.is_service_center
-
         is_inventory_storage = self.is_inventory_storage
-
         is_production = self.is_production
-
         time_zone_id = self.time_zone_id
-
         time_zone_offset_minutes = self.time_zone_offset_minutes
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -131,7 +114,6 @@ class SiteFromSiteCreateModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -139,54 +121,36 @@ class SiteFromSiteCreateModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         site_name = d.pop("SiteName", None)
-
         site_code = d.pop("SiteCode", None)
-
         shipping_inherited = d.pop("ShippingInherited", None)
-
         default_account_representative_employee_id = d.pop(
             "DefaultAccountRepresentativeEmployeeId", None
         )
-
         billing_inherited = d.pop("BillingInherited", None)
-
         federal_number = d.pop("FederalNumber", None)
-
         state_number = d.pop("StateNumber", None)
-
         culture_name = d.pop("CultureName", None)
-
         is_science_facility = d.pop("IsScienceFacility", None)
-
         is_service_center = d.pop("IsServiceCenter", None)
-
         is_inventory_storage = d.pop("IsInventoryStorage", None)
-
         is_production = d.pop("IsProduction", None)
-
         time_zone_id = d.pop("TimeZoneId", None)
-
         time_zone_offset_minutes = d.pop("TimeZoneOffsetMinutes", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_site_from_site_create_model = cls(
             site_name=site_name,
             site_code=site_code,
@@ -206,7 +170,6 @@ class SiteFromSiteCreateModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_site_from_site_create_model.additional_properties = d
         return qualer_api_models_site_from_site_create_model
 

--- a/src/qualer_sdk/models/qualer_api_models_site_from_site_update_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_from_site_update_model.py
@@ -57,45 +57,27 @@ class SiteFromSiteUpdateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         site_id = self.site_id
-
         site_name = self.site_name
-
         site_code = self.site_code
-
         shipping_inherited = self.shipping_inherited
-
         default_account_representative_employee_id = self.default_account_representative_employee_id
-
         billing_inherited = self.billing_inherited
-
         federal_number = self.federal_number
-
         state_number = self.state_number
-
         culture_name = self.culture_name
-
         is_science_facility = self.is_science_facility
-
         is_service_center = self.is_service_center
-
         is_inventory_storage = self.is_inventory_storage
-
         is_production = self.is_production
-
         time_zone_id = self.time_zone_id
-
         time_zone_offset_minutes = self.time_zone_offset_minutes
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -137,7 +119,6 @@ class SiteFromSiteUpdateModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -145,56 +126,37 @@ class SiteFromSiteUpdateModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         site_id = d.pop("SiteId", None)
-
         site_name = d.pop("SiteName", None)
-
         site_code = d.pop("SiteCode", None)
-
         shipping_inherited = d.pop("ShippingInherited", None)
-
         default_account_representative_employee_id = d.pop(
             "DefaultAccountRepresentativeEmployeeId", None
         )
-
         billing_inherited = d.pop("BillingInherited", None)
-
         federal_number = d.pop("FederalNumber", None)
-
         state_number = d.pop("StateNumber", None)
-
         culture_name = d.pop("CultureName", None)
-
         is_science_facility = d.pop("IsScienceFacility", None)
-
         is_service_center = d.pop("IsServiceCenter", None)
-
         is_inventory_storage = d.pop("IsInventoryStorage", None)
-
         is_production = d.pop("IsProduction", None)
-
         time_zone_id = d.pop("TimeZoneId", None)
-
         time_zone_offset_minutes = d.pop("TimeZoneOffsetMinutes", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_site_from_site_update_model = cls(
             site_id=site_id,
             site_name=site_name,
@@ -215,7 +177,6 @@ class SiteFromSiteUpdateModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_site_from_site_update_model.additional_properties = d
         return qualer_api_models_site_from_site_update_model
 

--- a/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response.py
@@ -74,13 +74,9 @@ class SiteToClientSiteResponse:
         from ..models.qualer_api_models_site_to_client_site_response_shipping_address_type_0 import (
             SiteToClientSiteResponseShippingAddressType0,
         )
-
         site_id = self.site_id
-
         site_name = self.site_name
-
         site_code = self.site_code
-
         shipping_address: Optional[Dict[str, Any]]
         if not self.shipping_address:
             shipping_address = None
@@ -91,9 +87,7 @@ class SiteToClientSiteResponse:
             shipping_address = self.shipping_address.to_dict()
         else:
             shipping_address = self.shipping_address
-
         shipping_inherited = self.shipping_inherited
-
         billing_address: Optional[Dict[str, Any]]
         if not self.billing_address:
             billing_address = None
@@ -104,40 +98,26 @@ class SiteToClientSiteResponse:
             billing_address = self.billing_address.to_dict()
         else:
             billing_address = self.billing_address
-
         default_account_representative_employee_id = self.default_account_representative_employee_id
-
         billing_inherited = self.billing_inherited
-
         federal_number = self.federal_number
-
         state_number = self.state_number
-
         culture_name = self.culture_name
-
         is_science_facility = self.is_science_facility
-
         is_service_center = self.is_service_center
-
         is_inventory_storage = self.is_inventory_storage
-
         is_production = self.is_production
-
         time_zone_id = self.time_zone_id
-
         time_zone_offset_minutes = self.time_zone_offset_minutes
-
         updated_on_utc: Optional[str] = None
         if self.updated_on_utc:
             updated_on_utc = self.updated_on_utc.isoformat()
-
         attributes: Optional[List[Dict[str, Any]]] = None
         if self.attributes:
             attributes = []
             for attributes_item_data in self.attributes:
                 attributes_item = attributes_item_data.to_dict()
                 attributes.append(attributes_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -181,7 +161,6 @@ class SiteToClientSiteResponse:
             field_dict["UpdatedOnUtc"] = updated_on_utc
         if attributes is not None:
             field_dict["Attributes"] = attributes
-
         return field_dict
 
     @classmethod
@@ -195,14 +174,10 @@ class SiteToClientSiteResponse:
         from ..models.qualer_api_models_site_to_client_site_response_shipping_address_type_0 import (
             SiteToClientSiteResponseShippingAddressType0,
         )
-
         d = dict(src_dict)
         site_id = d.pop("SiteId", None)
-
         site_name = d.pop("SiteName", None)
-
         site_code = d.pop("SiteCode", None)
-
         def _parse_shipping_address(
             data: object,
         ) -> Optional["SiteToClientSiteResponseShippingAddressType0"]:
@@ -214,7 +189,6 @@ class SiteToClientSiteResponse:
                 shipping_address_type_0 = SiteToClientSiteResponseShippingAddressType0.from_dict(
                     data
                 )
-
                 return shipping_address_type_0
             except Exception:
                 pass
@@ -222,11 +196,8 @@ class SiteToClientSiteResponse:
                 Optional["SiteToClientSiteResponseShippingAddressType0"],
                 data,
             )
-
         shipping_address = _parse_shipping_address(d.pop("ShippingAddress", None))
-
         shipping_inherited = d.pop("ShippingInherited", None)
-
         def _parse_billing_address(
             data: object,
         ) -> Optional["SiteToClientSiteResponseBillingAddressType0"]:
@@ -236,7 +207,6 @@ class SiteToClientSiteResponse:
                 if not isinstance(data, dict):
                     raise TypeError()
                 billing_address_type_0 = SiteToClientSiteResponseBillingAddressType0.from_dict(data)
-
                 return billing_address_type_0
             except Exception:
                 pass
@@ -244,47 +214,31 @@ class SiteToClientSiteResponse:
                 Optional["SiteToClientSiteResponseBillingAddressType0"],
                 data,
             )
-
         billing_address = _parse_billing_address(d.pop("BillingAddress", None))
-
         default_account_representative_employee_id = d.pop(
             "DefaultAccountRepresentativeEmployeeId", None
         )
-
         billing_inherited = d.pop("BillingInherited", None)
-
         federal_number = d.pop("FederalNumber", None)
-
         state_number = d.pop("StateNumber", None)
-
         culture_name = d.pop("CultureName", None)
-
         is_science_facility = d.pop("IsScienceFacility", None)
-
         is_service_center = d.pop("IsServiceCenter", None)
-
         is_inventory_storage = d.pop("IsInventoryStorage", None)
-
         is_production = d.pop("IsProduction", None)
-
         time_zone_id = d.pop("TimeZoneId", None)
-
         time_zone_offset_minutes = d.pop("TimeZoneOffsetMinutes", None)
-
         _updated_on_utc = d.pop("UpdatedOnUtc", None)
         updated_on_utc: Optional[datetime.datetime]
         if not _updated_on_utc:
             updated_on_utc = None
         else:
             updated_on_utc = isoparse(_updated_on_utc)
-
         attributes = []
         _attributes = d.pop("Attributes", None)
         for attributes_item_data in _attributes or []:
             attributes_item = CommonFromAttributeModel.from_dict(attributes_item_data)
-
             attributes.append(attributes_item)
-
         qualer_api_models_site_to_client_site_response = cls(
             site_id=site_id,
             site_name=site_name,
@@ -306,7 +260,6 @@ class SiteToClientSiteResponse:
             updated_on_utc=updated_on_utc,
             attributes=attributes,
         )
-
         qualer_api_models_site_to_client_site_response.additional_properties = d
         return qualer_api_models_site_to_client_site_response
 

--- a/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response_billing_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response_billing_address_type_0.py
@@ -16,14 +16,12 @@ class SiteToClientSiteResponseBillingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_site_to_client_site_response_billing_address_type_0 = cls()
-
         qualer_api_models_site_to_client_site_response_billing_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response_shipping_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_site_to_client_site_response_shipping_address_type_0.py
@@ -16,14 +16,12 @@ class SiteToClientSiteResponseShippingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_site_to_client_site_response_shipping_address_type_0 = cls()
-
         qualer_api_models_site_to_client_site_response_shipping_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_create_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_create_model.py
@@ -35,23 +35,16 @@ class VendorsFromSponsoredVendorCreateModel:
 
     def to_dict(self) -> Dict[str, Any]:
         account_number_text = self.account_number_text
-
         domain_name = self.domain_name
-
         custom_vendor_name = self.custom_vendor_name
-
         currency_id = self.currency_id
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -69,7 +62,6 @@ class VendorsFromSponsoredVendorCreateModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -77,32 +69,24 @@ class VendorsFromSponsoredVendorCreateModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         account_number_text = d.pop("AccountNumberText", None)
-
         domain_name = d.pop("DomainName", None)
-
         custom_vendor_name = d.pop("CustomVendorName", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_vendors_from_sponsored_vendor_create_model = cls(
             account_number_text=account_number_text,
             domain_name=domain_name,
@@ -112,7 +96,6 @@ class VendorsFromSponsoredVendorCreateModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_vendors_from_sponsored_vendor_create_model.additional_properties = d
         return qualer_api_models_vendors_from_sponsored_vendor_create_model
 

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_edit_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_sponsored_vendor_edit_model.py
@@ -37,25 +37,17 @@ class VendorsFromSponsoredVendorEditModel:
 
     def to_dict(self) -> Dict[str, Any]:
         company_id = self.company_id
-
         account_number_text = self.account_number_text
-
         domain_name = self.domain_name
-
         custom_vendor_name = self.custom_vendor_name
-
         currency_id = self.currency_id
-
         company_name = self.company_name
-
         billing_address: Optional[Dict[str, Any]] = None
         if self.billing_address:
             billing_address = self.billing_address.to_dict()
-
         shipping_address: Optional[Dict[str, Any]] = None
         if self.shipping_address:
             shipping_address = self.shipping_address.to_dict()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -75,7 +67,6 @@ class VendorsFromSponsoredVendorEditModel:
             field_dict["BillingAddress"] = billing_address
         if shipping_address is not None:
             field_dict["ShippingAddress"] = shipping_address
-
         return field_dict
 
     @classmethod
@@ -83,34 +74,25 @@ class VendorsFromSponsoredVendorEditModel:
         from ..models.qualer_api_models_address_address_model import (
             AddressAddressModel,
         )
-
         d = dict(src_dict)
         company_id = d.pop("CompanyId", None)
-
         account_number_text = d.pop("AccountNumberText", None)
-
         domain_name = d.pop("DomainName", None)
-
         custom_vendor_name = d.pop("CustomVendorName", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         company_name = d.pop("CompanyName", None)
-
         _billing_address = d.pop("BillingAddress", None)
         billing_address: Optional[AddressAddressModel]
         if not _billing_address:
             billing_address = None
         else:
             billing_address = AddressAddressModel.from_dict(_billing_address)
-
         _shipping_address = d.pop("ShippingAddress", None)
         shipping_address: Optional[AddressAddressModel]
         if not _shipping_address:
             shipping_address = None
         else:
             shipping_address = AddressAddressModel.from_dict(_shipping_address)
-
         qualer_api_models_vendors_from_sponsored_vendor_edit_model = cls(
             company_id=company_id,
             account_number_text=account_number_text,
@@ -121,7 +103,6 @@ class VendorsFromSponsoredVendorEditModel:
             billing_address=billing_address,
             shipping_address=shipping_address,
         )
-
         qualer_api_models_vendors_from_sponsored_vendor_edit_model.additional_properties = d
         return qualer_api_models_vendors_from_sponsored_vendor_edit_model
 

--- a/src/qualer_sdk/models/qualer_api_models_vendors_from_vendor_company_search_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_from_vendor_company_search_model.py
@@ -27,15 +27,11 @@ class VendorsFromVendorCompanySearchModel:
 
     def to_dict(self) -> Dict[str, Any]:
         account_number_text = self.account_number_text
-
         company_name = self.company_name
-
         take = self.take
-
         modified_after: Optional[str] = None
         if self.modified_after:
             modified_after = self.modified_after.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -47,32 +43,26 @@ class VendorsFromVendorCompanySearchModel:
             field_dict["Take"] = take
         if modified_after is not None:
             field_dict["ModifiedAfter"] = modified_after
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         account_number_text = d.pop("AccountNumberText", None)
-
         company_name = d.pop("CompanyName", None)
-
         take = d.pop("Take", None)
-
         _modified_after = d.pop("ModifiedAfter", None)
         modified_after: Optional[datetime.datetime]
         if not _modified_after:
             modified_after = None
         else:
             modified_after = isoparse(_modified_after)
-
         qualer_api_models_vendors_from_vendor_company_search_model = cls(
             account_number_text=account_number_text,
             company_name=company_name,
             take=take,
             modified_after=modified_after,
         )
-
         qualer_api_models_vendors_from_vendor_company_search_model.additional_properties = d
         return qualer_api_models_vendors_from_vendor_company_search_model
 

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_created_vendor_company_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_created_vendor_company_response.py
@@ -19,24 +19,20 @@ class VendorsToCreatedVendorCompanyResponse:
 
     def to_dict(self) -> Dict[str, Any]:
         id = self.id
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
         if id is not None:
             field_dict["Id"] = id
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         id = d.pop("Id", None)
-
         qualer_api_models_vendors_to_created_vendor_company_response = cls(
             id=id,
         )
-
         qualer_api_models_vendors_to_created_vendor_company_response.additional_properties = d
         return qualer_api_models_vendors_to_created_vendor_company_response
 

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model.py
@@ -53,21 +53,13 @@ class VendorsToVendorCompanyResponseModel:
         from ..models.qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0 import (
             VendorsToVendorCompanyResponseModelShippingAddressType0,
         )
-
         account_number_text = self.account_number_text
-
         account_number = self.account_number
-
         currency_id = self.currency_id
-
         company_id = self.company_id
-
         company_name = self.company_name
-
         domain_name = self.domain_name
-
         custom_name = self.custom_name
-
         billing_address: Optional[Dict[str, Any]]
         if not self.billing_address:
             billing_address = None
@@ -78,7 +70,6 @@ class VendorsToVendorCompanyResponseModel:
             billing_address = self.billing_address.to_dict()
         else:
             billing_address = self.billing_address
-
         shipping_address: Optional[Dict[str, Any]]
         if not self.shipping_address:
             shipping_address = None
@@ -89,11 +80,9 @@ class VendorsToVendorCompanyResponseModel:
             shipping_address = self.shipping_address.to_dict()
         else:
             shipping_address = self.shipping_address
-
         updated_on_utc: Optional[str] = None
         if self.updated_on_utc:
             updated_on_utc = self.updated_on_utc.isoformat()
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -117,7 +106,6 @@ class VendorsToVendorCompanyResponseModel:
             field_dict["ShippingAddress"] = shipping_address
         if updated_on_utc is not None:
             field_dict["UpdatedOnUtc"] = updated_on_utc
-
         return field_dict
 
     @classmethod
@@ -128,22 +116,14 @@ class VendorsToVendorCompanyResponseModel:
         from ..models.qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0 import (
             VendorsToVendorCompanyResponseModelShippingAddressType0,
         )
-
         d = dict(src_dict)
         account_number_text = d.pop("AccountNumberText", None)
-
         account_number = d.pop("AccountNumber", None)
-
         currency_id = d.pop("CurrencyId", None)
-
         company_id = d.pop("CompanyId", None)
-
         company_name = d.pop("CompanyName", None)
-
         domain_name = d.pop("DomainName", None)
-
         custom_name = d.pop("CustomName", None)
-
         def _parse_billing_address(
             data: object,
         ) -> Optional["VendorsToVendorCompanyResponseModelBillingAddressType0"]:
@@ -155,7 +135,6 @@ class VendorsToVendorCompanyResponseModel:
                 billing_address_type_0 = (
                     VendorsToVendorCompanyResponseModelBillingAddressType0.from_dict(data)
                 )
-
                 return billing_address_type_0
             except Exception:
                 pass
@@ -163,9 +142,7 @@ class VendorsToVendorCompanyResponseModel:
                 Optional["VendorsToVendorCompanyResponseModelBillingAddressType0"],
                 data,
             )
-
         billing_address = _parse_billing_address(d.pop("BillingAddress", None))
-
         def _parse_shipping_address(
             data: object,
         ) -> Optional["VendorsToVendorCompanyResponseModelShippingAddressType0"]:
@@ -177,7 +154,6 @@ class VendorsToVendorCompanyResponseModel:
                 shipping_address_type_0 = (
                     VendorsToVendorCompanyResponseModelShippingAddressType0.from_dict(data)
                 )
-
                 return shipping_address_type_0
             except Exception:
                 pass
@@ -185,16 +161,13 @@ class VendorsToVendorCompanyResponseModel:
                 Optional["VendorsToVendorCompanyResponseModelShippingAddressType0"],
                 data,
             )
-
         shipping_address = _parse_shipping_address(d.pop("ShippingAddress", None))
-
         _updated_on_utc = d.pop("UpdatedOnUtc", None)
         updated_on_utc: Optional[datetime.datetime]
         if not _updated_on_utc:
             updated_on_utc = None
         else:
             updated_on_utc = isoparse(_updated_on_utc)
-
         qualer_api_models_vendors_to_vendor_company_response_model = cls(
             account_number_text=account_number_text,
             account_number=account_number,
@@ -207,7 +180,6 @@ class VendorsToVendorCompanyResponseModel:
             shipping_address=shipping_address,
             updated_on_utc=updated_on_utc,
         )
-
         qualer_api_models_vendors_to_vendor_company_response_model.additional_properties = d
         return qualer_api_models_vendors_to_vendor_company_response_model
 

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model_billing_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model_billing_address_type_0.py
@@ -16,14 +16,12 @@ class VendorsToVendorCompanyResponseModelBillingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_vendors_to_vendor_company_response_model_billing_address_type_0 = cls()
-
         qualer_api_models_vendors_to_vendor_company_response_model_billing_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0.py
+++ b/src/qualer_sdk/models/qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0.py
@@ -16,14 +16,12 @@ class VendorsToVendorCompanyResponseModelShippingAddressType0:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0 = cls()
-
         qualer_api_models_vendors_to_vendor_company_response_model_shipping_address_type_0.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits.py
+++ b/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits.py
@@ -33,16 +33,13 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits:
 
     def to_dict(self) -> Dict[str, Any]:
         title = self.title
-
         subtitle = self.subtitle
-
         exhibits: Optional[List[Dict[str, Any]]] = None
         if self.exhibits:
             exhibits = []
             for exhibits_item_data in self.exhibits:
                 exhibits_item = exhibits_item_data.to_dict()
                 exhibits.append(exhibits_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -52,7 +49,6 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits:
             field_dict["Subtitle"] = subtitle
         if exhibits is not None:
             field_dict["Exhibits"] = exhibits
-
         return field_dict
 
     @classmethod
@@ -60,27 +56,21 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibits:
         from ..models.qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value import (
             QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue,
         )
-
         d = dict(src_dict)
         title = d.pop("Title", None)
-
         subtitle = d.pop("Subtitle", None)
-
         exhibits = []
         _exhibits = d.pop("Exhibits", None)
         for exhibits_item_data in _exhibits or []:
             exhibits_item = QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyValue.from_dict(
                 exhibits_item_data
             )
-
             exhibits.append(exhibits_item)
-
         qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits = cls(
             title=title,
             subtitle=subtitle,
             exhibits=exhibits,
         )
-
         qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value.py
+++ b/src/qualer_sdk/models/qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value.py
@@ -24,9 +24,7 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyV
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         value = self.value
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -34,21 +32,17 @@ class QualerCoreSharedModelsServiceOrderMetadataServiceOrderMetadataExhibitsKeyV
             field_dict["Name"] = name
         if value is not None:
             field_dict["Value"] = value
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         value = d.pop("Value", None)
-
         qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value = cls(
             name=name,
             value=value,
         )
-
         qualer_core_shared_models_service_order_metadata_service_order_metadata_exhibits_key_value.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_account_to_login_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_account_to_login_model.py
@@ -23,11 +23,8 @@ class QualerWebMvcAreasApiModelsAccountToLoginModel:
 
     def to_dict(self) -> Dict[str, Any]:
         user_name = self.user_name
-
         password = self.password
-
         clear_previous_tokens = self.clear_previous_tokens
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -38,24 +35,19 @@ class QualerWebMvcAreasApiModelsAccountToLoginModel:
         )
         if clear_previous_tokens is not None:
             field_dict["ClearPreviousTokens"] = clear_previous_tokens
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         user_name = d.pop("UserName")
-
         password = d.pop("Password")
-
         clear_previous_tokens = d.pop("ClearPreviousTokens", None)
-
         qualer_web_mvc_areas_api_models_account_to_login_model = cls(
             user_name=user_name,
             password=password,
             clear_previous_tokens=clear_previous_tokens,
         )
-
         qualer_web_mvc_areas_api_models_account_to_login_model.additional_properties = d
         return qualer_web_mvc_areas_api_models_account_to_login_model
 

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_add_department_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_add_department_model.py
@@ -21,9 +21,7 @@ class QualerWebMvcAreasApiModelsCompanyFromAddDepartmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         description = self.description
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class QualerWebMvcAreasApiModelsCompanyFromAddDepartmentModel:
             field_dict["Name"] = name
         if description is not None:
             field_dict["Description"] = description
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         description = d.pop("Description", None)
-
         qualer_web_mvc_areas_api_models_company_from_add_department_model = cls(
             name=name,
             description=description,
         )
-
         qualer_web_mvc_areas_api_models_company_from_add_department_model.additional_properties = d
         return qualer_web_mvc_areas_api_models_company_from_add_department_model
 

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_update_department_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_company_from_update_department_model.py
@@ -21,9 +21,7 @@ class QualerWebMvcAreasApiModelsCompanyFromUpdateDepartmentModel:
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         description = self.description
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -31,21 +29,17 @@ class QualerWebMvcAreasApiModelsCompanyFromUpdateDepartmentModel:
             field_dict["Name"] = name
         if description is not None:
             field_dict["Description"] = description
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         description = d.pop("Description", None)
-
         qualer_web_mvc_areas_api_models_company_from_update_department_model = cls(
             name=name,
             description=description,
         )
-
         qualer_web_mvc_areas_api_models_company_from_update_department_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_product_from_product_api_edit_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_product_from_product_api_edit_model.py
@@ -43,31 +43,18 @@ class QualerWebMvcAreasApiModelsProductFromProductApiEditModel:
 
     def to_dict(self) -> Dict[str, Any]:
         product_description = self.product_description
-
         category_id = self.category_id
-
         manufacturer_id = self.manufacturer_id
-
         parent_product_id = self.parent_product_id
-
         product_name = self.product_name
-
         manufacturer_part_number = self.manufacturer_part_number
-
         is_family = self.is_family
-
         is_discontinued = self.is_discontinued
-
         is_stock_item = self.is_stock_item
-
         unit_sale_price = self.unit_sale_price
-
         supplier_information = self.supplier_information
-
         quantity_on_hand = self.quantity_on_hand
-
         product_code = self.product_code
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -97,38 +84,24 @@ class QualerWebMvcAreasApiModelsProductFromProductApiEditModel:
             field_dict["QuantityOnHand"] = quantity_on_hand
         if product_code is not None:
             field_dict["ProductCode"] = product_code
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         product_description = d.pop("ProductDescription", None)
-
         category_id = d.pop("CategoryId", None)
-
         manufacturer_id = d.pop("ManufacturerId", None)
-
         parent_product_id = d.pop("ParentProductId", None)
-
         product_name = d.pop("ProductName", None)
-
         manufacturer_part_number = d.pop("ManufacturerPartNumber", None)
-
         is_family = d.pop("IsFamily", None)
-
         is_discontinued = d.pop("IsDiscontinued", None)
-
         is_stock_item = d.pop("IsStockItem", None)
-
         unit_sale_price = d.pop("UnitSalePrice", None)
-
         supplier_information = d.pop("SupplierInformation", None)
-
         quantity_on_hand = d.pop("QuantityOnHand", None)
-
         product_code = d.pop("ProductCode", None)
-
         qualer_web_mvc_areas_api_models_product_from_product_api_edit_model = cls(
             product_description=product_description,
             category_id=category_id,
@@ -144,7 +117,6 @@ class QualerWebMvcAreasApiModelsProductFromProductApiEditModel:
             quantity_on_hand=quantity_on_hand,
             product_code=product_code,
         )
-
         qualer_web_mvc_areas_api_models_product_from_product_api_edit_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model.py
@@ -50,35 +50,21 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateMod
 
     def to_dict(self) -> Dict[str, Any]:
         name = self.name
-
         description = self.description
-
         charge_date: Optional[str] = None
         if self.charge_date:
             charge_date = self.charge_date.isoformat()
-
         price = self.price
-
         unit_name = self.unit_name
-
         is_hourly_pricing = self.is_hourly_pricing
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         quantity = self.quantity
-
         discount = self.discount
-
         is_taxable = self.is_taxable
-
         delivery_charge = self.delivery_charge
-
         free_quantity = self.free_quantity
-
         created_by_id = self.created_by_id
-
         service_order_charge_type = self.service_order_charge_type
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -110,45 +96,30 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateMod
             field_dict["CreatedById"] = created_by_id
         if service_order_charge_type is not None:
             field_dict["ServiceOrderChargeType"] = service_order_charge_type
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         name = d.pop("Name", None)
-
         description = d.pop("Description", None)
-
         _charge_date = d.pop("ChargeDate", None)
         charge_date: Optional[datetime.datetime]
         if not _charge_date:
             charge_date = None
         else:
             charge_date = isoparse(_charge_date)
-
         price = d.pop("Price", None)
-
         unit_name = d.pop("UnitName", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         quantity = d.pop("Quantity", None)
-
         discount = d.pop("Discount", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         delivery_charge = d.pop("DeliveryCharge", None)
-
         free_quantity = d.pop("FreeQuantity", None)
-
         created_by_id = d.pop("CreatedById", None)
-
         service_order_charge_type = d.pop("ServiceOrderChargeType", None)
-
         qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model = cls(
             name=name,
             description=description,
@@ -165,7 +136,6 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairCreateMod
             created_by_id=created_by_id,
             service_order_charge_type=service_order_charge_type,
         )
-
         qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_create_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model.py
@@ -52,37 +52,22 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateMod
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_item_part_id = self.service_order_item_part_id
-
         name = self.name
-
         description = self.description
-
         charge_date: Optional[str] = None
         if self.charge_date:
             charge_date = self.charge_date.isoformat()
-
         price = self.price
-
         unit_name = self.unit_name
-
         is_hourly_pricing = self.is_hourly_pricing
-
         time_spent_in_minutes = self.time_spent_in_minutes
-
         quantity = self.quantity
-
         discount = self.discount
-
         is_taxable = self.is_taxable
-
         delivery_charge = self.delivery_charge
-
         free_quantity = self.free_quantity
-
         created_by_id = self.created_by_id
-
         service_order_charge_type = self.service_order_charge_type
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -116,47 +101,31 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateMod
             field_dict["CreatedById"] = created_by_id
         if service_order_charge_type is not None:
             field_dict["ServiceOrderChargeType"] = service_order_charge_type
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_order_item_part_id = d.pop("ServiceOrderItemPartId", None)
-
         name = d.pop("Name", None)
-
         description = d.pop("Description", None)
-
         _charge_date = d.pop("ChargeDate", None)
         charge_date: Optional[datetime.datetime]
         if not _charge_date:
             charge_date = None
         else:
             charge_date = isoparse(_charge_date)
-
         price = d.pop("Price", None)
-
         unit_name = d.pop("UnitName", None)
-
         is_hourly_pricing = d.pop("IsHourlyPricing", None)
-
         time_spent_in_minutes = d.pop("TimeSpentInMinutes", None)
-
         quantity = d.pop("Quantity", None)
-
         discount = d.pop("Discount", None)
-
         is_taxable = d.pop("IsTaxable", None)
-
         delivery_charge = d.pop("DeliveryCharge", None)
-
         free_quantity = d.pop("FreeQuantity", None)
-
         created_by_id = d.pop("CreatedById", None)
-
         service_order_charge_type = d.pop("ServiceOrderChargeType", None)
-
         qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model = cls(
             service_order_item_part_id=service_order_item_part_id,
             name=name,
@@ -174,7 +143,6 @@ class QualerWebMvcAreasApiModelsServiceOrdersFromServiceOrderPartRepairUpdateMod
             created_by_id=created_by_id,
             service_order_charge_type=service_order_charge_type,
         )
-
         qualer_web_mvc_areas_api_models_service_orders_from_service_order_part_repair_update_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model.py
@@ -63,35 +63,30 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
             for charges_item_data in self.charges:
                 charges_item = charges_item_data.to_dict()
                 charges.append(charges_item)
-
         tasks: Optional[List[Dict[str, Any]]] = None
         if self.tasks:
             tasks = []
             for tasks_item_data in self.tasks:
                 tasks_item = tasks_item_data.to_dict()
                 tasks.append(tasks_item)
-
         parts: Optional[List[Dict[str, Any]]] = None
         if self.parts:
             parts = []
             for parts_item_data in self.parts:
                 parts_item = parts_item_data.to_dict()
                 parts.append(parts_item)
-
         repairs: Optional[List[Dict[str, Any]]] = None
         if self.repairs:
             repairs = []
             for repairs_item_data in self.repairs:
                 repairs_item = repairs_item_data.to_dict()
                 repairs.append(repairs_item)
-
         work_items: Optional[List[Dict[str, Any]]] = None
         if self.work_items:
             work_items = []
             for work_items_item_data in self.work_items:
                 work_items_item = work_items_item_data.to_dict()
                 work_items.append(work_items_item)
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -105,7 +100,6 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
             field_dict["Repairs"] = repairs
         if work_items is not None:
             field_dict["WorkItems"] = work_items
-
         return field_dict
 
     @classmethod
@@ -122,7 +116,6 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
         from ..models.qualer_api_models_service_orders_to_charge_response_model_base_price_model import (
             ServiceOrdersToChargeResponseModelBasePriceModel,
         )
-
         d = dict(src_dict)
         charges = []
         _charges = d.pop("Charges", None)
@@ -130,27 +123,21 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
             charges_item = ServiceOrdersToChargeResponseModelBasePriceModel.from_dict(
                 charges_item_data
             )
-
             charges.append(charges_item)
-
         tasks = []
         _tasks = d.pop("Tasks", None)
         for tasks_item_data in _tasks or []:
             tasks_item = ServiceOrdersToChargeResponseModelBaseOrderTaskPriceModel.from_dict(
                 tasks_item_data
             )
-
             tasks.append(tasks_item)
-
         parts = []
         _parts = d.pop("Parts", None)
         for parts_item_data in _parts or []:
             parts_item = ServiceOrdersToChargeResponseModelBaseOrderPartRepairPriceModel.from_dict(
                 parts_item_data
             )
-
             parts.append(parts_item)
-
         repairs = []
         _repairs = d.pop("Repairs", None)
         for repairs_item_data in _repairs or []:
@@ -159,16 +146,12 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
                     repairs_item_data
                 )
             )
-
             repairs.append(repairs_item)
-
         work_items = []
         _work_items = d.pop("WorkItems", None)
         for work_items_item_data in _work_items or []:
             work_items_item = ServiceOrdersToBaseWorkItemModel.from_dict(work_items_item_data)
-
             work_items.append(work_items_item)
-
         qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model = cls(
             charges=charges,
             tasks=tasks,
@@ -176,7 +159,6 @@ class QualerWebMvcAreasApiModelsServiceOrdersToChargeResponseModel:
             repairs=repairs,
             work_items=work_items,
         )
-
         qualer_web_mvc_areas_api_models_service_orders_to_charge_response_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model.py
+++ b/src/qualer_sdk/models/qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model.py
@@ -51,39 +51,22 @@ class QualerWebMvcAreasApiModelsServicePricesFromServicePriceBulkEditModel:
 
     def to_dict(self) -> Dict[str, Any]:
         service_option_id = self.service_option_id
-
         service_option = self.service_option
-
         service_option_code = self.service_option_code
-
         option_type = self.option_type
-
         description = self.description
-
         service_task_id = self.service_task_id
-
         service_code = self.service_code
-
         document_number = self.document_number
-
         document_section = self.document_section
-
         capability_id = self.capability_id
-
         service_type_id = self.service_type_id
-
         service_task_price_id = self.service_task_price_id
-
         service_pricing_id = self.service_pricing_id
-
         price = self.price
-
         is_hourly = self.is_hourly
-
         issue = self.issue
-
         log_error = self.log_error
-
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -121,46 +104,28 @@ class QualerWebMvcAreasApiModelsServicePricesFromServicePriceBulkEditModel:
             field_dict["Issue"] = issue
         if log_error is not None:
             field_dict["LogError"] = log_error
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         service_option_id = d.pop("ServiceOptionId", None)
-
         service_option = d.pop("ServiceOption", None)
-
         service_option_code = d.pop("ServiceOptionCode", None)
-
         option_type = d.pop("OptionType", None)
-
         description = d.pop("Description", None)
-
         service_task_id = d.pop("ServiceTaskId", None)
-
         service_code = d.pop("ServiceCode", None)
-
         document_number = d.pop("DocumentNumber", None)
-
         document_section = d.pop("DocumentSection", None)
-
         capability_id = d.pop("CapabilityId", None)
-
         service_type_id = d.pop("ServiceTypeId", None)
-
         service_task_price_id = d.pop("ServiceTaskPriceId", None)
-
         service_pricing_id = d.pop("ServicePricingId", None)
-
         price = d.pop("Price", None)
-
         is_hourly = d.pop("IsHourly", None)
-
         issue = d.pop("Issue", None)
-
         log_error = d.pop("LogError", None)
-
         qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model = cls(
             service_option_id=service_option_id,
             service_option=service_option,
@@ -180,7 +145,6 @@ class QualerWebMvcAreasApiModelsServicePricesFromServicePriceBulkEditModel:
             issue=issue,
             log_error=log_error,
         )
-
         qualer_web_mvc_areas_api_models_service_prices_from_service_price_bulk_edit_model.additional_properties = (
             d
         )

--- a/src/qualer_sdk/models/reset_initial_service_date_response_200.py
+++ b/src/qualer_sdk/models/reset_initial_service_date_response_200.py
@@ -16,14 +16,12 @@ class ResetInitialServiceDateResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         reset_initial_service_date_response_200 = cls()
-
         reset_initial_service_date_response_200.additional_properties = d
         return reset_initial_service_date_response_200
 

--- a/src/qualer_sdk/models/send_employee_email_response_200.py
+++ b/src/qualer_sdk/models/send_employee_email_response_200.py
@@ -16,14 +16,12 @@ class SendEmployeeEmailResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         send_employee_email_response_200 = cls()
-
         send_employee_email_response_200.additional_properties = d
         return send_employee_email_response_200
 

--- a/src/qualer_sdk/models/service_order_status.py
+++ b/src/qualer_sdk/models/service_order_status.py
@@ -28,17 +28,14 @@ class ServiceOrderStatus(str, Enum):
     @classmethod
     def from_api_value(cls, value: int | str | None) -> ServiceOrderStatus | None:
         """Best-effort parser for API values.
-
         Accepts either a string enum value (e.g. "Processing") or an integer code
         (e.g. 11) seen in some API responses. Returns None for unknown values.
         """
         if value is None:
             return None
-
         if isinstance(value, int):
             mapped = _INT_TO_STR.get(value)
             return mapped if isinstance(mapped, cls) else None
-
         # Strings: accept exact match; try case-insensitive as a fallback.
         try:
             return cls(value)

--- a/src/qualer_sdk/models/set_work_item_response_200.py
+++ b/src/qualer_sdk/models/set_work_item_response_200.py
@@ -16,14 +16,12 @@ class SetWorkItemResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         set_work_item_response_200 = cls()
-
         set_work_item_response_200.additional_properties = d
         return set_work_item_response_200
 

--- a/src/qualer_sdk/models/update_asset_class_response_200.py
+++ b/src/qualer_sdk/models/update_asset_class_response_200.py
@@ -16,14 +16,12 @@ class UpdateAssetClassResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_asset_class_response_200 = cls()
-
         update_asset_class_response_200.additional_properties = d
         return update_asset_class_response_200
 

--- a/src/qualer_sdk/models/update_asset_department_response_200.py
+++ b/src/qualer_sdk/models/update_asset_department_response_200.py
@@ -16,14 +16,12 @@ class UpdateAssetDepartmentResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_asset_department_response_200 = cls()
-
         update_asset_department_response_200.additional_properties = d
         return update_asset_department_response_200
 

--- a/src/qualer_sdk/models/update_asset_room_response_200.py
+++ b/src/qualer_sdk/models/update_asset_room_response_200.py
@@ -16,14 +16,12 @@ class UpdateAssetRoomResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_asset_room_response_200 = cls()
-
         update_asset_room_response_200.additional_properties = d
         return update_asset_room_response_200
 

--- a/src/qualer_sdk/models/update_asset_service_record_response_200.py
+++ b/src/qualer_sdk/models/update_asset_service_record_response_200.py
@@ -16,14 +16,12 @@ class UpdateAssetServiceRecordResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_asset_service_record_response_200 = cls()
-
         update_asset_service_record_response_200.additional_properties = d
         return update_asset_service_record_response_200
 

--- a/src/qualer_sdk/models/update_client_site_response_200.py
+++ b/src/qualer_sdk/models/update_client_site_response_200.py
@@ -16,14 +16,12 @@ class UpdateClientSiteResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_client_site_response_200 = cls()
-
         update_client_site_response_200.additional_properties = d
         return update_client_site_response_200
 

--- a/src/qualer_sdk/models/update_department_response_204.py
+++ b/src/qualer_sdk/models/update_department_response_204.py
@@ -16,14 +16,12 @@ class UpdateDepartmentResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_department_response_204 = cls()
-
         update_department_response_204.additional_properties = d
         return update_department_response_204
 

--- a/src/qualer_sdk/models/update_employee_filter_preference_response_200.py
+++ b/src/qualer_sdk/models/update_employee_filter_preference_response_200.py
@@ -16,14 +16,12 @@ class UpdateEmployeeFilterPreferenceResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_employee_filter_preference_response_200 = cls()
-
         update_employee_filter_preference_response_200.additional_properties = d
         return update_employee_filter_preference_response_200
 

--- a/src/qualer_sdk/models/update_employee_response_201.py
+++ b/src/qualer_sdk/models/update_employee_response_201.py
@@ -16,14 +16,12 @@ class UpdateEmployeeResponse201:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_employee_response_201 = cls()
-
         update_employee_response_201.additional_properties = d
         return update_employee_response_201
 

--- a/src/qualer_sdk/models/update_measurement_form_response_200.py
+++ b/src/qualer_sdk/models/update_measurement_form_response_200.py
@@ -16,14 +16,12 @@ class UpdateMeasurementFormResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_measurement_form_response_200 = cls()
-
         update_measurement_form_response_200.additional_properties = d
         return update_measurement_form_response_200
 

--- a/src/qualer_sdk/models/update_put_2_response_200.py
+++ b/src/qualer_sdk/models/update_put_2_response_200.py
@@ -16,14 +16,12 @@ class UpdatePut2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_put_2_response_200 = cls()
-
         update_put_2_response_200.additional_properties = d
         return update_put_2_response_200
 

--- a/src/qualer_sdk/models/update_put_4_response_200.py
+++ b/src/qualer_sdk/models/update_put_4_response_200.py
@@ -16,14 +16,12 @@ class UpdatePut4Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_put_4_response_200 = cls()
-
         update_put_4_response_200.additional_properties = d
         return update_put_4_response_200
 

--- a/src/qualer_sdk/models/update_response_200.py
+++ b/src/qualer_sdk/models/update_response_200.py
@@ -16,14 +16,12 @@ class UpdateResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_response_200 = cls()
-
         update_response_200.additional_properties = d
         return update_response_200
 

--- a/src/qualer_sdk/models/update_room_response_200.py
+++ b/src/qualer_sdk/models/update_room_response_200.py
@@ -16,14 +16,12 @@ class UpdateRoomResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_room_response_200 = cls()
-
         update_room_response_200.additional_properties = d
         return update_room_response_200
 

--- a/src/qualer_sdk/models/update_shipment_status_response_200.py
+++ b/src/qualer_sdk/models/update_shipment_status_response_200.py
@@ -16,14 +16,12 @@ class UpdateShipmentStatusResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_shipment_status_response_200 = cls()
-
         update_shipment_status_response_200.additional_properties = d
         return update_shipment_status_response_200
 

--- a/src/qualer_sdk/models/update_work_order_parts_response_204.py
+++ b/src/qualer_sdk/models/update_work_order_parts_response_204.py
@@ -16,14 +16,12 @@ class UpdateWorkOrderPartsResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_work_order_parts_response_204 = cls()
-
         update_work_order_parts_response_204.additional_properties = d
         return update_work_order_parts_response_204
 

--- a/src/qualer_sdk/models/update_work_order_task_response_204.py
+++ b/src/qualer_sdk/models/update_work_order_task_response_204.py
@@ -16,14 +16,12 @@ class UpdateWorkOrderTaskResponse204:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         update_work_order_task_response_204 = cls()
-
         update_work_order_task_response_204.additional_properties = d
         return update_work_order_task_response_204
 

--- a/src/qualer_sdk/models/upload_documents_post_2_response_200.py
+++ b/src/qualer_sdk/models/upload_documents_post_2_response_200.py
@@ -16,14 +16,12 @@ class UploadDocumentsPost2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upload_documents_post_2_response_200 = cls()
-
         upload_documents_post_2_response_200.additional_properties = d
         return upload_documents_post_2_response_200
 

--- a/src/qualer_sdk/models/upload_documents_post_3_response_200.py
+++ b/src/qualer_sdk/models/upload_documents_post_3_response_200.py
@@ -16,14 +16,12 @@ class UploadDocumentsPost3Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upload_documents_post_3_response_200 = cls()
-
         upload_documents_post_3_response_200.additional_properties = d
         return upload_documents_post_3_response_200
 

--- a/src/qualer_sdk/models/upload_documents_response_200.py
+++ b/src/qualer_sdk/models/upload_documents_response_200.py
@@ -16,14 +16,12 @@ class UploadDocumentsResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upload_documents_response_200 = cls()
-
         upload_documents_response_200.additional_properties = d
         return upload_documents_response_200
 

--- a/src/qualer_sdk/models/upload_work_item_images_response_200.py
+++ b/src/qualer_sdk/models/upload_work_item_images_response_200.py
@@ -16,14 +16,12 @@ class UploadWorkItemImagesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upload_work_item_images_response_200 = cls()
-
         upload_work_item_images_response_200.additional_properties = d
         return upload_work_item_images_response_200
 

--- a/src/qualer_sdk/models/upsert_asset_attributes_put_2_response_200.py
+++ b/src/qualer_sdk/models/upsert_asset_attributes_put_2_response_200.py
@@ -16,14 +16,12 @@ class UpsertAssetAttributesPut2Response200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upsert_asset_attributes_put_2_response_200 = cls()
-
         upsert_asset_attributes_put_2_response_200.additional_properties = d
         return upsert_asset_attributes_put_2_response_200
 

--- a/src/qualer_sdk/models/upsert_asset_attributes_response_200.py
+++ b/src/qualer_sdk/models/upsert_asset_attributes_response_200.py
@@ -16,14 +16,12 @@ class UpsertAssetAttributesResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upsert_asset_attributes_response_200 = cls()
-
         upsert_asset_attributes_response_200.additional_properties = d
         return upsert_asset_attributes_response_200
 

--- a/src/qualer_sdk/models/upsert_client_attribute_response_200.py
+++ b/src/qualer_sdk/models/upsert_client_attribute_response_200.py
@@ -16,14 +16,12 @@ class UpsertClientAttributeResponse200:
     def to_dict(self) -> Dict[str, Any]:
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
-
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
         upsert_client_attribute_response_200 = cls()
-
         upsert_client_attribute_response_200.additional_properties = d
         return upsert_client_attribute_response_200
 


### PR DESCRIPTION
## Summary
- simplify generated model `to_dict` methods by collapsing redundant optional handling and enum conversions
- normalize spacing inside `to_dict` assignments across the SDK models for consistency

## Testing
- python -m compileall src/qualer_sdk/models

------
https://chatgpt.com/codex/tasks/task_e_68d919182eb08329a7ab553c6a720155