### PR TITLE
Refactor Service Order Document Response Models for Clarity and Simplicity

### DIFF
--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_controlled_document_response.py
@@ -1,12 +1,12 @@
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, TypeVar
 from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..models.qualer_api_models_service_order_documents_to_company_order_controlled_document_response_document_type import (
-    ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType,
+    ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType as _ControlledDocType,
 )
 from ..models.report_type import ReportType
 
@@ -20,110 +20,74 @@ T = TypeVar(
 class ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse:
     """
     Attributes:
-        service_order_id (Optional[int]):
-        guid (Optional[UUID]):  Example: 00000000-0000-0000-0000-000000000000.
-        document_name (Optional[str]):
-        file_name (Optional[str]):
-        document_type (Optional[ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType]):
-        revision_number (Optional[int]):
-        report_type (Optional[ReportType]):
-        download_url (Optional[str]):
+        service_order_id (int):
+        guid (UUID):  Example: 00000000-0000-0000-0000-000000000000.
+        document_name (str):
+        file_name (str):
+        document_type (_ControlledDocType):
+        revision_number (int):
+        report_type (ReportType):
+        download_url (str):
     """
 
-    service_order_id: Optional[int] = None
-    guid: Optional[UUID] = None
-    document_name: Optional[str] = None
-    file_name: Optional[str] = None
-    document_type: Optional[
-        ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType
-    ] = None
-    revision_number: Optional[int] = None
-    report_type: Optional[ReportType] = None
-    download_url: Optional[str] = None
+    service_order_id: int
+    guid: UUID
+    document_name: str
+    file_name: str
+    document_type: _ControlledDocType
+    revision_number: int
+    report_type: ReportType
+    download_url: str
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
-        guid: Optional[str] = None
-        if self.guid:
-            guid = str(self.guid)
+        guid = str(self.guid)
         document_name = self.document_name
         file_name = self.file_name
-        document_type = self.document_type.value if self.document_type else None
+        document_type = self.document_type.value
         revision_number = self.revision_number
-        report_type = self.report_type.value if self.report_type else None
+        report_type = self.report_type.value
         download_url = self.download_url
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if service_order_id is not None:
-            field_dict["ServiceOrderId"] = service_order_id
-        if guid is not None:
-            field_dict["Guid"] = guid
-        if document_name is not None:
-            field_dict["DocumentName"] = document_name
-        if file_name is not None:
-            field_dict["FileName"] = file_name
-        if document_type is not None:
-            field_dict["DocumentType"] = document_type
-        if revision_number is not None:
-            field_dict["RevisionNumber"] = revision_number
-        if report_type is not None:
-            field_dict["ReportType"] = report_type
-        if download_url is not None:
-            field_dict["DownloadUrl"] = download_url
+        field_dict["ServiceOrderId"] = service_order_id
+        field_dict["Guid"] = guid
+        field_dict["DocumentName"] = document_name
+        field_dict["FileName"] = file_name
+        field_dict["DocumentType"] = document_type
+        field_dict["RevisionNumber"] = revision_number
+        field_dict["ReportType"] = report_type
+        field_dict["DownloadUrl"] = download_url
         return field_dict
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        service_order_id = d.pop("ServiceOrderId", None)
-        _guid = d.pop("Guid", None)
-        guid: Optional[UUID]
-        if not _guid:
-            guid = None
-        else:
-            guid = UUID(_guid)
-        document_name = d.pop("DocumentName", None)
-        file_name = d.pop("FileName", None)
-        _document_type = d.pop("DocumentType", None)
-        document_type: Optional[
-            ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType
-        ]
-        if not _document_type:
-            document_type = None
-        else:
-            document_type = (
-                ServiceOrderDocumentsToCompanyOrderControlledDocumentResponseDocumentType(
-                    _document_type
-                )
-            )
-        revision_number = d.pop("RevisionNumber", None)
-        _report_type = d.pop("ReportType", None)
-        report_type: Optional[ReportType]
-        if not _report_type:
-            report_type = None
-        else:
-            report_type = ReportType(_report_type)
-        download_url = d.pop("DownloadUrl", None)
-        qualer_api_models_service_order_documents_to_company_order_controlled_document_response = (
-            cls(
-                service_order_id=service_order_id,
-                guid=guid,
-                document_name=document_name,
-                file_name=file_name,
-                document_type=document_type,
-                revision_number=revision_number,
-                report_type=report_type,
-                download_url=download_url,
-            )
+        service_order_id = d.pop("ServiceOrderId")
+        _guid = d.pop("Guid")
+        guid = UUID(_guid)
+        document_name = d.pop("DocumentName")
+        file_name = d.pop("FileName")
+        _document_type = d.pop("DocumentType")
+        document_type = _ControlledDocType(_document_type)
+        revision_number = d.pop("RevisionNumber")
+        _report_type = d.pop("ReportType")
+        report_type = ReportType(_report_type)
+        download_url = d.pop("DownloadUrl")
+        obj = cls(
+            service_order_id=service_order_id,
+            guid=guid,
+            document_name=document_name,
+            file_name=file_name,
+            document_type=document_type,
+            revision_number=revision_number,
+            report_type=report_type,
+            download_url=download_url,
         )
-        qualer_api_models_service_order_documents_to_company_order_controlled_document_response.additional_properties = (
-            d
-        )
-        return (
-            qualer_api_models_service_order_documents_to_company_order_controlled_document_response
-        )
+        obj.additional_properties = d
+        return obj
 
     @property
     def additional_keys(self) -> List[str]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, Dict, List, Optional, TypeVar
+from typing import Any, Dict, List, TypeVar
 from uuid import UUID
 
 from attrs import define as _attrs_define
@@ -17,61 +17,50 @@ T = TypeVar(
 class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
     """
     Attributes:
-        service_order_id (Optional[int]):
-        service_order_item_id (Optional[int]):
-        guid (Optional[UUID]):  Example: 00000000-0000-0000-0000-000000000000.
-        document_name (Optional[str]):
-        file_name (Optional[str]):
-        document_type (Optional[int]):
-        revision_number (Optional[int]):
-        report_type (Optional[ReportType]):
-        download_url (Optional[str]):
+        service_order_id (int):
+        service_order_item_id (int):
+        guid (UUID):  Example: 00000000-0000-0000-0000-000000000000.
+        document_name (str):
+        file_name (str):
+        document_type (int):
+        revision_number (int):
+        report_type (ReportType):
+        download_url (str):
     """
 
-    service_order_id: Optional[int] = None
-    service_order_item_id: Optional[int] = None
-    guid: Optional[UUID] = None
-    document_name: Optional[str] = None
-    file_name: Optional[str] = None
-    document_type: Optional[int] = None
-    revision_number: Optional[int] = None
-    report_type: Optional[ReportType] = None
-    download_url: Optional[str] = None
+    service_order_id: int
+    service_order_item_id: int
+    guid: UUID
+    document_name: str
+    file_name: str
+    document_type: int
+    revision_number: int
+    report_type: ReportType
+    download_url: str
     additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         service_order_id = self.service_order_id
         service_order_item_id = self.service_order_item_id
-        guid: Optional[str] = None
-        if self.guid:
-            guid = str(self.guid)
+        guid = str(self.guid)
         document_name = self.document_name
         file_name = self.file_name
         document_type = self.document_type
         revision_number = self.revision_number
-        report_type = self.report_type.value if self.report_type else None
+        report_type = self.report_type.value
         download_url = self.download_url
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
-        if service_order_id is not None:
-            field_dict["ServiceOrderId"] = service_order_id
-        if service_order_item_id is not None:
-            field_dict["ServiceOrderItemId"] = service_order_item_id
-        if guid is not None:
-            field_dict["Guid"] = guid
-        if document_name is not None:
-            field_dict["DocumentName"] = document_name
-        if file_name is not None:
-            field_dict["FileName"] = file_name
-        if document_type is not None:
-            field_dict["DocumentType"] = document_type
-        if revision_number is not None:
-            field_dict["RevisionNumber"] = revision_number
-        if report_type is not None:
-            field_dict["ReportType"] = report_type
-        if download_url is not None:
-            field_dict["DownloadUrl"] = download_url
+        field_dict["ServiceOrderId"] = service_order_id
+        field_dict["ServiceOrderItemId"] = service_order_item_id
+        field_dict["Guid"] = guid
+        field_dict["DocumentName"] = document_name
+        field_dict["FileName"] = file_name
+        field_dict["DocumentType"] = document_type
+        field_dict["RevisionNumber"] = revision_number
+        field_dict["ReportType"] = report_type
+        field_dict["DownloadUrl"] = download_url
         return field_dict
 
     @classmethod
@@ -80,21 +69,13 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
         service_order_id = d.pop("ServiceOrderId", None)
         service_order_item_id = d.pop("ServiceOrderItemId", None)
         _guid = d.pop("Guid", None)
-        guid: Optional[UUID]
-        if not _guid:
-            guid = None
-        else:
-            guid = UUID(_guid)
+        guid = UUID(_guid)
         document_name = d.pop("DocumentName", None)
         file_name = d.pop("FileName", None)
         document_type = d.pop("DocumentType", None)
         revision_number = d.pop("RevisionNumber", None)
         _report_type = d.pop("ReportType", None)
-        report_type: Optional[ReportType]
-        if not _report_type:
-            report_type = None
-        else:
-            report_type = ReportType(_report_type)
+        report_type = ReportType(_report_type)
         download_url = d.pop("DownloadUrl", None)
         qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response = cls(
             service_order_id=service_order_id,

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
@@ -77,7 +77,7 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
         _report_type = d.pop("ReportType")
         report_type = ReportType(_report_type)
         download_url = d.pop("DownloadUrl")
-        qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response = cls(
+        obj = cls(
             service_order_id=service_order_id,
             service_order_item_id=service_order_item_id,
             guid=guid,
@@ -88,10 +88,8 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
             report_type=report_type,
             download_url=download_url,
         )
-        qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.additional_properties = (
-            d
-        )
-        return qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response
+        obj.additional_properties = d
+        return obj
 
     @property
     def additional_keys(self) -> List[str]:

--- a/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
+++ b/src/qualer_sdk/models/qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response.py
@@ -66,17 +66,17 @@ class ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         d = dict(src_dict)
-        service_order_id = d.pop("ServiceOrderId", None)
-        service_order_item_id = d.pop("ServiceOrderItemId", None)
-        _guid = d.pop("Guid", None)
+        service_order_id = d.pop("ServiceOrderId")
+        service_order_item_id = d.pop("ServiceOrderItemId")
+        _guid = d.pop("Guid")
         guid = UUID(_guid)
-        document_name = d.pop("DocumentName", None)
-        file_name = d.pop("FileName", None)
-        document_type = d.pop("DocumentType", None)
-        revision_number = d.pop("RevisionNumber", None)
-        _report_type = d.pop("ReportType", None)
+        document_name = d.pop("DocumentName")
+        file_name = d.pop("FileName")
+        document_type = d.pop("DocumentType")
+        revision_number = d.pop("RevisionNumber")
+        _report_type = d.pop("ReportType")
         report_type = ReportType(_report_type)
-        download_url = d.pop("DownloadUrl", None)
+        download_url = d.pop("DownloadUrl")
         qualer_api_models_service_order_documents_to_company_order_item_controlled_document_response = cls(
             service_order_id=service_order_id,
             service_order_item_id=service_order_item_id,


### PR DESCRIPTION
Remove Optional types and default None values from attributes in ServiceOrderDocumentsToCompanyOrderControlledDocumentResponse and ServiceOrderDocumentsToCompanyOrderItemControlledDocumentResponse. Ensure required fields are always present and improve readability in the from_dict method.